### PR TITLE
Remove license from source headers

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,6 +1,3 @@
-header = """/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */"""
 autogen_warning = """/* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
  * To generate this file:
  *   1. Get the latest cbindgen using `cargo install --force cbindgen`

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 #ifndef WGPU_H
 #define WGPU_H
 #include "wgpu.h"

--- a/examples/framework.c
+++ b/examples/framework.c
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 #ifndef WGPU_H
 #define WGPU_H
 #include "wgpu.h"

--- a/examples/framework.h
+++ b/examples/framework.h
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 #ifndef WGPU_H
 #define WGPU_H
 #include "wgpu.h"

--- a/examples/remote/main.c
+++ b/examples/remote/main.c
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 #define WGPU_INLINE
 #define WGPU_FUNC
 

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 #ifndef WGPU_H
 #define WGPU_H
 #include "wgpu.h"

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 /* Generated with cbindgen:0.14.1 */
 
 /* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 use crate::GLOBAL;
 
 pub use core::command::{compute_ffi::*, render_ffi::*};

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 use crate::GLOBAL;
 
 use core::{gfx_select, hub::Token, id};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 use std::sync::Arc;
 
 mod command;


### PR DESCRIPTION
> This block was needed for vendoring in mozilla-central. As the code is
> now moved out from wgpu to wgpu-native, it's no longer vendored, so we
> can remove the nasty headers.

fixes #2

Let me know if I missed something!