### PR TITLE
Android support

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -828,6 +828,8 @@ WGPUSurfaceId wgpu_create_surface_from_metal_layer(void *layer);
 
 WGPUSurfaceId wgpu_create_surface_from_wayland(void *surface, void *display);
 
+WGPUSurfaceId wgpu_create_surface_from_android(void *a_native_window);
+
 WGPUSurfaceId wgpu_create_surface_from_windows_hwnd(void *_hinstance, void *hwnd);
 
 WGPUSurfaceId wgpu_create_surface_from_xlib(const void **display, unsigned long window);

--- a/src/device.rs
+++ b/src/device.rs
@@ -43,14 +43,24 @@ pub fn wgpu_create_surface(raw_handle: raw_window_handle::RawWindowHandle) -> id
                     .create_surface_from_nsview(ns_view, cfg!(debug_assertions)),
             }
         }
-        #[cfg(all(unix, not(target_os = "android"), not(target_os = "ios"), not(target_os = "macos")))]
+        #[cfg(all(
+            unix,
+            not(target_os = "android"),
+            not(target_os = "ios"),
+            not(target_os = "macos")
+        ))]
         Rwh::Xlib(h) => core::instance::Surface {
             vulkan: instance
                 .vulkan
                 .as_ref()
                 .map(|inst| inst.create_surface_from_xlib(h.display as _, h.window as _)),
         },
-        #[cfg(all(unix, not(target_os = "android"), not(target_os = "ios"), not(target_os = "macos")))]
+        #[cfg(all(
+            unix,
+            not(target_os = "android"),
+            not(target_os = "ios"),
+            not(target_os = "macos")
+        ))]
         Rwh::Wayland(h) => core::instance::Surface {
             vulkan: instance
                 .vulkan
@@ -85,7 +95,12 @@ pub fn wgpu_create_surface(raw_handle: raw_window_handle::RawWindowHandle) -> id
         .register_identity(PhantomData, surface, &mut token)
 }
 
-#[cfg(all(unix, not(target_os = "android"), not(target_os = "ios"), not(target_os = "macos")))]
+#[cfg(all(
+    unix,
+    not(target_os = "android"),
+    not(target_os = "ios"),
+    not(target_os = "macos")
+))]
 #[no_mangle]
 pub extern "C" fn wgpu_create_surface_from_xlib(
     display: *mut *const std::ffi::c_void,
@@ -99,7 +114,12 @@ pub extern "C" fn wgpu_create_surface_from_xlib(
     }))
 }
 
-#[cfg(all(unix, not(target_os = "android"), not(target_os = "ios"), not(target_os = "macos")))]
+#[cfg(all(
+    unix,
+    not(target_os = "android"),
+    not(target_os = "ios"),
+    not(target_os = "macos")
+))]
 #[no_mangle]
 pub extern "C" fn wgpu_create_surface_from_wayland(
     surface: *mut std::ffi::c_void,


### PR DESCRIPTION
With these changes, I was able to run the `hello-triangle` example on a Pixel 2 without much effort, which is pretty cool! (I'd say "with minimal effort" instead if winit EL2 had an Android backend... and in case you were wondering, the example also works fine on iOS!)