### PR TITLE
Add wgpu_get_version()

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -928,7 +928,7 @@ void wgpu_device_get_limits(WGPUDeviceId _device_id, WGPULimits *limits);
 
 void wgpu_device_poll(WGPUDeviceId device_id, bool force_wait);
 
-const char *wgpu_get_version(void);
+unsigned int wgpu_get_version(void);
 
 /**
  * # Safety

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -928,6 +928,8 @@ void wgpu_device_get_limits(WGPUDeviceId _device_id, WGPULimits *limits);
 
 void wgpu_device_poll(WGPUDeviceId device_id, bool force_wait);
 
+const char *wgpu_get_version(void);
+
 /**
  * # Safety
  *

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,12 @@ type Global = core::hub::Global<core::hub::IdentityManagerFactory>;
 lazy_static::lazy_static! {
     static ref GLOBAL: Arc<Global> = Arc::new(Global::new("wgpu", core::hub::IdentityManagerFactory));
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpu_get_version() -> *const std::os::raw::c_char {
+    let version = env!("CARGO_PKG_VERSION");
+    let version_c = std::ffi::CString::new(version).unwrap();
+    let version_p = version_c.as_ptr();
+    std::mem::forget(version_c); // see https://thefullsnack.com/en/string-ffi-rust.html
+    return version_p;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,9 @@ lazy_static::lazy_static! {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpu_get_version() -> *const std::os::raw::c_char {
-    let version = env!("CARGO_PKG_VERSION");
-    let version_c = std::ffi::CString::new(version).unwrap();
-    let version_p = version_c.as_ptr();
-    std::mem::forget(version_c); // see https://thefullsnack.com/en/string-ffi-rust.html
-    return version_p;
+pub unsafe extern "C" fn wgpu_get_version() -> std::os::raw::c_uint {
+    let major: u32 = env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap();
+    let minor: u32 = env!("CARGO_PKG_VERSION_MINOR").parse().unwrap();
+    let patch: u32 = env!("CARGO_PKG_VERSION_PATCH").parse().unwrap();
+    return (major << 16) + (minor << 8) + patch;
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -22,7 +22,7 @@ impl log::Log for LogProxy {
             unsafe {
                 callback(record.level() as c_int, msg_c.as_ptr());
             }
-            // We do not use std::mem::forget(s), so Rust will reclaim the memory
+            // We do not use std::mem::forget(msg_c), so Rust will reclaim the memory
             // once msg_c gets cleared. The callback should thus make a copy.
         }
     }


### PR DESCRIPTION
This ads a C api function to obtain the version of `gpu-native`.

The use-case for wgpu-py is that although we do ship a pre-compiled wgpu-native library, we allow our users to bring their own library. We would like to check whether the version that the wrapper expects matches the actual library version :)