### PR TITLE
Add wgpu_set_log_callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
  "arrayvec",
  "lazy_static",
  "libc",
+ "log",
  "objc",
  "parking_lot",
  "raw-window-handle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ git = "https://github.com/gfx-rs/wgpu"
 version = "0.5"
 
 [dependencies]
+log="0.4"
 arrayvec = "0.5"
 lazy_static = "1.1"
 parking_lot = "0.10"

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -703,6 +703,8 @@ typedef uint32_t WGPUBackendBit;
 
 typedef void (*WGPURequestAdapterCallback)(WGPUOption_AdapterId id, void *userdata);
 
+typedef void (*WGPULogCallback)(const char *msg);
+
 typedef struct {
   WGPUOption_TextureViewId view_id;
 } WGPUSwapChainOutput;
@@ -989,6 +991,8 @@ void wgpu_request_adapter_async(const WGPURequestAdapterOptions *desc,
                                 void *userdata);
 
 void wgpu_sampler_destroy(WGPUSamplerId sampler_id);
+
+void wgpu_set_log_callback(int level, WGPULogCallback callback);
 
 WGPUSwapChainOutput wgpu_swap_chain_get_next_texture(WGPUSwapChainId swap_chain_id);
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -703,7 +703,7 @@ typedef uint32_t WGPUBackendBit;
 
 typedef void (*WGPURequestAdapterCallback)(WGPUOption_AdapterId id, void *userdata);
 
