### PR TITLE
Moved development of the wgpu scopes wrapper to git

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The C API header is generated at `ffi/wgpu.h` by [cbindgen](https://github.com/e
 
 - [gfx-rs/wgpu-rs](https://github.com/gfx-rs/wgpu-rs) - idiomatic Rust wrapper with [a few more examples](https://github.com/gfx-rs/wgpu-rs/tree/master/examples) to get a feel of the API
 - [pygfx/wgpu-py](https://github.com/pygfx/wgpu-py) - Python wrapper
-- [porky11/wgpu](https://nest.pijul.com/porky11/wgpu) - experimental [Scopes](http://scopes.rocks) wrapper
+- [porky11/wgpu](https://gitlab.com/scopes-libraries/wgpu) - experimental [Scopes](http://scopes.rocks) wrapper
 - [cshenton/WebGPU.jl](https://github.com/cshenton/WebGPU.jl) - experimental Julia wrapper
 - [kgpu/wgpuj](https://github.com/kgpu/kgpu/tree/master/wgpuj) - Java/Kotlin wrapper
 


### PR DESCRIPTION
It's now developed in a special group at GitLab instead of pijul