### PR TITLE
Updated to newer version of wgpu: rev 847d9748f525b3725564e933b83f11cc5a7abb83

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "raw-window-handle",
  "smallvec",
  "winapi",
+ "x11",
 ]
 
 [[package]]
@@ -471,6 +472,12 @@ dependencies = [
  "synstructure",
  "unicode-xid",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "proc-macro2"
@@ -714,6 +721,7 @@ name = "wgpu-native"
 version = "0.5.0"
 dependencies = [
  "arrayvec",
+ "gfx-backend-vulkan",
  "lazy_static",
  "libc",
  "log",
@@ -762,4 +770,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "x11"
+version = "2.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#417ea69b4509d4d5a51d16835e793cb5d4c6bec6"
+source = "git+https://github.com/gfx-rs/wgpu#b76c8481f8b6a2c2b50b737d966866071dd7a722"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -732,7 +732,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#417ea69b4509d4d5a51d16835e793cb5d4c6bec6"
+source = "git+https://github.com/gfx-rs/wgpu#b76c8481f8b6a2c2b50b737d966866071dd7a722"
 dependencies = [
  "bitflags",
  "peek-poke",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#eaf8f4af87237373105b016832662e7943b3899c"
+source = "git+https://github.com/gfx-rs/wgpu#847d9748f525b3725564e933b83f11cc5a7abb83"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -732,7 +732,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#eaf8f4af87237373105b016832662e7943b3899c"
+source = "git+https://github.com/gfx-rs/wgpu#847d9748f525b3725564e933b83f11cc5a7abb83"
 dependencies = [
  "bitflags",
  "peek-poke",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#041db60f9080769b5edc40888cf9683ccb255399"
+source = "git+https://github.com/gfx-rs/wgpu#417ea69b4509d4d5a51d16835e793cb5d4c6bec6"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -732,7 +732,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#041db60f9080769b5edc40888cf9683ccb255399"
+source = "git+https://github.com/gfx-rs/wgpu#417ea69b4509d4d5a51d16835e793cb5d4c6bec6"
 dependencies = [
  "bitflags",
  "peek-poke",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#b76c8481f8b6a2c2b50b737d966866071dd7a722"
+source = "git+https://github.com/gfx-rs/wgpu#eaf8f4af87237373105b016832662e7943b3899c"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -732,7 +732,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#b76c8481f8b6a2c2b50b737d966866071dd7a722"
+source = "git+https://github.com/gfx-rs/wgpu#eaf8f4af87237373105b016832662e7943b3899c"
 dependencies = [
  "bitflags",
  "peek-poke",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "ash"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69daec0742947f33a85931fa3cb0ce5f07929159dcbd1f0cbb5b2912e2978509"
+checksum = "c69a8137596e84c22d57f3da1b5de1d4230b1742a710091c85f4d7ce50f00f38"
 dependencies = [
  "libloading",
 ]
@@ -62,9 +62,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 
 [[package]]
 name = "cfg-if"
@@ -82,15 +82,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "cocoa"
-version = "0.20.1"
+name = "cocoa-foundation"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7b6f3f7f4f0b3ec5c5039aaa9e8c3cef97a7a480a400fd62944841314f293d"
+checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
  "bitflags",
  "block",
  "core-foundation",
- "core-graphics",
+ "core-graphics-types",
  "foreign-types",
  "libc",
  "objc",
@@ -104,9 +104,9 @@ checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+checksum = "3b5ed8e7e76c45974e15e41bfa8d5b0483cd90191639e01d8f5f1e606299d3fb"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -114,15 +114,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+checksum = "9a21fa21941700a3cd8fcb4091f361a6a712fac632f85d9f487cc892045d55c6"
 
 [[package]]
-name = "core-graphics"
-version = "0.19.0"
+name = "core-graphics-types"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e78b2e0aaf43f08e7ae0d6bc96895ef72ff0921c7d4ff4762201b2dba376dd"
+checksum = "e92f5d519093a4178296707dbaa3880eae85a5ef5386675f361a1cf25376e93c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7ed48e89905e5e146bcc1951cc3facb9e44aea9adf5dc01078cda1bd24b662"
+checksum = "c1324bc4eae34f03b0ced586da5ae2b1ab46acfdae68b5b26d2e23dadae376a2"
 dependencies = [
  "bitflags",
  "libloading",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-dx11"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92de0ddc0fde1a89b2a0e92dcc6bbb554bd34af0135e53a28d5ef064611094a4"
+checksum = "32d95d5fddfa596c0628be117a16979b273f676b4e5a037a417365f274349123"
 dependencies = [
  "bitflags",
  "gfx-auxil",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-dx12"
-version = "0.5.5"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708067c51793d2165a9d0c11e896c0365d2591753538c6b1b386ac9af1dab2ed"
+checksum = "5959ce9dd48e7e04c71128024c3e76e86aa6fb6d83e48aad6819a1f7afae52e4"
 dependencies = [
  "bitflags",
  "d3d12",
@@ -216,26 +216,26 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-empty"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67bd2d7bc022b257ddbdabc5fa3b10c29c292372c3409f2b6a6e3f4e11cdb85"
+checksum = "2e0f922b263916801583b7a1d58213f51c46a225c1cdf29f6d10135a23945f07"
 dependencies = [
  "gfx-hal",
+ "log",
  "raw-window-handle",
 ]
 
 [[package]]
 name = "gfx-backend-metal"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205f3ca8e74ed814ea2c0206d47d8925077673cab2e21f9b12d48ff781cf87ee"
+checksum = "92804d20b194de6c84cb4bec14ec6a6dcae9c51f0a9186817fb412a590131ae6"
 dependencies = [
  "arrayvec",
  "bitflags",
  "block",
- "cocoa",
+ "cocoa-foundation",
  "copyless",
- "core-graphics",
  "foreign-types",
  "gfx-auxil",
  "gfx-hal",
@@ -253,14 +253,14 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-vulkan"
-version = "0.5.6"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ff36feae801fa23d29acd74082603a0145a697a23595757dd4e78828ab33da"
+checksum = "aec9c919cfc236d2c36aaa38609c1906a92f2df99a3c7f53022b01936f98275a"
 dependencies = [
  "arrayvec",
  "ash",
  "byteorder",
- "core-graphics",
+ "core-graphics-types",
  "gfx-hal",
  "lazy_static",
  "log",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-hal"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc96180204064c9493e0fe4a9efeb721e0ac59fe8e1906d0c659142a93114fb1"
+checksum = "a18534b23d4c262916231511309bc1f307c74cda8dcb68b93a10ca213a22814b"
 dependencies = [
  "bitflags",
  "raw-window-handle",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.40"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
+checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -331,17 +331,16 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "2cadb8e769f070c45df05c78c7520eb4cd17061d4ab262e43cfc68b4d00ac71c"
 dependencies = [
- "cc",
  "winapi",
 ]
 
@@ -356,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
 ]
@@ -374,14 +373,13 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e198a0ee42bdbe9ef2c09d0b9426f3b2b47d90d93a4a9b0395c4cea605e92dc0"
+checksum = "5c4e8a431536529327e28c9ba6992f2cb0c15d4222f0602a16e6d7695ff3bccf"
 dependencies = [
  "bitflags",
  "block",
- "cocoa",
- "core-graphics",
+ "cocoa-foundation",
  "foreign-types",
  "log",
  "objc",
@@ -401,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]
@@ -481,9 +479,9 @@ checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
 ]
@@ -514,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "ron"
@@ -537,18 +535,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.111"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.111"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -563,9 +561,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "spirv_cross"
@@ -599,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -610,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -622,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "vec_map"
@@ -634,9 +632,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.63"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
+checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -644,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.63"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
+checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -659,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.63"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
+checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -669,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.63"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
+checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -682,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.63"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
+checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 
 [[package]]
 name = "wgpu-core"
@@ -743,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ lazy_static = "1.1"
 parking_lot = "0.10"
 raw-window-handle = "0.3"
 libc = {version="0.2", features=[]}
+
+[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
+gfx-backend-vulkan = { version = "0.5", features = ["x11"] }
+

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -55,6 +55,7 @@ int main(
             &(WGPUCLimits){
                 .max_bind_groups = 1
             },
+            false,
              NULL);
 
     WGPUBufferId staging_buffer = wgpu_device_create_buffer(device,

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -103,6 +103,7 @@ int main() {
         &(WGPUCLimits){
             .max_bind_groups = 1,
         },
+        false,
         NULL);
 
     WGPUShaderModuleId vertex_shader = wgpu_device_create_shader_module(device,

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1,4 +1,4 @@
-/* Generated with cbindgen:0.14.2 */
+/* Generated with cbindgen:0.14.3 */
 
 /* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
  * To generate this file:
@@ -370,19 +370,19 @@ typedef uint64_t WGPUExtensions;
  *
  * https://github.com/gpuweb/gpuweb/issues/696
  */
-#define WGPUExtensions_ANISOTROPIC_FILTERING 65536
+#define WGPUExtensions_ANISOTROPIC_FILTERING (uint64_t)65536
 /**
  * Extensions which are part of the upstream webgpu standard
  */
-#define WGPUExtensions_ALL_WEBGPU 65535
+#define WGPUExtensions_ALL_WEBGPU (uint64_t)65535
 /**
  * Extensions that require activating the unsafe extension flag
  */
-#define WGPUExtensions_ALL_UNSAFE 18446462598732840960ULL
+#define WGPUExtensions_ALL_UNSAFE (uint64_t)18446462598732840960ULL
 /**
  * Extensions that are only available when targeting native (not web)
  */
-#define WGPUExtensions_ALL_NATIVE 18446744073709486080ULL
+#define WGPUExtensions_ALL_NATIVE (uint64_t)18446744073709486080ULL
 
 typedef struct WGPUCAdapterInfo {
   /**
@@ -603,10 +603,10 @@ typedef struct WGPUBindGroupDescriptor {
 } WGPUBindGroupDescriptor;
 
 typedef uint32_t WGPUShaderStage;
-#define WGPUShaderStage_NONE 0
-#define WGPUShaderStage_VERTEX 1
-#define WGPUShaderStage_FRAGMENT 2
-#define WGPUShaderStage_COMPUTE 4
+#define WGPUShaderStage_NONE (uint32_t)0
+#define WGPUShaderStage_VERTEX (uint32_t)1
+#define WGPUShaderStage_FRAGMENT (uint32_t)2
+#define WGPUShaderStage_COMPUTE (uint32_t)4
 
 typedef struct WGPUBindGroupLayoutEntry {
   uint32_t binding;
@@ -628,15 +628,15 @@ typedef struct WGPUBindGroupLayoutDescriptor {
 typedef const char *WGPULabel;
 
 typedef uint32_t WGPUBufferUsage;
-#define WGPUBufferUsage_MAP_READ 1
-#define WGPUBufferUsage_MAP_WRITE 2
-#define WGPUBufferUsage_COPY_SRC 4
-#define WGPUBufferUsage_COPY_DST 8
-#define WGPUBufferUsage_INDEX 16
-#define WGPUBufferUsage_VERTEX 32
-#define WGPUBufferUsage_UNIFORM 64
-#define WGPUBufferUsage_STORAGE 128
-#define WGPUBufferUsage_INDIRECT 256
+#define WGPUBufferUsage_MAP_READ (uint32_t)1
+#define WGPUBufferUsage_MAP_WRITE (uint32_t)2
+#define WGPUBufferUsage_COPY_SRC (uint32_t)4
+#define WGPUBufferUsage_COPY_DST (uint32_t)8
+#define WGPUBufferUsage_INDEX (uint32_t)16
+#define WGPUBufferUsage_VERTEX (uint32_t)32
+#define WGPUBufferUsage_UNIFORM (uint32_t)64
+#define WGPUBufferUsage_STORAGE (uint32_t)128
+#define WGPUBufferUsage_INDIRECT (uint32_t)256
 
 typedef struct WGPUBufferDescriptor {
   WGPULabel label;
@@ -691,12 +691,12 @@ typedef struct WGPUBlendDescriptor {
 } WGPUBlendDescriptor;
 
 typedef uint32_t WGPUColorWrite;
-#define WGPUColorWrite_RED 1
-#define WGPUColorWrite_GREEN 2
-#define WGPUColorWrite_BLUE 4
-#define WGPUColorWrite_ALPHA 8
-#define WGPUColorWrite_COLOR 7
-#define WGPUColorWrite_ALL 15
+#define WGPUColorWrite_RED (uint32_t)1
+#define WGPUColorWrite_GREEN (uint32_t)2
+#define WGPUColorWrite_BLUE (uint32_t)4
+#define WGPUColorWrite_ALPHA (uint32_t)8
+#define WGPUColorWrite_COLOR (uint32_t)7
+#define WGPUColorWrite_ALL (uint32_t)15
 
 typedef struct WGPUColorStateDescriptor {
   WGPUTextureFormat format;
@@ -791,11 +791,11 @@ typedef WGPUNonZeroU64 WGPUId_SwapChain_Dummy;
 typedef WGPUId_SwapChain_Dummy WGPUSwapChainId;
 
 typedef uint32_t WGPUTextureUsage;
-#define WGPUTextureUsage_COPY_SRC 1
-#define WGPUTextureUsage_COPY_DST 2
-#define WGPUTextureUsage_SAMPLED 4
-#define WGPUTextureUsage_STORAGE 8
-#define WGPUTextureUsage_OUTPUT_ATTACHMENT 16
+#define WGPUTextureUsage_COPY_SRC (uint32_t)1
+#define WGPUTextureUsage_COPY_DST (uint32_t)2
+#define WGPUTextureUsage_SAMPLED (uint32_t)4
+#define WGPUTextureUsage_STORAGE (uint32_t)8
+#define WGPUTextureUsage_OUTPUT_ATTACHMENT (uint32_t)16
 
 typedef struct WGPUSwapChainDescriptor {
   WGPUTextureUsage usage;
@@ -906,6 +906,7 @@ WGPUCLimits wgpu_adapter_limits(WGPUAdapterId adapter_id);
 WGPUDeviceId wgpu_adapter_request_device(WGPUAdapterId adapter_id,
                                          WGPUExtensions extensions,
                                          const WGPUCLimits *limits,
+                                         bool shader_validation,
                                          const char *trace_path);
 
 void wgpu_bind_group_destroy(WGPUBindGroupId bind_group_id);

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -26,6 +26,11 @@ typedef struct WGPUChainedStruct WGPUChainedStruct;
 #define WGPUBIND_BUFFER_ALIGNMENT 256
 
 /**
+ * Buffer to buffer copy offsets and sizes must be aligned to this number
+ */
+#define WGPUCOPY_BUFFER_ALIGNMENT 4
+
+/**
  * Buffer-Texture copies on command encoders have to have the `bytes_per_row`
  * aligned to this number.
  *
@@ -365,12 +370,25 @@ typedef WGPUId_Adapter_Dummy WGPUAdapterId;
 
 typedef uint64_t WGPUExtensions;
 /**
+ * Allow anisotropic filtering in samplers.
+ *
  * This is a native only extension. Support is planned to be added to webgpu,
  * but it is not yet implemented.
  *
  * https://github.com/gpuweb/gpuweb/issues/696
  */
 #define WGPUExtensions_ANISOTROPIC_FILTERING (uint64_t)65536
+/**
+ * Webgpu only allows the MAP_READ and MAP_WRITE buffer usage to be matched with
+ * COPY_DST and COPY_SRC respectively. This removes this requirement.
+ *
+ * This is only beneficial on systems that share memory between CPU and GPU. If enabled
+ * on a system that doesn't, this can severely hinder performance. Only use if you understand
+ * the consequences.
+ *
+ * This is a native only extension.
+ */
+#define WGPUExtensions_MAPPABLE_PRIMARY_BUFFERS (uint64_t)131072
 /**
  * Extensions which are part of the upstream webgpu standard
  */

--- a/src/device.rs
+++ b/src/device.rs
@@ -359,7 +359,7 @@ pub extern "C" fn wgpu_device_create_bind_group_layout(
     device_id: id::DeviceId,
     desc: &wgc::binding_model::BindGroupLayoutDescriptor,
 ) -> id::BindGroupLayoutId {
-    gfx_select!(device_id => GLOBAL.device_create_bind_group_layout(device_id, desc, PhantomData))
+    gfx_select!(device_id => GLOBAL.device_create_bind_group_layout(device_id, desc, PhantomData)).expect("Creation of pipeline layout failed")
 }
 
 #[no_mangle]
@@ -372,7 +372,7 @@ pub extern "C" fn wgpu_device_create_pipeline_layout(
     device_id: id::DeviceId,
     desc: &wgc::binding_model::PipelineLayoutDescriptor,
 ) -> id::PipelineLayoutId {
-    gfx_select!(device_id => GLOBAL.device_create_pipeline_layout(device_id, desc, PhantomData))
+    gfx_select!(device_id => GLOBAL.device_create_pipeline_layout(device_id, desc, PhantomData)).expect("Creation of pipeline layout failed")
 }
 
 #[no_mangle]
@@ -495,7 +495,7 @@ pub extern "C" fn wgpu_device_create_compute_pipeline(
     device_id: id::DeviceId,
     desc: &wgc::pipeline::ComputePipelineDescriptor,
 ) -> id::ComputePipelineId {
-    gfx_select!(device_id => GLOBAL.device_create_compute_pipeline(device_id, desc, PhantomData))
+    gfx_select!(device_id => GLOBAL.device_create_compute_pipeline(device_id, desc, PhantomData)).expect("Creation of compute pipeline failed")
 }
 
 #[no_mangle]

--- a/src/device.rs
+++ b/src/device.rs
@@ -484,7 +484,7 @@ pub extern "C" fn wgpu_device_create_render_pipeline(
     device_id: id::DeviceId,
     desc: &wgc::pipeline::RenderPipelineDescriptor,
 ) -> id::RenderPipelineId {
-    gfx_select!(device_id => GLOBAL.device_create_render_pipeline(device_id, desc, PhantomData))
+    gfx_select!(device_id => GLOBAL.device_create_render_pipeline(device_id, desc, PhantomData)).expect("Creation of render pipeline failed")
 }
 
 #[no_mangle]

--- a/src/device.rs
+++ b/src/device.rs
@@ -206,6 +206,7 @@ pub unsafe extern "C" fn wgpu_adapter_request_device(
     adapter_id: id::AdapterId,
     extensions: wgt::Extensions,
     limits: &CLimits,
+    shader_validation: bool,
     trace_path: *const std::os::raw::c_char,
 ) -> id::DeviceId {
     let desc = DeviceDescriptor {
@@ -214,6 +215,7 @@ pub unsafe extern "C" fn wgpu_adapter_request_device(
             max_bind_groups: limits.max_bind_groups,
             ..Limits::default()
         },
+        shader_validation,
     };
     let trace_cstr = if trace_path.is_null() {
         None


### PR DESCRIPTION
In order to build ffi/wgpu.h now, you need a more recent version of cbindgen, at least d652d29ae28f9b83bead8feca98cdd30752e63fa (see https://github.com/eqrion/cbindgen/issues/532).