-typedef void (*WGPULogCallback)(const char *msg);
+typedef void (*WGPULogCallback)(int level, const char *msg);
 
 typedef struct {
   WGPUOption_TextureViewId view_id;
@@ -992,7 +992,9 @@ void wgpu_request_adapter_async(const WGPURequestAdapterOptions *desc,
 
 void wgpu_sampler_destroy(WGPUSamplerId sampler_id);
 
-void wgpu_set_log_callback(int level, WGPULogCallback callback);
+void wgpu_set_log_callback(WGPULogCallback callback);
+
+void wgpu_set_log_level(int level);
 
 WGPUSwapChainOutput wgpu_swap_chain_get_next_texture(WGPUSwapChainId swap_chain_id);
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -127,6 +127,15 @@ typedef enum {
 } WGPULoadOp;
 
 typedef enum {
+  WGPULogLevel_Off = 0,
+  WGPULogLevel_Error = 1,
+  WGPULogLevel_Warn = 2,
+  WGPULogLevel_Info = 3,
+  WGPULogLevel_Debug = 4,
+  WGPULogLevel_Trace = 5,
+} WGPULogLevel;
+
+typedef enum {
   WGPUPowerPreference_Default = 0,
   WGPUPowerPreference_LowPower = 1,
   WGPUPowerPreference_HighPerformance = 2,
@@ -994,7 +1003,7 @@ void wgpu_sampler_destroy(WGPUSamplerId sampler_id);
 
 void wgpu_set_log_callback(WGPULogCallback callback);
 
-void wgpu_set_log_level(int level);
+int wgpu_set_log_level(WGPULogLevel level);
 
 WGPUSwapChainOutput wgpu_swap_chain_get_next_texture(WGPUSwapChainId swap_chain_id);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 
 mod command;
 mod device;
+mod logging;
 
 pub use self::command::*;
 pub use self::device::*;
+pub use self::logging::*;
 
 type Global = core::hub::Global<core::hub::IdentityManagerFactory>;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use log::{Record, Metadata};
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::os::raw::c_int;
+
+pub type LogCallback = unsafe extern "C" fn(msg: *const c_char);
+
+struct LogProxy {level: log::Level, callback: LogCallback}
+
+impl log::Log for LogProxy {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= self.level
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            let msg = format!("{} - {}", record.level(), record.args());
+            // println!("{}", msg);  // Print the message to stdout
+            let cb: LogCallback = self.callback;
+            let s = CString::new(msg).unwrap();
+            let p = s.as_ptr();
+            unsafe {
+                cb(p);
+            }
+            // We do not use std::mem::forget(s), so the memory will be reclaimed
+            // by Rust once this function here. The callback should thus make a
+            // copy of the string. This is fine, because its probably converted to
+            // an internal (unicode) string type.
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+// Store the logger instance as a mutable nullable static object
+static mut LOGGER: Option<LogProxy> = None;
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpu_set_log_callback(level: c_int, callback: LogCallback) {
+    // Get level
+    let level_filter = match level {
+        0 => log::LevelFilter::Off,
+        1 => log::LevelFilter::Error,
+        2 => log::LevelFilter::Warn,
+        3 => log::LevelFilter::Info,
+        4 => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Trace,
+    };
+    // Instantiate logger and store as the static object
+    let logger: LogProxy = LogProxy{level: level_filter.to_level().unwrap(), callback: callback};
+    LOGGER = Some(logger);
+    // set_logger seems to require that the logger is static,
+    // so we need to use LOGGER instead of logger.
+    match &LOGGER {
+        Some(logger) =>log::set_logger(logger)
+            .map(|()| log::set_max_level(level_filter)).unwrap(),
+        None => println!("{}", "Failed to set logger"),
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -2,34 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use log::{Record, Metadata};
+use log::{LevelFilter, Metadata, Record};
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
 
-pub type LogCallback = unsafe extern "C" fn(msg: *const c_char);
+pub type LogCallback = unsafe extern "C" fn(level: c_int, msg: *const c_char);
 
-struct LogProxy {level: log::Level, callback: LogCallback}
+struct LogProxy {
+    callback: LogCallback,
+}
 
 impl log::Log for LogProxy {
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() <= self.level
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
     }
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            let msg = format!("{} - {}", record.level(), record.args());
-            // println!("{}", msg);  // Print the message to stdout
-            let cb: LogCallback = self.callback;
-            let s = CString::new(msg).unwrap();
-            let p = s.as_ptr();
+            let callback: LogCallback = self.callback;
+            let msg = record.args().to_string();
+            let msg_c = CString::new(msg).unwrap();
             unsafe {
-                cb(p);
+                callback(record.level() as c_int, msg_c.as_ptr());
             }
-            // We do not use std::mem::forget(s), so the memory will be reclaimed
-            // by Rust once this function here. The callback should thus make a
-            // copy of the string. This is fine, because its probably converted to
-            // an internal (unicode) string type.
+            // We do not use std::mem::forget(s), so Rust will reclaim the memory
+            // once msg_c gets cleared. The callback should thus make a copy.
         }
     }
 
@@ -39,25 +37,28 @@ impl log::Log for LogProxy {
 // Store the logger instance as a mutable nullable static object
 static mut LOGGER: Option<LogProxy> = None;
 
+// Note: this function may only be called once in the lifetime of a program.
 #[no_mangle]
-pub unsafe extern "C" fn wgpu_set_log_callback(level: c_int, callback: LogCallback) {
-    // Get level
-    let level_filter = match level {
-        0 => log::LevelFilter::Off,
-        1 => log::LevelFilter::Error,
-        2 => log::LevelFilter::Warn,
-        3 => log::LevelFilter::Info,
-        4 => log::LevelFilter::Debug,
-        _ => log::LevelFilter::Trace,
-    };
-    // Instantiate logger and store as the static object
-    let logger: LogProxy = LogProxy{level: level_filter.to_level().unwrap(), callback: callback};
+pub unsafe extern "C" fn wgpu_set_log_callback(callback: LogCallback) {
+    // Instantiate logger, store as static object, and make it THE logger.
+    let logger: LogProxy = LogProxy { callback: callback };
     LOGGER = Some(logger);
-    // set_logger seems to require that the logger is static,
-    // so we need to use LOGGER instead of logger.
-    match &LOGGER {
-        Some(logger) =>log::set_logger(logger)
-            .map(|()| log::set_max_level(level_filter)).unwrap(),
-        None => println!("{}", "Failed to set logger"),
+    log::set_logger(LOGGER.as_ref().unwrap()).unwrap();
+    // The max_level is Off by default. If not set yet, set it to Warn instead.
+    if log::max_level() == LevelFilter::Off {
+        log::set_max_level(LevelFilter::Warn);
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpu_set_log_level(level: c_int) {
+    let level_filter = match level {
+        0 => LevelFilter::Off,
+        1 => LevelFilter::Error,
+        2 => LevelFilter::Warn,
+        3 => LevelFilter::Info,
+        4 => LevelFilter::Debug,
+        _ => LevelFilter::Trace,
+    };
+    log::set_max_level(level_filter);
 }


### PR DESCRIPTION
This is a proposal to make it possible for projects that wrap the wgpu-native static library, to get the log messages via a callback.

Having them printed to stdout is much easier, but having a callback gives the application much more control (e.g. feeding log messages in the environments own logging system).