### PR TITLE
Update copy functions, add write_texture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#a7200bb8658e7b7bb972ee46a81f423209fb7659"
+source = "git+https://github.com/gfx-rs/wgpu#4e1d76013c0b272383400beba48dc306e1a350f6"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -733,7 +733,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#a7200bb8658e7b7bb972ee46a81f423209fb7659"
+source = "git+https://github.com/gfx-rs/wgpu#4e1d76013c0b272383400beba48dc306e1a350f6"
 dependencies = [
  "bitflags",
  "peek-poke",

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -18,7 +18,16 @@ language = "C"
 
 [export]
 prefix = "WGPU"
-exclude = ["Option_AdapterId", "Option_SurfaceId", "Option_TextureViewId", "wgpu_render_pass_finish", "wgpu_compute_pass_finish"]
+exclude = [
+	"BufferUse",
+	"TextureUse",
+	"Option_AdapterId",
+	"Option_BufferId",
+	"Option_SurfaceId",
+	"Option_TextureViewId",
+	"wgpu_render_pass_finish",
+	"wgpu_compute_pass_finish",
+]
 
 [export.rename]
 "BufferDescriptor_Label" = "BufferDescriptor"
@@ -29,7 +38,6 @@ exclude = ["Option_AdapterId", "Option_SurfaceId", "Option_TextureViewId", "wgpu
 [parse]
 parse_deps = true
 include = ["wgpu-core", "wgpu-types"]
-
 extra_bindings = ["wgpu-core", "wgpu-types"]
 
 [fn]
@@ -45,6 +53,7 @@ derive_helper_methods = true
 bitflags = true
 
 [defines]
+#"target_os = android" = "WGPU_TARGET_ANDROID"
 #"target_os = ios" = "WGPU_TARGET_IOS"
 #"target_os = macos" = "WGPU_TARGET_MACOS"
 #"unix" = "WGPU_TARGET_FAMILY_UNIX"

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -289,16 +289,6 @@ typedef enum {
   WGPUVertexFormat_Int4 = 29,
 } WGPUVertexFormat;
 
-/**
- * The internal enum mirrored from `BufferUsage`. The values don't have to match!
- */
-typedef struct WGPUBufferUse WGPUBufferUse;
-
-/**
- * The internal enum mirrored from `TextureUsage`. The values don't have to match!
- */
-typedef struct WGPUTextureUse WGPUTextureUse;
-
 typedef WGPUNonZeroU64 WGPUId_Adapter_Dummy;
 
 typedef WGPUId_Adapter_Dummy WGPUAdapterId;
@@ -397,10 +387,14 @@ typedef struct {
 } WGPURenderPassDescriptor;
 
 typedef struct {
-  WGPUBufferId buffer;
   WGPUBufferAddress offset;
   uint32_t bytes_per_row;
   uint32_t rows_per_image;
+} WGPUTextureDataLayout;
+
+typedef struct {
+  WGPUBufferId buffer;
+  WGPUTextureDataLayout layout;
 } WGPUBufferCopyView;
 
 typedef WGPUNonZeroU64 WGPUId_Texture_Dummy;
@@ -417,7 +411,6 @@ typedef struct {
 typedef struct {
   WGPUTextureId texture;
   uint32_t mip_level;
-  uint32_t array_layer;
   WGPUOrigin3d origin;
 } WGPUTextureCopyView;
 
@@ -822,17 +815,17 @@ void wgpu_command_encoder_copy_buffer_to_buffer(WGPUCommandEncoderId command_enc
 void wgpu_command_encoder_copy_buffer_to_texture(WGPUCommandEncoderId command_encoder_id,
                                                  const WGPUBufferCopyView *source,
                                                  const WGPUTextureCopyView *destination,
-                                                 WGPUExtent3d copy_size);
+                                                 const WGPUExtent3d *copy_size);
 
 void wgpu_command_encoder_copy_texture_to_buffer(WGPUCommandEncoderId command_encoder_id,
                                                  const WGPUTextureCopyView *source,
                                                  const WGPUBufferCopyView *destination,
-                                                 WGPUExtent3d copy_size);
+                                                 const WGPUExtent3d *copy_size);
 
 void wgpu_command_encoder_copy_texture_to_texture(WGPUCommandEncoderId command_encoder_id,
                                                   const WGPUTextureCopyView *source,
                                                   const WGPUTextureCopyView *destination,
-                                                  WGPUExtent3d copy_size);
+                                                  const WGPUExtent3d *copy_size);
 
 void wgpu_command_encoder_destroy(WGPUCommandEncoderId command_encoder_id);
 
@@ -950,10 +943,23 @@ void wgpu_queue_submit(WGPUQueueId queue_id,
  * pointer is valid for `data_length` elements.
  */
 void wgpu_queue_write_buffer(WGPUQueueId queue_id,
-                             const uint8_t *data,
-                             uintptr_t data_length,
                              WGPUBufferId buffer_id,
-                             WGPUBufferAddress buffer_offset);
+                             WGPUBufferAddress buffer_offset,
+                             const uint8_t *data,
+                             uintptr_t data_length);
+
+/**
+ * # Safety
+ *
+ * This function is unsafe as there is no guarantee that the given `data`
+ * pointer is valid for `data_length` elements.
+ */
+void wgpu_queue_write_texture(WGPUQueueId queue_id,
+                              const WGPUTextureCopyView *texture,
+                              const uint8_t *data,
+                              uintptr_t data_length,
+                              const WGPUTextureDataLayout *data_layout,
+                              const WGPUExtent3d *size);
 
 void wgpu_render_pass_destroy(WGPURawPass *pass);
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -35,7 +35,7 @@ pub extern "C" fn wgpu_command_encoder_copy_buffer_to_texture(
     command_encoder_id: id::CommandEncoderId,
     source: &wgc::command::BufferCopyView,
     destination: &wgc::command::TextureCopyView,
-    copy_size: wgt::Extent3d,
+    copy_size: &wgt::Extent3d,
 ) {
     gfx_select!(command_encoder_id => GLOBAL.command_encoder_copy_buffer_to_texture(
         command_encoder_id,
@@ -49,7 +49,7 @@ pub extern "C" fn wgpu_command_encoder_copy_texture_to_buffer(
     command_encoder_id: id::CommandEncoderId,
     source: &wgc::command::TextureCopyView,
     destination: &wgc::command::BufferCopyView,
-    copy_size: wgt::Extent3d,
+    copy_size: &wgt::Extent3d,
 ) {
     gfx_select!(command_encoder_id => GLOBAL.command_encoder_copy_texture_to_buffer(
         command_encoder_id,
@@ -63,7 +63,7 @@ pub extern "C" fn wgpu_command_encoder_copy_texture_to_texture(
     command_encoder_id: id::CommandEncoderId,
     source: &wgc::command::TextureCopyView,
     destination: &wgc::command::TextureCopyView,
-    copy_size: wgt::Extent3d,
+    copy_size: &wgt::Extent3d,
 ) {
     gfx_select!(command_encoder_id => GLOBAL.command_encoder_copy_texture_to_texture(
         command_encoder_id,

--- a/src/device.rs
+++ b/src/device.rs
@@ -294,13 +294,30 @@ pub extern "C" fn wgpu_device_get_default_queue(device_id: id::DeviceId) -> id::
 #[no_mangle]
 pub unsafe extern "C" fn wgpu_queue_write_buffer(
     queue_id: id::QueueId,
-    data: *const u8,
-    data_length: usize,
     buffer_id: id::BufferId,
     buffer_offset: wgt::BufferAddress,
+    data: *const u8,
+    data_length: usize,
 ) {
     let slice = slice::from_raw_parts(data, data_length);
-    gfx_select!(queue_id => GLOBAL.queue_write_buffer(queue_id, slice, buffer_id, buffer_offset))
+    gfx_select!(queue_id => GLOBAL.queue_write_buffer(queue_id, buffer_id, buffer_offset, slice))
+}
+
+/// # Safety
+///
+/// This function is unsafe as there is no guarantee that the given `data`
+/// pointer is valid for `data_length` elements.
+#[no_mangle]
+pub unsafe extern "C" fn wgpu_queue_write_texture(
+    queue_id: id::QueueId,
+    texture: &wgc::command::TextureCopyView,
+    data: *const u8,
+    data_length: usize,
+    data_layout: &wgt::TextureDataLayout,
+    size: &wgt::Extent3d,
+) {
+    let slice = slice::from_raw_parts(data, data_length);
+    gfx_select!(queue_id => GLOBAL.queue_write_texture(queue_id, texture, slice, data_layout, size))
 }
 
 /// # Safety


### PR DESCRIPTION
Depends on https://github.com/gfx-rs/wgpu/pull/666
Notable API changes:
- `BufferCopyView` now includes a new `TextureDataLayout`.
- the `TextureCopyView::array_layer` is removed. Instead, the `origin.z` is treated as an array layer for non-3D textures.
- new `write_texture` method is here.