### PR TITLE
Added X11 dependency to gfx-backend-vulkan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "raw-window-handle",
  "smallvec",
  "winapi",
+ "x11",
 ]
 
 [[package]]
@@ -456,6 +457,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "proc-macro2"
@@ -706,6 +713,7 @@ name = "wgpu-native"
 version = "0.6.0"
 dependencies = [
  "arrayvec",
+ "gfx-backend-vulkan",
  "lazy_static",
  "libc",
  "log",
@@ -753,4 +761,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "x11"
+version = "2.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ lazy_static = "1.1"
 parking_lot = "0.10"
 raw-window-handle = "0.3"
 libc = {version="0.2", features=[]}
+
+[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]
+gfx-backend-vulkan = { version = "0.5", features = ["x11"] }


### PR DESCRIPTION
Fix for #38. It's copied from wgpu-rs, however it wouldn't work with gfx-backend-vulkan version 0.6 so I let it at version 0.5 since that has worked for me locally.