### PR TITLE
Updated bindings for wgpu to properly expose Option<BufferSize>

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -13,6 +13,7 @@ typedef unsigned long long WGPUOption_BufferId;
 typedef unsigned long long WGPUOption_SamplerId;
 typedef unsigned long long WGPUOption_SurfaceId;
 typedef unsigned long long WGPUOption_TextureViewId;
+typedef unsigned long long WGPUOption_BufferSize;
 
 typedef struct WGPUChainedStruct WGPUChainedStruct;
 """
@@ -35,6 +36,7 @@ exclude = [
 	"Option_BufferId",
 	"Option_SamplerId",
 	"Option_SurfaceId",
+	"Option_BufferSize",
 	"Option_TextureViewId",
 	"Option_NonZeroU32",
 	"Option_NonZeroU64",

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1,4 +1,4 @@
-/* Generated with cbindgen:0.14.4 */
+/* Generated with cbindgen:0.14.6 */
 
 /* DO NOT MODIFY THIS MANUALLY! This file was generated using cbindgen.
  * To generate this file:
@@ -15,6 +15,7 @@ typedef unsigned long long WGPUOption_BufferId;
 typedef unsigned long long WGPUOption_SamplerId;
 typedef unsigned long long WGPUOption_SurfaceId;
 typedef unsigned long long WGPUOption_TextureViewId;
+typedef unsigned long long WGPUOption_BufferSize;
 
 typedef struct WGPUChainedStruct WGPUChainedStruct;
 
@@ -840,8 +841,6 @@ typedef enum WGPUVertexFormat {
 } WGPUVertexFormat;
 
 typedef struct WGPUComputePass WGPUComputePass;
-
-typedef struct WGPUOption_BufferSize WGPUOption_BufferSize;
 
 typedef struct WGPURenderBundleEncoder WGPURenderBundleEncoder;
 


### PR DESCRIPTION
`cbindgen.toml` was previously missing an exception for `Option<BufferSize>` so it was being exposed incorrectly. This PR should fix that.

Thanks to @kvark and @cwfitzgerald in #wgpu:matrix.org for helping me get this issue sorted out.