### PR TITLE
Add pipeline types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
 name = "gpu-native"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx-backend-dx12 0.1.0 (git+https://github.com/gfx-rs/gfx?rev=a435a05)",
  "gfx-backend-empty 0.1.0 (git+https://github.com/gfx-rs/gfx?rev=a435a05)",
  "gfx-backend-metal 0.1.0 (git+https://github.com/gfx-rs/gfx?rev=a435a05)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Dzmitry Malyshau <kvark@mozilla.com>"]
 default = []
 
 [dependencies]
+bitflags = "1.0"
 gfx-hal = { git = "https://github.com/gfx-rs/gfx", rev = "a435a05" } # required by gfx-memory
 gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", rev = "a435a05" }
 gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", rev = "a435a05", optional = true }

--- a/src/binding_model.rs
+++ b/src/binding_model.rs
@@ -1,0 +1,6 @@
+use hal;
+
+
+pub struct PipelineLayout<B: hal::Backend> {
+    raw: B::PipelineLayout,
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,5 +1,5 @@
 use hal::{self, Device as _Device, QueueGroup};
-use memory;
+use {memory, pipeline};
 
 use {BufferHandle, CommandBufferHandle, DeviceHandle, ShaderModuleHandle};
 
@@ -10,11 +10,6 @@ pub type BufferUsage = hal::buffer::Usage;
 pub struct BufferDescriptor {
     pub size: u64,
     pub usage: BufferUsage,
-}
-
-#[repr(C)]
-pub struct ShaderModuleDescriptor<'a> {
-    pub code: &'a [u8],
 }
 
 #[repr(C)]
