### PR TITLE
Hide Rust-only fns from cbindgen

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -18,7 +18,7 @@ language = "C"
 
 [export]
 prefix = "WGPU"
-exclude = ["Option_AdapterId", "Option_SurfaceId", "Option_TextureViewId"]
+exclude = ["Option_AdapterId", "Option_SurfaceId", "Option_TextureViewId", "wgpu_render_pass_finish", "wgpu_compute_pass_finish"]
 
 [parse]
 parse_deps = true

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -813,8 +813,6 @@ void wgpu_compute_pass_dispatch_indirect(WGPURawPass *pass,
 
 void wgpu_compute_pass_end_pass(WGPUComputePassId pass_id);
 
-const uint8_t *wgpu_compute_pass_finish(WGPURawPass *pass, uintptr_t *length);
-
 void wgpu_compute_pass_insert_debug_marker(WGPURawPass *_pass, WGPURawString _label);
 
 void wgpu_compute_pass_pop_debug_group(WGPURawPass *_pass);
@@ -835,11 +833,11 @@ void wgpu_compute_pass_set_bind_group(WGPURawPass *pass,
 
 void wgpu_compute_pass_set_pipeline(WGPURawPass *pass, WGPUComputePipelineId pipeline_id);
 
+WGPUSurfaceId wgpu_create_surface_from_android(void *a_native_window);
+
 WGPUSurfaceId wgpu_create_surface_from_metal_layer(void *layer);
 
 WGPUSurfaceId wgpu_create_surface_from_wayland(void *surface, void *display);
-
-WGPUSurfaceId wgpu_create_surface_from_android(void *a_native_window);
 
 WGPUSurfaceId wgpu_create_surface_from_windows_hwnd(void *_hinstance, void *hwnd);
 
@@ -939,8 +937,6 @@ void wgpu_render_pass_end_pass(WGPURenderPassId pass_id);
 void wgpu_render_pass_execute_bundles(WGPURawPass *_pass,
                                       const WGPURenderBundleId *_bundles,
                                       uintptr_t _bundles_length);
-
-const uint8_t *wgpu_render_pass_finish(WGPURawPass *pass, uintptr_t *length);
 
 void wgpu_render_pass_insert_debug_marker(WGPURawPass *_pass, WGPURawString _label);
 


### PR DESCRIPTION
This is for [wgpu#490](https://github.com/gfx-rs/wgpu/issues/490)

Hide wgpu_compute_pass_finish and wgpu_render_pass_finish