### PR TITLE
Package DLL import lib on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ FFI_DIR:=ffi
 BUILD_DIR:=build
 CLEAN_FFI_DIR:=
 CREATE_BUILD_DIR:=
+LIB_NAME:=wgpu_native
 
 WILDCARD_SOURCE:=$(wildcard src/*.rs)
 
@@ -32,10 +33,8 @@ endif
 ifeq ($(OS),Windows_NT)
 	LIB_EXTENSION=dll
 	OS_NAME=windows
-	ZIP_TOOL=7z
 else
 	UNAME_S:=$(shell uname -s)
-	ZIP_TOOL=zip
 	ifeq ($(UNAME_S),Linux)
 		LIB_EXTENSION=so
 		OS_NAME=linux
@@ -60,10 +59,10 @@ package: lib-native lib-native-release
 	for RELEASE in debug release; do \
 		ARCHIVE=wgpu-$$RELEASE-$(OS_NAME)-$(GIT_TAG).zip; \
 		rm -f dist/$$ARCHIVE; \
-		if [ $(ZIP_TOOL) = zip ]; then \
-			zip -j dist/$$ARCHIVE target/$$RELEASE/libwgpu_*.$(LIB_EXTENSION) ffi/*.h dist/commit-sha; \
+		if [ $(OS_NAME) = windows ]; then \
+			7z a -tzip dist/$$ARCHIVE ./target/$$RELEASE/$(LIB_NAME).$(LIB_EXTENSION) ./target/$$RELEASE/$(LIB_NAME).$(LIB_EXTENSION).lib ./ffi/*.h ./dist/commit-sha; \
 		else \
-			7z a -tzip dist/$$ARCHIVE ./target/$$RELEASE/wgpu_*.$(LIB_EXTENSION) ./ffi/*.h ./dist/commit-sha; \
+			zip -j dist/$$ARCHIVE target/$$RELEASE/lib$(LIB_NAME).$(LIB_EXTENSION) ffi/*.h dist/commit-sha; \
 		fi; \
 	done
 


### PR DESCRIPTION
Fixes #57.

Note: rustc/cargo emits `$lib_name.dll.lib` import libraries, which requires some tweaking by consumers, since the default expected name is `$lib_name.lib` (see [/IMPLIB documentation](https://docs.microsoft.com/en-us/cpp/build/reference/implib-name-import-library?view=msvc-160)). While we could rename it during packaging, I've decided not to, because:
 - it would cause a conflict if static libraries are put into the package too,
 - CMake similarly outputs `$libnamedll.lib` import libraries when building DLLs,
 - and once `wgpu-native` gets proper CMake integration, /IMPLIB can be overwritten easily (see [IMPORTED_IMPLIB documentation](https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_IMPLIB.html)).

I've also removed the wildcards, according to our discussion on Discord (`wgpu-remote` has been removed, only `wgpu-native` is built now).