### PR TITLE
Draft: Add support for shader module chain

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -26,7 +26,9 @@ style = "both"
 prefix = "WGPU"
 include = [
     "AnisotropicSamplerDescriptorExt",
-    "SamplerBorderColor"
+    "SamplerBorderColor",
+    "ShaderModuleSPIRVDescriptor",
+    "ShaderModuleWGSLDescriptor",
 ]
 exclude = [
 	"BufferUse",

--- a/examples/framework.c
+++ b/examples/framework.c
@@ -18,9 +18,17 @@ WGPUShaderModuleDescriptor read_file(const char *name) {
     fseek(file, 0, SEEK_SET);
     fread(bytes, 1, length, file);
     fclose(file);
-    return (WGPUShaderModuleDescriptor){
-        .bytes = (uint32_t*) bytes,
-        .length = length / 4,
+
+    WGPUShaderModuleSPIRVDescriptor *spirvDescriptor = malloc(sizeof(WGPUShaderModuleSPIRVDescriptor));
+    spirvDescriptor->chain = (WGPUChainedStruct) {
+        .next = NULL,
+        .s_type = WGPUSType_ShaderModuleSPIRVDescriptor
+    };
+    spirvDescriptor->code = (uint32_t *) bytes;
+    spirvDescriptor->code_size = length / 4;
+    return (WGPUShaderModuleDescriptor) {
+        .nextInChain = (const WGPUChainedStruct *) spirvDescriptor,
+        .label = NULL,
         .flags = WGPUShaderFlags_VALIDATION,
     };
 }

--- a/examples/framework.c
+++ b/examples/framework.c
@@ -27,7 +27,7 @@ WGPUShaderModuleDescriptor read_file(const char *name) {
     spirvDescriptor->code = (uint32_t *) bytes;
     spirvDescriptor->code_size = length / 4;
     return (WGPUShaderModuleDescriptor) {
-        .nextInChain = (const WGPUChainedStruct *) spirvDescriptor,
+        .next_in_chain = (const WGPUChainedStruct *) spirvDescriptor,
         .label = NULL,
         .flags = WGPUShaderFlags_VALIDATION,
     };

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -2081,11 +2081,21 @@ typedef uint32_t WGPUShaderFlags;
 #define WGPUShaderFlags_EXPERIMENTAL_TRANSLATION (uint32_t)2
 
 typedef struct WGPUShaderModuleDescriptor {
-  WGPULabel label;
-  const uint32_t *bytes;
-  uintptr_t length;
+    WGPUChainedStruct const * nextInChain;
+    char const * label;
   WGPUShaderFlags flags;
 } WGPUShaderModuleDescriptor;
+
+typedef struct WGPUShaderModuleSPIRVDescriptor {
+    WGPUChainedStruct chain;
+    uint32_t code_size;
+    const uint32_t *code;
+} WGPUShaderModuleSPIRVDescriptor;
+
+typedef struct WGPUShaderModuleWGSLDescriptor {
+    WGPUChainedStruct chain;
+    const char *source;
+} WGPUShaderModuleWGSLDescriptor;
 
 /**
  * Describes a [`CommandEncoder`].

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -2081,21 +2081,10 @@ typedef uint32_t WGPUShaderFlags;
 #define WGPUShaderFlags_EXPERIMENTAL_TRANSLATION (uint32_t)2
 
 typedef struct WGPUShaderModuleDescriptor {
-    WGPUChainedStruct const * nextInChain;
-    char const * label;
+  const struct WGPUChainedStruct *next_in_chain;
+  WGPULabel label;
   WGPUShaderFlags flags;
 } WGPUShaderModuleDescriptor;
-
-typedef struct WGPUShaderModuleSPIRVDescriptor {
-    WGPUChainedStruct chain;
-    uint32_t code_size;
-    const uint32_t *code;
-} WGPUShaderModuleSPIRVDescriptor;
-
-typedef struct WGPUShaderModuleWGSLDescriptor {
-    WGPUChainedStruct chain;
-    const char *source;
-} WGPUShaderModuleWGSLDescriptor;
 
 /**
  * Describes a [`CommandEncoder`].
@@ -2434,6 +2423,17 @@ typedef struct WGPUAnisotropicSamplerDescriptorExt {
   WGPUSType s_type;
   uint8_t anisotropic_clamp;
 } WGPUAnisotropicSamplerDescriptorExt;
+
+typedef struct WGPUShaderModuleSPIRVDescriptor {
+  struct WGPUChainedStruct chain;
+  uint32_t code_size;
+  const uint32_t *code;
+} WGPUShaderModuleSPIRVDescriptor;
+
+typedef struct WGPUShaderModuleWGSLDescriptor {
+  struct WGPUChainedStruct chain;
+  const char *source;
+} WGPUShaderModuleWGSLDescriptor;
 
 
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -9,6 +9,7 @@ use libc::c_char;
 use std::{
     borrow::Cow, ffi::CString, marker::PhantomData, num::NonZeroU32, num::NonZeroU64, ptr, slice,
 };
+use std::ffi::CStr;
 
 pub type RequestAdapterCallback =
     unsafe extern "C" fn(id: id::AdapterId, userdata: *mut std::ffi::c_void);
@@ -647,11 +648,23 @@ pub extern "C" fn wgpu_bind_group_destroy(bind_group_id: id::BindGroupId) {
 }
 
 #[repr(C)]
-pub struct ShaderModuleDescriptor {
+pub struct ShaderModuleDescriptor<'c> {
+    next_in_chain: Option<&'c ChainedStruct<'c>>,
     label: Label,
-    bytes: *const u32,
-    length: usize,
     flags: wgt::ShaderFlags,
+}
+
+#[repr(C)]
+pub struct ShaderModuleSPIRVDescriptor<'c> {
+    chain: ChainedStruct<'c>,
+    code_size: u32,
+    code: *const u32,
+}
+
+#[repr(C)]
+pub struct ShaderModuleWGSLDescriptor<'c> {
+    chain: ChainedStruct<'c>,
+    source: *const c_char
 }
 
 #[no_mangle]
@@ -659,8 +672,21 @@ pub extern "C" fn wgpu_device_create_shader_module(
     device_id: id::DeviceId,
     desc: &ShaderModuleDescriptor,
 ) -> id::ShaderModuleId {
-    let slice = unsafe { std::slice::from_raw_parts(desc.bytes, desc.length) };
-    let src = ShaderModuleSource::SpirV(Cow::Borrowed(slice));
+    let chain = desc.next_in_chain.expect("shader required");
+    let src = match &chain.s_type {
+        SType::ShaderModuleSPIRVDescriptor => {
+            let desc: &ShaderModuleSPIRVDescriptor = unsafe { std::mem::transmute(chain) };
+            let slice = unsafe { std::slice::from_raw_parts(desc.code, desc.code_size as usize) };
+            ShaderModuleSource::SpirV(Cow::Borrowed(slice))
+        }
+        SType::ShaderModuleWGSLDescriptor => {
+            let desc: &ShaderModuleWGSLDescriptor = unsafe { std::mem::transmute(chain) };
+            let c_str: &CStr = unsafe { CStr::from_ptr(desc.source) };
+            let str_slice: &str = c_str.to_str().expect("not a valid utf-8 string");
+            ShaderModuleSource::Wgsl(Cow::Borrowed(str_slice))
+        }
+        _ => panic!("invalid type"),
+    };
     let desc = wgc::pipeline::ShaderModuleDescriptor {
         label: OwnedLabel::new(desc.label).into_cow(),
         flags: desc.flags,

--- a/src/device.rs
+++ b/src/device.rs
@@ -673,7 +673,7 @@ pub extern "C" fn wgpu_device_create_shader_module(
     desc: &ShaderModuleDescriptor,
 ) -> id::ShaderModuleId {
     let chain = desc.next_in_chain.expect("shader required");
-    let src = match &chain.s_type {
+    let src = match chain.s_type {
         SType::ShaderModuleSPIRVDescriptor => {
             let desc: &ShaderModuleSPIRVDescriptor = unsafe { std::mem::transmute(chain) };
             let slice = unsafe { std::slice::from_raw_parts(desc.code, desc.code_size as usize) };


### PR DESCRIPTION
Initial work to fix https://github.com/gfx-rs/wgpu-native/issues/69

- [x] fix bindgen (it currently adds struct/enum everywhere)
- [x] bindgen currently ignores unused structs (ShaderModuleSPIRVDescriptor, ShaderModuleWGSLDescriptor)
- [ ] verify use of unsafe

I've also left `WGPUShaderFlags flags;` in for the time being.

Further work, based on things I noticed.
- why the case missmatch? (why e.g. codeSize vs code_size)
- update examples that use spirv to use wgsl instead