@@ -61,7 +56,7 @@ pub struct ShaderModule<B: hal::Backend> {
 
 pub extern "C"
 fn device_create_shader_module(
-    device: DeviceHandle, desc: ShaderModuleDescriptor
+    device: DeviceHandle, desc: pipeline::ShaderModuleDescriptor
 ) -> ShaderModuleHandle {
     let shader = device.device.create_shader_module(desc.code).unwrap();
     ShaderModuleHandle::new(ShaderModule {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use] extern crate bitflags;
+
 #[cfg(feature = "gfx-backend-vulkan")]
 extern crate gfx_backend_vulkan as back;
 #[cfg(feature = "gfx-backend-dx12")]
@@ -10,14 +12,20 @@ extern crate gfx_backend_empty as back;
 extern crate gfx_hal as hal;
 extern crate gfx_memory as memory;
 
+mod binding_model;
 mod command;
 mod device;
 mod handle;
 mod instance;
+mod pipeline;
+mod resource;
 
+pub use self::binding_model::*;
 pub use self::command::*;
 pub use self::device::*;
 pub use self::instance::*;
+pub use self::pipeline::*;
+pub use self::resource::*;
 
 use back::Backend as B;
 use handle::Handle;
@@ -26,7 +34,19 @@ pub type InstanceHandle = Handle<back::Instance>;
 pub type AdapterHandle = Handle<hal::Adapter<B>>;
 pub type DeviceHandle = Handle<Device<B>>;
 pub type BufferHandle = Handle<Buffer<B>>;
+
+// Binding model
+pub type PipelineLayoutHandle = Handle<PipelineLayout<B>>;
+
+// Pipeline
+pub type BlendStateHandle = Handle<BlendState>;
+pub type DepthStencilStateHandle = Handle<DepthStencilState>;
+pub type InputStateHandle = Handle<InputState>;
 pub type ShaderModuleHandle = Handle<ShaderModule<B>>;
+pub type AttachmentStateHandle = Handle<AttachmentState>;
+pub type ComputePipelineHandle = Handle<ComputePipeline>;
+pub type RenderPipelineHandle = Handle<RenderPipeline>;
+
 pub type CommandBufferHandle = Handle<CommandBuffer<B>>;
 pub type RenderPassHandle = Handle<RenderPass<B>>;
 pub type ComputePassHandle = Handle<ComputePass<B>>;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,203 @@
+use hal;
+use resource;
+
+use {BlendStateHandle, DepthStencilStateHandle, PipelineLayoutHandle};
+
+
+#[repr(C)]
+pub enum BlendFactor {
+    Zero = 0,
+    One = 1,
+    SrcColor = 2,
+    OneMinusSrcColor = 3,
+    SrcAlpha = 4,
+    OneMinusSrcAlpha = 5,
+    DstColor = 6,
+    OneMinusDstColor = 7,
+    DstAlpha = 8,
+    OneMinusDstAlpha = 9,
+    SrcAlphaSaturated = 10,
+    BlendColor = 11,
+    OneMinusBlendColor = 12,
+}
+
+#[repr(C)]
+pub enum BlendOperation {
+    Add = 0,
+    Subtract = 1,
+    ReverseSubtract = 2,
+    Min = 3,
+    Max = 4,
+}
+
+bitflags! {
+    #[repr(transparent)]
+    pub struct ColorWriteFlags: u32 {
+        const NONE = 0x0;
+        const RED = 0x1;
+        const GREEN = 0x2;
+        const BLUE = 0x4;
+        const ALPHA = 0x8;
+        const ALL = 0x15;
+    }
+}
+
+#[repr(C)]
+pub struct BlendDescriptor {
+    pub src_factor: BlendFactor,
+    pub dst_factor: BlendFactor,
+    pub operation: BlendOperation,
+}
+
+#[repr(C)]
+pub struct BlendStateDescriptor {
+    pub blend_enabled: bool,
+    pub alpha: BlendDescriptor,
+    pub color: BlendDescriptor,
+    pub write_mask: ColorWriteFlags,
+}
+
+pub struct BlendState {
+    raw: hal::pso::BlendState,
+}
+
+#[repr(C)]
+pub enum StencilOperation {
+    Keep = 0,
+    Zero = 1,
+    Replace = 2,
+    Invert = 3,
+    IncrementClamp = 4,
+    DecrementClamp = 5,
+    IncrementWrap = 6,
+    DecrementWrap = 7,
+}
+
+#[repr(C)]
+pub struct StencilStateFaceDescriptor {
+    pub compare: resource::CompareFunction,
+    pub stencil_fail_op: StencilOperation,
+    pub depth_fail_op: StencilOperation,
+    pub pass_op: StencilOperation,
+}
+
+#[repr(C)]
+pub struct DepthStencilStateDescriptor {
+    pub depth_write_enabled: bool,
+    pub depth_compare: resource::CompareFunction,
+    pub front: StencilStateFaceDescriptor,
+    pub back: StencilStateFaceDescriptor,
+    pub stencil_read_mask: u32,
+    pub stencil_write_mask: u32,
+}
+
+pub struct DepthStencilState {
+    raw: hal::pso::DepthStencilDesc,
+}
+
+#[repr(C)]
+pub enum IndexFormat {
+    Uint16 = 0,
+    Uint32 = 1,
+}
+
+#[repr(C)]
+pub enum VertexFormat {
+    FloatR32G32B32A32 = 0,
+    FloatR32G32B32 = 1,
+    FloatR32G32 = 2,
+    FloatR32 = 3,
+}
+
+#[repr(C)]
+pub enum InputStepMode {
+    Vertex = 0,
+    Instance = 1,
+}
+
+#[repr(C)]
+pub struct VertexAttributeDescriptor {
+    pub shader_location: u32,
+    pub input_slot: u32,
+    pub offset: u32,
+    pub format: VertexFormat,
+}
+
+#[repr(C)]
+pub struct VertexInputDescriptor {
+    pub input_slot: u32,
+    pub stride: u32,
+    pub step_mode: InputStepMode,
+}
+
+#[repr(C)]
+pub struct InputStateDescriptor<'a> {
+    pub index_format: IndexFormat,
+    pub attributes: &'a [VertexAttributeDescriptor],
+    pub inputs: &'a [VertexInputDescriptor],
+}
+
+pub struct InputState {
+    // TODO
+}
+
+#[repr(C)]
+pub struct ShaderModuleDescriptor<'a> {
+    pub code: &'a [u8],
+}
+
+#[repr(C)]
+pub struct AttachmentStateDescriptor<'a> {
+    pub formats: &'a [resource::TextureFormat],
+}
+
+pub struct AttachmentState {
+    raw: hal::pass::Attachment,
+}
+
+#[repr(C)]
+pub enum ShaderStage {
+    Vertex = 0,
+    Fragment = 1,
+    Compute = 2,
+}
+
+#[repr(C)]
+pub struct PipelineStageDescriptor<'a> {
+    pub module: ShaderModuleDescriptor<'a>,
+    pub stage: ShaderStage,
+    pub entry_point: *const ::std::os::raw::c_char,
+}
+
+#[repr(C)]
+pub struct ComputePipelineDescriptor<'a> {
+    pub layout: PipelineLayoutHandle,
+    pub stages: &'a [PipelineStageDescriptor<'a>],
+}
+
+pub struct ComputePipeline {
+    // TODO
+}
+
+#[repr(C)]
+pub enum PrimitiveTopology {
+    PointList = 0,
+    LineList = 1,
+    LineStrip = 2,
+    TriangleList = 3,
+    TriangleStrip = 4,
+}
+
+#[repr(C)]
+pub struct RenderPipelineDescriptor<'a> {
+    pub layout: PipelineLayoutHandle,
+    pub stages: &'a [PipelineStageDescriptor<'a>],
+    pub primitive_topology: PrimitiveTopology,
+    pub blend_state: &'a [BlendStateHandle],
+    pub depth_stencil_state: DepthStencilStateHandle,
+    pub attachment_state: AttachmentState,
+}
+
+pub struct RenderPipeline {
+    // TODO
+}

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,0 +1,19 @@
+#[repr(C)]
+pub enum TextureFormat {
+    R8g8b8a8Unorm = 0,
+    R8g8b8a8Uint = 1,
+    B8g8r8a8Unorm = 2,
+    D32FloatS8Uint = 3,
+}
+
+#[repr(C)]
+pub enum CompareFunction {
+    Never = 0,
+    Less = 1,
+    Equal = 2,
+    LessEqual = 3,
+    Greater = 4,
+    NotEqual = 5,
+    GreaterEqual = 6,
+    Always = 7,
+}


### PR DESCRIPTION
Started to add the types from the pipeline section of the WebIDL (started to add binding model and resource sections too because the pipeline section references them).