### PR TITLE
Remove `C` prefix from some type names

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -49,7 +49,6 @@ exclude = [
 	"wgpu_render_pass_finish",
 	"wgpu_compute_pass_finish",
 	"NonExhaustive",
-	"Limits"
 ]
 
 [export.rename]
@@ -60,7 +59,10 @@ exclude = [
 "SamplerDescriptor_Label" = "SamplerDescriptor"
 "BufferCopyViewC" = "BufferCopyView"
 "TextureCopyViewC" = "TextureCopyView"
+"CAdapterInfo" = "AdapterInfo"
 "CDeviceDescriptor" = "DeviceDescriptor"
+"CDeviceType" = "DeviceType"
+"CLimits" = "Limits"
 "RequestAdapterOptions_SurfaceId" = "RequestAdapterOptions"
 "Option_SamplerBorderColor" = "SamplerBorderColor"
 "Option_TextureViewDimension" = "TextureViewDimension"

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -53,7 +53,7 @@ int main(
         &(WGPUDeviceDescriptor) {
             .label = "",
             0,
-            (WGPUCLimits) {
+            (WGPULimits) {
                 .max_bind_groups = 1
             },
             NULL}

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -101,7 +101,7 @@ int main() {
         &(WGPUDeviceDescriptor) {
             .label = "",
             0,
-            (WGPUCLimits) {
+            (WGPULimits) {
                 .max_bind_groups = 1
             },
             NULL}

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -156,29 +156,29 @@ typedef enum WGPUBufferMapAsyncStatus {
   WGPUBufferMapAsyncStatus_ContextLost,
 } WGPUBufferMapAsyncStatus;
 
-enum WGPUCDeviceType {
+enum WGPUDeviceType {
   /**
    * Other.
    */
-  WGPUCDeviceType_Other = 0,
+  WGPUDeviceType_Other = 0,
   /**
    * Integrated GPU with shared CPU/GPU memory.
    */
-  WGPUCDeviceType_IntegratedGpu,
+  WGPUDeviceType_IntegratedGpu,
   /**
    * Discrete GPU with separate CPU/GPU memory.
    */
-  WGPUCDeviceType_DiscreteGpu,
+  WGPUDeviceType_DiscreteGpu,
   /**
    * Virtual / Hosted.
    */
-  WGPUCDeviceType_VirtualGpu,
+  WGPUDeviceType_VirtualGpu,
   /**
    * Cpu / Software Rendering.
    */
-  WGPUCDeviceType_Cpu,
+  WGPUDeviceType_Cpu,
 };
-typedef uint8_t WGPUCDeviceType;
+typedef uint8_t WGPUDeviceType;
 
 enum WGPUCompareFunction {
   WGPUCompareFunction_Undefined,
@@ -1722,14 +1722,14 @@ typedef uint64_t WGPUFeatures;
  */
 #define WGPUFeatures_ALL_NATIVE (uint64_t)18446744073709486080ULL
 
-typedef struct WGPUCLimits {
+typedef struct WGPULimits {
   uint32_t max_bind_groups;
-} WGPUCLimits;
+} WGPULimits;
 
 typedef struct WGPUDeviceDescriptor {
   WGPULabel label;
   WGPUFeatures features;
-  WGPUCLimits limits;
+  WGPULimits limits;
   const char *trace_path;
 } WGPUDeviceDescriptor;
 
@@ -2312,7 +2312,7 @@ typedef struct WGPUSwapChainDescriptor {
 
 typedef void (*WGPUBufferMapCallback)(WGPUBufferMapAsyncStatus status, uint8_t *userdata);
 
-typedef struct WGPUCAdapterInfo {
+typedef struct WGPUAdapterInfo {
   /**
    * Adapter name
    */
@@ -2332,12 +2332,12 @@ typedef struct WGPUCAdapterInfo {
   /**
    * Type of device
    */
-  WGPUCDeviceType device_type;
+  WGPUDeviceType device_type;
   /**
    * Backend used for device
    */
   WGPUBackend backend;
-} WGPUCAdapterInfo;
+} WGPUAdapterInfo;
 
 typedef void (*WGPULogCallback)(int level, const char *msg);
 
@@ -2498,13 +2498,13 @@ WGPUDeviceId wgpu_adapter_request_device(WGPUAdapterId adapter_id,
 
 WGPUFeatures wgpu_adapter_features(WGPUAdapterId adapter_id);
 
-WGPUCLimits wgpu_adapter_limits(WGPUAdapterId adapter_id);
+WGPULimits wgpu_adapter_limits(WGPUAdapterId adapter_id);
 
 void wgpu_adapter_destroy(WGPUAdapterId adapter_id);
 
 WGPUFeatures wgpu_device_features(WGPUDeviceId device_id);
 
-WGPUCLimits wgpu_device_limits(WGPUDeviceId device_id);
+WGPULimits wgpu_device_limits(WGPUDeviceId device_id);
 
 WGPUBufferId wgpu_device_create_buffer(WGPUDeviceId device_id, const WGPUBufferDescriptor *desc);
 
@@ -2644,7 +2644,7 @@ uint8_t *wgpu_buffer_get_mapped_range(WGPUBufferId buffer_id,
  * location. This function is unsafe as there is no guarantee that the
  * pointer is valid and big enough to hold the adapter name.
  */
-void wgpu_adapter_get_info(WGPUAdapterId adapter_id, WGPUCAdapterInfo *info);
+void wgpu_adapter_get_info(WGPUAdapterId adapter_id, WGPUAdapterInfo *info);
 
 void wgpu_set_log_callback(WGPULogCallback callback);
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -264,7 +264,7 @@ pub extern "C" fn wgpu_adapter_features(adapter_id: id::AdapterId) -> wgt::Featu
 #[no_mangle]
 pub extern "C" fn wgpu_adapter_limits(adapter_id: id::AdapterId) -> CLimits {
     gfx_select!(adapter_id => GLOBAL.adapter_limits(adapter_id))
-        .expect("Unable to get adapter limis")
+        .expect("Unable to get adapter limits")
         .into()
 }
 


### PR DESCRIPTION
wgpu-native users shouldn't need to  be aware whether they're working with a separate C version of a type, so we should avoid using a prefix.