### PR TITLE
Migrate pipeline creation to align with webgpu-headers

### DIFF
--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -141,52 +141,43 @@ int main() {
                 .bind_group_layouts_length = BIND_GROUP_LAYOUTS_LENGTH,
             });
 
-    WGPURenderPipelineId render_pipeline =
-        wgpu_device_create_render_pipeline(device,
-            &(WGPURenderPipelineDescriptor){
-                .layout = pipeline_layout,
-                .vertex = (WGPUVertexState){
-                    .stage = (WGPUProgrammableStageDescriptor) {
-                        .entry_point = "main",
-                        .module = vertex_shader
-                    },
-                    .buffers = NULL,
-                    .buffer_count = 0
-                },
-                .primitive = (WGPUPrimitiveState) {
-                    .front_face = WGPUFrontFace_Ccw,
-                    .cull_mode = WGPUCullMode_None,
-                    .polygon_mode = WGPUPolygonMode_Fill,
-                    .topology = WGPUPrimitiveTopology_TriangleList,
-                    .strip_index_format = WGPUIndexFormat_Undefined
-                    },
-                .depth_stencil = NULL,
-                .multisample = (WGPUMultisampleState) {
-                    .alpha_to_coverage_enabled = false,
-                    .count = 1,
-                    .mask = -1
-                    },
-                .fragment = &(WGPUFragmentState) {
-                    .stage = (WGPUProgrammableStageDescriptor) {
+    WGPURenderPipelineId render_pipeline = wgpuDeviceCreateRenderPipeline(
+            device,
+            &(WGPURenderPipelineDescriptor) {
+                    .layout = pipeline_layout,
+                    .vertexStage = (WGPUProgrammableStageDescriptor) {
+                            .module = vertex_shader,
                             .entry_point = "main",
-                            .module = fragment_shader
                     },
-                    .targets = &(WGPUColorTargetState) {
-                        .alpha_blend = (WGPUBlendState) {
-                                .src_factor = WGPUBlendFactor_One,
-                                .dst_factor = WGPUBlendFactor_Zero,
-                                .operation = WGPUBlendOperation_Add,
-                        },
-                        .color_blend = (WGPUBlendState) {
-                                .src_factor = WGPUBlendFactor_One,
-                                .dst_factor = WGPUBlendFactor_Zero,
-                                .operation = WGPUBlendOperation_Add,
+                    .fragmentStage = &(WGPUProgrammableStageDescriptor) {
+                            .module = fragment_shader,
+                            .entry_point = "main",
+                    },
+                    .vertexState = (WGPUVertexStateDescriptor) {
+                            .indexFormat = WGPUIndexFormat_Undefined,
+                    },
+                    .primitiveTopology = WGPUPrimitiveTopology_TriangleList,
+                    .rasterizationState = (WGPURasterizationStateDescriptor) {
+                            .frontFace = WGPUFrontFace_Ccw,
+                            .cullMode = WGPUCullMode_None,
+                    },
+                    .sampleCount = 1,
+                    .depthStencilState = NULL,
+                    .colorStateCount = 1,
+                    .colorStates = &(WGPUColorStateDescriptor) {
+                            .format = WGPUTextureFormat_Bgra8Unorm,
+                            .alphaBlend = (WGPUBlendDescriptor) {
+                                    .srcFactor = WGPUBlendFactor_One,
+                                    .dstFactor = WGPUBlendFactor_Zero,
+                                    .operation = WGPUBlendOperation_Add,
                             },
-                        .format = WGPUTextureFormat_Bgra8Unorm,
-                        .write_mask = WGPUColorWrite_ALL
-                    },
-                    .target_count = 1
-                }
+                            .colorBlend = (WGPUBlendDescriptor) {
+                                    .srcFactor = WGPUBlendFactor_One,
+                                    .dstFactor = WGPUBlendFactor_Zero,
+                                    .operation = WGPUBlendOperation_Add,
+                            },
+                            .writeMask = WGPUColorWrite_ALL,
+                    }
             });
 
     int prev_width = 0;

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -143,93 +143,31 @@ enum WGPUBindingType {
 };
 typedef uint32_t WGPUBindingType;
 
-/**
- * Alpha blend factor.
- *
- * Alpha blending is very complicated: see the OpenGL or Vulkan spec for more information.
- */
-typedef enum WGPUBlendFactor {
-  /**
-   * 0.0
-   */
+enum WGPUBlendFactor {
   WGPUBlendFactor_Zero = 0,
-  /**
-   * 1.0
-   */
   WGPUBlendFactor_One = 1,
-  /**
-   * S.color
-   */
   WGPUBlendFactor_SrcColor = 2,
-  /**
-   * 1.0 - S.color
-   */
   WGPUBlendFactor_OneMinusSrcColor = 3,
-  /**
-   * S.alpha
-   */
   WGPUBlendFactor_SrcAlpha = 4,
-  /**
-   * 1.0 - S.alpha
-   */
   WGPUBlendFactor_OneMinusSrcAlpha = 5,
-  /**
-   * D.color
-   */
   WGPUBlendFactor_DstColor = 6,
-  /**
-   * 1.0 - D.color
-   */
   WGPUBlendFactor_OneMinusDstColor = 7,
-  /**
-   * D.alpha
-   */
   WGPUBlendFactor_DstAlpha = 8,
-  /**
-   * 1.0 - D.alpha
-   */
   WGPUBlendFactor_OneMinusDstAlpha = 9,
-  /**
-   * min(S.alpha, 1.0 - D.alpha)
-   */
   WGPUBlendFactor_SrcAlphaSaturated = 10,
-  /**
-   * Constant
-   */
   WGPUBlendFactor_BlendColor = 11,
-  /**
-   * 1.0 - Constant
-   */
   WGPUBlendFactor_OneMinusBlendColor = 12,
-} WGPUBlendFactor;
+};
+typedef uint32_t WGPUBlendFactor;
 
-/**
- * Alpha blend operation.
- *
- * Alpha blending is very complicated: see the OpenGL or Vulkan spec for more information.
- */
-typedef enum WGPUBlendOperation {
-  /**
-   * Src + Dst
-   */
+enum WGPUBlendOperation {
   WGPUBlendOperation_Add = 0,
-  /**
-   * Src - Dst
-   */
   WGPUBlendOperation_Subtract = 1,
-  /**
-   * Dst - Src
-   */
   WGPUBlendOperation_ReverseSubtract = 2,
-  /**
-   * min(Src, Dst)
-   */
   WGPUBlendOperation_Min = 3,
-  /**
-   * max(Src, Dst)
-   */
   WGPUBlendOperation_Max = 4,
-} WGPUBlendOperation;
+};
+typedef uint32_t WGPUBlendOperation;
 
 typedef enum WGPUBufferMapAsyncStatus {
   WGPUBufferMapAsyncStatus_Success,
@@ -275,23 +213,12 @@ enum WGPUCompareFunction {
 };
 typedef uint32_t WGPUCompareFunction;
 
-/**
- * Type of faces to be culled.
- */
-typedef enum WGPUCullMode {
-  /**
-   * No faces should be culled
-   */
+enum WGPUCullMode {
   WGPUCullMode_None = 0,
-  /**
-   * Front faces should be culled
-   */
   WGPUCullMode_Front = 1,
-  /**
-   * Back faces should be culled
-   */
   WGPUCullMode_Back = 2,
-} WGPUCullMode;
+};
+typedef uint32_t WGPUCullMode;
 
 /**
  * Texel mixing mode when sampling between texels.
@@ -372,24 +299,6 @@ typedef enum WGPULogLevel {
   WGPULogLevel_Debug = 4,
   WGPULogLevel_Trace = 5,
 } WGPULogLevel;
-
-/**
- * Type of drawing mode for polygons
- */
-typedef enum WGPUPolygonMode {
-  /**
-   * Polygons are filled
-   */
-  WGPUPolygonMode_Fill = 0,
-  /**
-   * Polygons are drawn as line segments
-   */
-  WGPUPolygonMode_Line = 1,
-  /**
-   * Polygons are drawn as points
-   */
-  WGPUPolygonMode_Point = 2,
-} WGPUPolygonMode;
 
 /**
  * Power Preference when choosing a physical adapter.
@@ -2307,194 +2216,59 @@ typedef struct WGPUProgrammableStageDescriptor {
   WGPULabel entry_point;
 } WGPUProgrammableStageDescriptor;
 
-/**
- * Integral type used for binding locations in shaders.
- */
-typedef uint32_t WGPUShaderLocation;
-
-/**
- * Vertex inputs (attributes) to shaders.
- *
- * Arrays of these can be made with the [`vertex_attr_array`] macro. Vertex attributes are assumed to be tightly packed.
- */
-typedef struct WGPUVertexAttribute {
-  /**
-   * Format of the input
-   */
+typedef struct WGPUVertexAttributeDescriptor {
   enum WGPUVertexFormat format;
-  /**
-   * Byte offset of the start of the input
-   */
-  WGPUBufferAddress offset;
-  /**
-   * Location for this input. Must match the location in the shader.
-   */
-  WGPUShaderLocation shader_location;
-} WGPUVertexAttribute;
+  uint64_t offset;
+  uint32_t shaderLocation;
+} WGPUVertexAttributeDescriptor;
 
-typedef struct WGPUVertexBufferLayout {
-  WGPUBufferAddress array_stride;
-  enum WGPUInputStepMode step_mode;
-  const struct WGPUVertexAttribute *attributes;
-  uintptr_t attributes_count;
-} WGPUVertexBufferLayout;
+typedef struct WGPUVertexBufferLayoutDescriptor {
+  uint64_t arrayStride;
+  enum WGPUInputStepMode stepMode;
+  uint32_t attributeCount;
+  const struct WGPUVertexAttributeDescriptor *attributes;
+} WGPUVertexBufferLayoutDescriptor;
 
-typedef struct WGPUVertexState {
-  struct WGPUProgrammableStageDescriptor stage;
-  const struct WGPUVertexBufferLayout *buffers;
-  uintptr_t buffer_count;
-} WGPUVertexState;
+typedef struct WGPUVertexStateDescriptor {
+  const struct WGPUChainedStruct *nextInChain;
+  WGPUIndexFormat indexFormat;
+  uint32_t vertexBufferCount;
+  const struct WGPUVertexBufferLayoutDescriptor *vertexBuffers;
+} WGPUVertexStateDescriptor;
 
-typedef struct WGPUPrimitiveState {
-  enum WGPUPrimitiveTopology topology;
-  WGPUIndexFormat strip_index_format;
-  enum WGPUFrontFace front_face;
-  enum WGPUCullMode cull_mode;
-  enum WGPUPolygonMode polygon_mode;
-} WGPUPrimitiveState;
+typedef struct WGPURasterizationStateDescriptor {
+  const struct WGPUChainedStruct *nextInChain;
+  enum WGPUFrontFace frontFace;
+  WGPUCullMode cullMode;
+  int32_t depthBias;
+  float depthBiasSlopeScale;
+  float depthBiasClamp;
+  bool clampDepth;
+} WGPURasterizationStateDescriptor;
 
-/**
- * Describes stencil state in a render pipeline.
- *
- * If you are not using stencil state, set this to [`StencilFaceState::IGNORE`].
- */
-typedef struct WGPUStencilFaceState {
-  /**
-   * Comparison function that determines if the fail_op or pass_op is used on the stencil buffer.
-   */
+typedef struct WGPUStencilStateFaceDescriptor {
   WGPUCompareFunction compare;
-  /**
-   * Operation that is preformed when stencil test fails.
-   */
-  enum WGPUStencilOperation fail_op;
-  /**
-   * Operation that is performed when depth test fails but stencil test succeeds.
-   */
-  enum WGPUStencilOperation depth_fail_op;
-  /**
-   * Operation that is performed when stencil test success.
-   */
-  enum WGPUStencilOperation pass_op;
-} WGPUStencilFaceState;
+  enum WGPUStencilOperation failOp;
+  enum WGPUStencilOperation depthFailOp;
+  enum WGPUStencilOperation passOp;
+} WGPUStencilStateFaceDescriptor;
 
-/**
- * State of the stencil operation (fixed-pipeline stage).
- */
-typedef struct WGPUStencilState {
-  /**
-   * Front face mode.
-   */
-  struct WGPUStencilFaceState front;
-  /**
-   * Back face mode.
-   */
-  struct WGPUStencilFaceState back;
-  /**
-   * Stencil values are AND'd with this mask when reading and writing from the stencil buffer. Only low 8 bits are used.
-   */
-  uint32_t read_mask;
-  /**
-   * Stencil values are AND'd with this mask when writing to the stencil buffer. Only low 8 bits are used.
-   */
-  uint32_t write_mask;
-} WGPUStencilState;
-
-/**
- * Describes the biasing setting for the depth target.
- */
-typedef struct WGPUDepthBiasState {
-  /**
-   * Constant depth biasing factor, in basic units of the depth format.
-   */
-  int32_t constant;
-  /**
-   * Slope depth biasing factor.
-   */
-  float slope_scale;
-  /**
-   * Depth bias clamp value (absolute).
-   */
-  float clamp;
-} WGPUDepthBiasState;
-
-/**
- * Describes the depth/stencil state in a render pipeline.
- */
-typedef struct WGPUDepthStencilState {
-  /**
-   * Format of the depth/stencil buffer, must be special depth format. Must match the the format
-   * of the depth/stencil attachment in [`CommandEncoder::begin_render_pass`].
-   */
+typedef struct WGPUDepthStencilStateDescriptor {
+  const struct WGPUChainedStruct *nextInChain;
   enum WGPUTextureFormat format;
-  /**
-   * If disabled, depth will not be written to.
-   */
-  bool depth_write_enabled;
-  /**
-   * Comparison function used to compare depth values in the depth test.
-   */
-  WGPUCompareFunction depth_compare;
-  /**
-   * Stencil state.
-   */
-  struct WGPUStencilState stencil;
-  /**
-   * Depth bias state.
-   */
-  struct WGPUDepthBiasState bias;
-  /**
-   * If enabled polygon depth is clamped to 0-1 range instead of being clipped.
-   *
-   * Requires `Features::DEPTH_CLAMPING` enabled.
-   */
-  bool clamp_depth;
-} WGPUDepthStencilState;
+  bool depthWriteEnabled;
+  WGPUCompareFunction depthCompare;
+  struct WGPUStencilStateFaceDescriptor stencilFront;
+  struct WGPUStencilStateFaceDescriptor stencilBack;
+  uint32_t stencilReadMask;
+  uint32_t stencilWriteMask;
+} WGPUDepthStencilStateDescriptor;
 
-/**
- * Describes the multi-sampling state of a render pipeline.
- */
-typedef struct WGPUMultisampleState {
-  /**
-   * The number of samples calculated per pixel (for MSAA). For non-multisampled textures,
-   * this should be `1`
-   */
-  uint32_t count;
-  /**
-   * Bitmask that restricts the samples of a pixel modified by this pipeline. All samples
-   * can be enabled using the value `!0`
-   */
-  uint64_t mask;
-  /**
-   * When enabled, produces another sample mask per pixel based on the alpha output value, that
-   * is ANDed with the sample_mask and the primitive coverage to restrict the set of samples
-   * affected by a primitive.
-   *
-   * The implicit mask produced for alpha of zero is guaranteed to be zero, and for alpha of one
-   * is guaranteed to be all 1-s.
-   */
-  bool alpha_to_coverage_enabled;
-} WGPUMultisampleState;
-
-/**
- * Describes the blend state of a pipeline.
- *
- * Alpha blending is very complicated: see the OpenGL or Vulkan spec for more information.
- */
-typedef struct WGPUBlendState {
-  /**
-   * Multiplier for the source, which is produced by the fragment shader.
-   */
-  enum WGPUBlendFactor src_factor;
-  /**
-   * Multiplier for the destination, which is stored in the target.
-   */
-  enum WGPUBlendFactor dst_factor;
-  /**
-   * The binary operation applied to the source and destination,
-   * multiplied by their respective factors.
-   */
-  enum WGPUBlendOperation operation;
-} WGPUBlendState;
+typedef struct WGPUBlendDescriptor {
+  WGPUBlendOperation operation;
+  WGPUBlendFactor srcFactor;
+  WGPUBlendFactor dstFactor;
+} WGPUBlendDescriptor;
 
 /**
  * Color write mask. Disabled color channels will not be written to.
@@ -2525,43 +2299,29 @@ typedef uint32_t WGPUColorWrite;
  */
 #define WGPUColorWrite_ALL (uint32_t)15
 
-/**
- * Describes the color state of a render pipeline.
- */
-typedef struct WGPUColorTargetState {
-  /**
-   * The [`TextureFormat`] of the image that this pipeline will render to. Must match the the format
-   * of the corresponding color attachment in [`CommandEncoder::begin_render_pass`].
-   */
+typedef struct WGPUColorStateDescriptor {
+  const struct WGPUChainedStruct *nextInChain;
   enum WGPUTextureFormat format;
-  /**
-   * The alpha blending that is used for this pipeline.
-   */
-  struct WGPUBlendState alpha_blend;
-  /**
-   * The color blending that is used for this pipeline.
-   */
-  struct WGPUBlendState color_blend;
-  /**
-   * Mask which enables/disables writes to different color/alpha channel.
-   */
-  WGPUColorWrite write_mask;
-} WGPUColorTargetState;
-
-typedef struct WGPUFragmentState {
-  struct WGPUProgrammableStageDescriptor stage;
-  const struct WGPUColorTargetState *targets;
-  uintptr_t target_count;
-} WGPUFragmentState;
+  struct WGPUBlendDescriptor alphaBlend;
+  struct WGPUBlendDescriptor colorBlend;
+  WGPUColorWrite writeMask;
+} WGPUColorStateDescriptor;
 
 typedef struct WGPURenderPipelineDescriptor {
+  const struct WGPUChainedStruct *nextInChain;
   WGPULabel label;
   WGPUOption_PipelineLayoutId layout;
-  struct WGPUVertexState vertex;
-  struct WGPUPrimitiveState primitive;
-  const struct WGPUDepthStencilState *depth_stencil;
-  struct WGPUMultisampleState multisample;
-  const struct WGPUFragmentState *fragment;
+  struct WGPUProgrammableStageDescriptor vertexStage;
+  const struct WGPUProgrammableStageDescriptor *fragmentStage;
+  struct WGPUVertexStateDescriptor vertexState;
+  enum WGPUPrimitiveTopology primitiveTopology;
+  struct WGPURasterizationStateDescriptor rasterizationState;
+  uint32_t sampleCount;
+  const struct WGPUDepthStencilStateDescriptor *depthStencilState;
+  uint32_t colorStateCount;
+  const struct WGPUColorStateDescriptor *colorStates;
+  uint32_t sampleMask;
+  bool alphaToCoverageEnabled;
 } WGPURenderPipelineDescriptor;
 
 typedef uint64_t WGPUId_ComputePipeline_Dummy;
@@ -2909,8 +2669,8 @@ void wgpu_queue_submit(WGPUQueueId queue_id,
                        const WGPUCommandBufferId *command_buffers,
                        uintptr_t command_buffers_length);
 
-WGPURenderPipelineId wgpu_device_create_render_pipeline(WGPUDeviceId device_id,
-                                                        const struct WGPURenderPipelineDescriptor *desc_base);
+WGPURenderPipelineId wgpuDeviceCreateRenderPipeline(WGPUDeviceId device,
+                                                    const struct WGPURenderPipelineDescriptor *descriptor);
 
 void wgpu_render_pipeline_destroy(WGPURenderPipelineId render_pipeline_id);
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -143,31 +143,93 @@ enum WGPUBindingType {
 };
 typedef uint32_t WGPUBindingType;
 
-enum WGPUBlendFactor {
+/**
+ * Alpha blend factor.
+ *
+ * Alpha blending is very complicated: see the OpenGL or Vulkan spec for more information.
+ */
+typedef enum WGPUBlendFactor {
+  /**
+   * 0.0
+   */
   WGPUBlendFactor_Zero = 0,
+  /**
+   * 1.0
+   */
   WGPUBlendFactor_One = 1,
+  /**
+   * S.color
+   */
   WGPUBlendFactor_SrcColor = 2,
+  /**
+   * 1.0 - S.color
+   */
   WGPUBlendFactor_OneMinusSrcColor = 3,
+  /**
+   * S.alpha
+   */
   WGPUBlendFactor_SrcAlpha = 4,
+  /**
+   * 1.0 - S.alpha
+   */
   WGPUBlendFactor_OneMinusSrcAlpha = 5,
+  /**
+   * D.color
+   */
   WGPUBlendFactor_DstColor = 6,
+  /**
+   * 1.0 - D.color
+   */
   WGPUBlendFactor_OneMinusDstColor = 7,
+  /**
+   * D.alpha
+   */
   WGPUBlendFactor_DstAlpha = 8,
+  /**
+   * 1.0 - D.alpha
+   */
   WGPUBlendFactor_OneMinusDstAlpha = 9,
+  /**
+   * min(S.alpha, 1.0 - D.alpha)
+   */
   WGPUBlendFactor_SrcAlphaSaturated = 10,
+  /**
+   * Constant
+   */
   WGPUBlendFactor_BlendColor = 11,
+  /**
+   * 1.0 - Constant
+   */
   WGPUBlendFactor_OneMinusBlendColor = 12,
-};
-typedef uint32_t WGPUBlendFactor;
+} WGPUBlendFactor;
 
-enum WGPUBlendOperation {
+/**
+ * Alpha blend operation.
+ *
+ * Alpha blending is very complicated: see the OpenGL or Vulkan spec for more information.
+ */
+typedef enum WGPUBlendOperation {
+  /**
+   * Src + Dst
+   */
   WGPUBlendOperation_Add = 0,
+  /**
+   * Src - Dst
+   */
   WGPUBlendOperation_Subtract = 1,
+  /**
+   * Dst - Src
+   */
   WGPUBlendOperation_ReverseSubtract = 2,
+  /**
+   * min(Src, Dst)
+   */
   WGPUBlendOperation_Min = 3,
+  /**
+   * max(Src, Dst)
+   */
   WGPUBlendOperation_Max = 4,
-};
-typedef uint32_t WGPUBlendOperation;
+} WGPUBlendOperation;
 
 typedef enum WGPUBufferMapAsyncStatus {
   WGPUBufferMapAsyncStatus_Success,
@@ -2265,9 +2327,9 @@ typedef struct WGPUDepthStencilStateDescriptor {
 } WGPUDepthStencilStateDescriptor;
 
 typedef struct WGPUBlendDescriptor {
-  WGPUBlendOperation operation;
-  WGPUBlendFactor srcFactor;
-  WGPUBlendFactor dstFactor;
+  enum WGPUBlendOperation operation;
+  enum WGPUBlendFactor srcFactor;
+  enum WGPUBlendFactor dstFactor;
 } WGPUBlendDescriptor;
 
 /**

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -363,6 +363,24 @@ typedef enum WGPULogLevel {
 } WGPULogLevel;
 
 /**
+ * Type of drawing mode for polygons
+ */
+typedef enum WGPUPolygonMode {
+  /**
+   * Polygons are filled
+   */
+  WGPUPolygonMode_Fill = 0,
+  /**
+   * Polygons are drawn as line segments
+   */
+  WGPUPolygonMode_Line = 1,
+  /**
+   * Polygons are drawn as points
+   */
+  WGPUPolygonMode_Point = 2,
+} WGPUPolygonMode;
+
+/**
  * Power Preference when choosing a physical adapter.
  */
 typedef enum WGPUPowerPreference {
@@ -2306,6 +2324,7 @@ typedef struct WGPURasterizationStateDescriptor {
   float depthBiasSlopeScale;
   float depthBiasClamp;
   bool clampDepth;
+  enum WGPUPolygonMode polygonMode;
 } WGPURasterizationStateDescriptor;
 
 typedef struct WGPUStencilStateFaceDescriptor {

--- a/src/device.rs
+++ b/src/device.rs
@@ -834,110 +834,287 @@ impl<'a> ProgrammableStageDescriptor {
     }
 }
 
-#[repr(C)]
-pub struct VertexBufferLayout {
-    pub array_stride: wgt::BufferAddress,
-    pub step_mode: wgt::InputStepMode,
-    pub attributes: *const wgt::VertexAttribute,
-    pub attributes_count: usize,
+#[repr(u32)]
+pub enum BlendOperation {
+    Add = 0,
+    Subtract = 1,
+    ReverseSubtract = 2,
+    Min = 3,
+    Max = 4,
 }
 
-impl VertexBufferLayout {
+impl BlendOperation {
+    fn to_wgpu(&self) -> wgt::BlendOperation {
+        match self {
+            BlendOperation::Add => wgt::BlendOperation::Add,
+            BlendOperation::Subtract => wgt::BlendOperation::Subtract,
+            BlendOperation::ReverseSubtract => wgt::BlendOperation::ReverseSubtract,
+            BlendOperation::Min => wgt::BlendOperation::Min,
+            BlendOperation::Max => wgt::BlendOperation::Max,
+        }
+    }
+}
+
+#[repr(u32)]
+pub enum BlendFactor {
+    Zero = 0,
+    One = 1,
+    SrcColor = 2,
+    OneMinusSrcColor = 3,
+    SrcAlpha = 4,
+    OneMinusSrcAlpha = 5,
+    DstColor = 6,
+    OneMinusDstColor = 7,
+    DstAlpha = 8,
+    OneMinusDstAlpha = 9,
+    SrcAlphaSaturated = 10,
+    BlendColor = 11,
+    OneMinusBlendColor = 12,
+}
+
+impl BlendFactor {
+    fn to_wgpu(&self) -> wgt::BlendFactor {
+        match self {
+            BlendFactor::Zero => wgt::BlendFactor::Zero,
+            BlendFactor::One => wgt::BlendFactor::One,
+            BlendFactor::SrcColor => wgt::BlendFactor::SrcColor,
+            BlendFactor::OneMinusSrcColor => wgt::BlendFactor::OneMinusSrcColor,
+            BlendFactor::SrcAlpha => wgt::BlendFactor::SrcAlpha,
+            BlendFactor::OneMinusSrcAlpha => wgt::BlendFactor::OneMinusSrcAlpha,
+            BlendFactor::DstColor => wgt::BlendFactor::DstColor,
+            BlendFactor::OneMinusDstColor => wgt::BlendFactor::OneMinusDstColor,
+            BlendFactor::DstAlpha => wgt::BlendFactor::DstAlpha,
+            BlendFactor::OneMinusDstAlpha => wgt::BlendFactor::OneMinusDstAlpha,
+            BlendFactor::SrcAlphaSaturated => wgt::BlendFactor::SrcAlphaSaturated,
+            BlendFactor::BlendColor => wgt::BlendFactor::BlendColor,
+            BlendFactor::OneMinusBlendColor => wgt::BlendFactor::OneMinusBlendColor,
+        }
+    }
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct BlendDescriptor {
+    pub operation: BlendOperation,
+    pub srcFactor: BlendFactor,
+    pub dstFactor: BlendFactor,
+}
+
+impl BlendDescriptor {
+    fn to_wgpu(&self) -> wgt::BlendState {
+        wgt::BlendState {
+            src_factor: self.srcFactor.to_wgpu(),
+            dst_factor: self.dstFactor.to_wgpu(),
+            operation: self.operation.to_wgpu(),
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+pub struct ColorStateDescriptor<'c> {
+    pub nextInChain: Option<&'c ChainedStruct<'c>>,
+    pub format: wgt::TextureFormat,
+    pub alphaBlend: BlendDescriptor,
+    pub colorBlend: BlendDescriptor,
+    pub writeMask: wgt::ColorWrite,
+}
+
+impl ColorStateDescriptor<'_> {
+    fn to_wgpu(&self) -> wgt::ColorTargetState {
+        wgt::ColorTargetState {
+            format: self.format,
+            alpha_blend: self.alphaBlend.to_wgpu(),
+            color_blend: self.colorBlend.to_wgpu(),
+            write_mask: self.writeMask,
+
+        }
+    }
+}
+
+#[repr(u32)]
+pub enum CullMode {
+    None = 0,
+    Front = 1,
+    Back = 2,
+}
+
+impl CullMode {
+    fn to_wgpu(&self) -> wgt::CullMode {
+        match self {
+            CullMode::None => wgt::CullMode::None,
+            CullMode::Front => wgt::CullMode::Front,
+            CullMode::Back => wgt::CullMode::Back,
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+pub struct VertexAttributeDescriptor {
+    pub format: wgt::VertexFormat,
+    pub offset: u64,
+    pub shaderLocation: u32,
+}
+
+impl VertexAttributeDescriptor {
+    fn to_wgpu(&self) -> wgt::VertexAttribute {
+        wgt::VertexAttribute {
+            format: self.format,
+            offset: self.offset,
+            shader_location: self.shaderLocation,
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+pub struct VertexBufferLayoutDescriptor {
+    pub arrayStride: u64,
+    pub stepMode: wgt::InputStepMode,
+    pub attributeCount: u32,
+    pub attributes: *const VertexAttributeDescriptor,
+}
+
+impl VertexBufferLayoutDescriptor {
     unsafe fn to_wgpu(&self) -> wgc::pipeline::VertexBufferLayout {
         wgc::pipeline::VertexBufferLayout {
-            array_stride: self.array_stride,
-            step_mode: self.step_mode,
-            attributes: Cow::Borrowed(make_slice(
-                self.attributes,
-                self.attributes_count,
-            )),
+            array_stride: self.arrayStride,
+            step_mode: self.stepMode,
+            attributes: Cow::Owned(make_slice(self.attributes, self.attributeCount as usize).iter().map(|x| x.to_wgpu()).collect()),
         }
     }
 }
 
+#[allow(non_snake_case)]
 #[repr(C)]
-pub struct VertexState {
-    pub stage: ProgrammableStageDescriptor,
-    pub buffers: *const VertexBufferLayout,
-    pub buffer_count: usize,
+pub struct VertexStateDescriptor<'c> {
+    pub nextInChain: Option<&'c ChainedStruct<'c>>,
+    pub indexFormat: IndexFormat,
+    pub vertexBufferCount: u32,
+    pub vertexBuffers: *const VertexBufferLayoutDescriptor,
 }
 
+#[allow(non_snake_case)]
 #[repr(C)]
-pub struct FragmentState {
-    pub stage: ProgrammableStageDescriptor,
-    pub targets: *const wgt::ColorTargetState,
-    pub target_count: usize,
+pub struct RasterizationStateDescriptor<'c> {
+    pub nextInChain: Option<&'c ChainedStruct<'c>>,
+    pub frontFace: wgt::FrontFace,
+    pub cullMode: CullMode,
+    pub depthBias: i32,
+    pub depthBiasSlopeScale: f32,
+    pub depthBiasClamp: f32,
+    pub clampDepth: bool,
 }
 
-impl FragmentState {
-    unsafe fn to_wgpu(&self) -> wgc::pipeline::FragmentState {
-        wgc::pipeline::FragmentState {
-            stage: self.stage.to_wgpu(),
-            targets: Cow::Borrowed(make_slice(
-                self.targets,
-                self.target_count,
-            ))
+#[allow(non_snake_case)]
+#[repr(C)]
+pub struct StencilStateFaceDescriptor {
+    pub compare: CompareFunction,
+    pub failOp: wgt::StencilOperation,
+    pub depthFailOp: wgt::StencilOperation,
+    pub passOp: wgt::StencilOperation,
+}
+
+impl StencilStateFaceDescriptor {
+    fn to_wgpu(&self) -> wgt::StencilFaceState {
+        let compare: Option<wgt::CompareFunction> = self.compare.into();
+        wgt::StencilFaceState {
+            compare: compare.expect("compare to be valid"),
+            fail_op: self.failOp,
+            depth_fail_op: self.depthFailOp,
+            pass_op: self.passOp,
         }
     }
 }
 
+#[allow(non_snake_case)]
 #[repr(C)]
-pub struct PrimitiveState {
-    pub topology: wgt::PrimitiveTopology,
-    pub strip_index_format: IndexFormat,
-    pub front_face: wgt::FrontFace,
-    pub cull_mode: wgt::CullMode,
-    pub polygon_mode: wgt::PolygonMode,
+pub struct DepthStencilStateDescriptor<'c> {
+    pub nextInChain: Option<&'c ChainedStruct<'c>>,
+    pub format: wgt::TextureFormat,
+    pub depthWriteEnabled: bool,
+    pub depthCompare: CompareFunction,
+    pub stencilFront: StencilStateFaceDescriptor,
+    pub stencilBack: StencilStateFaceDescriptor,
+    pub stencilReadMask: u32,
+    pub stencilWriteMask: u32,
 }
 
-impl PrimitiveState {
-    fn to_wgpu(&self) -> wgt::PrimitiveState {
-        wgt::PrimitiveState {
-            topology: self.topology,
-            strip_index_format: self.strip_index_format.to_wgpu(),
-            front_face: self.front_face,
-            cull_mode: self.cull_mode,
-            polygon_mode: self.polygon_mode,
+impl DepthStencilStateDescriptor<'_> {
+    fn to_wgpu(&self, s: &RasterizationStateDescriptor) -> wgt::DepthStencilState {
+        let depth_compare: Option<wgt::CompareFunction> = self.depthCompare.into();
+        wgt::DepthStencilState {
+            format: self.format,
+            depth_write_enabled: self.depthWriteEnabled,
+            depth_compare: depth_compare.expect("depth_compare to be valid"),
+            stencil: wgt::StencilState {
+                front: self.stencilFront.to_wgpu(),
+                back: self.stencilBack.to_wgpu(),
+                read_mask: self.stencilReadMask,
+                write_mask: self.stencilWriteMask,
+            },
+            bias: wgt::DepthBiasState {
+                constant: 0, // todo: not in webgpu-headers
+                slope_scale: s.depthBiasSlopeScale,
+                clamp: s.depthBiasClamp,
+            },
+            clamp_depth: s.clampDepth,
         }
     }
 }
 
+#[allow(non_snake_case)]
 #[repr(C)]
-pub struct RenderPipelineDescriptor {
+pub struct RenderPipelineDescriptor<'c> {
+    pub nextInChain: Option<&'c ChainedStruct<'c>>,
     pub label: Label,
     pub layout: Option<id::PipelineLayoutId>,
-    pub vertex: VertexState,
-    pub primitive: PrimitiveState,
-    pub depth_stencil: *const wgt::DepthStencilState,
-    pub multisample: wgt::MultisampleState,
-    pub fragment: *const FragmentState,
+    pub vertexStage: ProgrammableStageDescriptor,
+    pub fragmentStage: *const ProgrammableStageDescriptor,
+    pub vertexState: VertexStateDescriptor<'c>,
+    pub primitiveTopology: wgt::PrimitiveTopology,
+    pub rasterizationState: RasterizationStateDescriptor<'c>,
+    pub sampleCount: u32,
+    pub depthStencilState: *const DepthStencilStateDescriptor<'c>,
+    pub colorStateCount: u32,
+    pub colorStates: *const ColorStateDescriptor<'c>,
+    pub sampleMask: u32,
+    pub alphaToCoverageEnabled: bool,
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpu_device_create_render_pipeline(
-    device_id: id::DeviceId,
-    desc_base: &RenderPipelineDescriptor,
+pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
+    device: id::DeviceId,
+    descriptor: &RenderPipelineDescriptor,
 ) -> id::RenderPipelineId {
-    let buffers: Vec<_> = make_slice(
-        desc_base.vertex.buffers,
-        desc_base.vertex.buffer_count,
-    ).iter().map(|buffer| buffer.to_wgpu()).collect::<Vec<_>>();
-
-    let vertex = wgc::pipeline::VertexState {
-        stage: desc_base.vertex.stage.to_wgpu(),
-        buffers: Cow::Owned(buffers),
-    };
-
     let desc = wgc::pipeline::RenderPipelineDescriptor {
-        label: OwnedLabel::new(desc_base.label).into_cow(),
-        layout: desc_base.layout,
-        vertex,
-        primitive: desc_base.primitive.to_wgpu(),
-        depth_stencil: desc_base.depth_stencil.as_ref().cloned(),
-        multisample: desc_base.multisample.clone(),
-        fragment: desc_base.fragment.as_ref().map(|fragment| fragment.to_wgpu()),
+        label: OwnedLabel::new(descriptor.label).into_cow(),
+        layout: descriptor.layout,
+        vertex: wgc::pipeline::VertexState {
+            stage: descriptor.vertexStage.to_wgpu(),
+            buffers: Cow::Owned(make_slice(descriptor.vertexState.vertexBuffers, descriptor.vertexState.vertexBufferCount as usize).iter().map(|x|x.to_wgpu()).collect()),
+        },
+        primitive: wgt::PrimitiveState {
+            topology: descriptor.primitiveTopology,
+            strip_index_format: descriptor.vertexState.indexFormat.to_wgpu(),
+            front_face: descriptor.rasterizationState.frontFace,
+            cull_mode: descriptor.rasterizationState.cullMode.to_wgpu(),
+            polygon_mode: Default::default() // todo: not in webgpu-headers
+        },
+        depth_stencil: descriptor.depthStencilState.as_ref().map(|x|x.to_wgpu(&descriptor.rasterizationState)),
+        multisample: wgt::MultisampleState {
+            count: descriptor.sampleCount,
+            mask: descriptor.sampleMask as u64,
+            alpha_to_coverage_enabled: descriptor.alphaToCoverageEnabled,
+        },
+        fragment: descriptor.fragmentStage.as_ref().map(|x| wgc::pipeline::FragmentState {
+            stage: x.to_wgpu(),
+            targets: Cow::Owned(make_slice(descriptor.colorStates, descriptor.colorStateCount as usize).iter().map(|x|x.to_wgpu()).collect()),
+        }
+        ),
     };
-    let (id, _, error) = gfx_select!(device_id => GLOBAL.device_create_render_pipeline(device_id, &desc, PhantomData, None));
+    let (id, _, error) = gfx_select!(device => GLOBAL.device_create_render_pipeline(device, &desc, PhantomData, None));
     if let Some(err) = error {
         panic!("{:?}", err);
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -946,6 +946,7 @@ pub struct RasterizationStateDescriptor<'c> {
     pub depthBiasSlopeScale: f32,
     pub depthBiasClamp: f32,
     pub clampDepth: bool,
+    pub polygonMode: wgt::PolygonMode, // todo: move to nextInChain
 }
 
 #[allow(non_snake_case)]
@@ -1041,7 +1042,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
             strip_index_format: descriptor.vertexState.indexFormat.to_wgpu(),
             front_face: descriptor.rasterizationState.frontFace,
             cull_mode: descriptor.rasterizationState.cullMode.to_wgpu(),
-            polygon_mode: Default::default() // todo: not in webgpu-headers
+            polygon_mode: descriptor.rasterizationState.polygonMode,
         },
         depth_stencil: descriptor.depthStencilState.as_ref().map(|x|x.to_wgpu(&descriptor.rasterizationState)),
         multisample: wgt::MultisampleState {

--- a/src/device.rs
+++ b/src/device.rs
@@ -834,78 +834,20 @@ impl<'a> ProgrammableStageDescriptor {
     }
 }
 
-#[repr(u32)]
-pub enum BlendOperation {
-    Add = 0,
-    Subtract = 1,
-    ReverseSubtract = 2,
-    Min = 3,
-    Max = 4,
-}
-
-impl BlendOperation {
-    fn to_wgpu(&self) -> wgt::BlendOperation {
-        match self {
-            BlendOperation::Add => wgt::BlendOperation::Add,
-            BlendOperation::Subtract => wgt::BlendOperation::Subtract,
-            BlendOperation::ReverseSubtract => wgt::BlendOperation::ReverseSubtract,
-            BlendOperation::Min => wgt::BlendOperation::Min,
-            BlendOperation::Max => wgt::BlendOperation::Max,
-        }
-    }
-}
-
-#[repr(u32)]
-pub enum BlendFactor {
-    Zero = 0,
-    One = 1,
-    SrcColor = 2,
-    OneMinusSrcColor = 3,
-    SrcAlpha = 4,
-    OneMinusSrcAlpha = 5,
-    DstColor = 6,
-    OneMinusDstColor = 7,
-    DstAlpha = 8,
-    OneMinusDstAlpha = 9,
-    SrcAlphaSaturated = 10,
-    BlendColor = 11,
-    OneMinusBlendColor = 12,
-}
-
-impl BlendFactor {
-    fn to_wgpu(&self) -> wgt::BlendFactor {
-        match self {
-            BlendFactor::Zero => wgt::BlendFactor::Zero,
-            BlendFactor::One => wgt::BlendFactor::One,
-            BlendFactor::SrcColor => wgt::BlendFactor::SrcColor,
-            BlendFactor::OneMinusSrcColor => wgt::BlendFactor::OneMinusSrcColor,
-            BlendFactor::SrcAlpha => wgt::BlendFactor::SrcAlpha,
-            BlendFactor::OneMinusSrcAlpha => wgt::BlendFactor::OneMinusSrcAlpha,
-            BlendFactor::DstColor => wgt::BlendFactor::DstColor,
-            BlendFactor::OneMinusDstColor => wgt::BlendFactor::OneMinusDstColor,
-            BlendFactor::DstAlpha => wgt::BlendFactor::DstAlpha,
-            BlendFactor::OneMinusDstAlpha => wgt::BlendFactor::OneMinusDstAlpha,
-            BlendFactor::SrcAlphaSaturated => wgt::BlendFactor::SrcAlphaSaturated,
-            BlendFactor::BlendColor => wgt::BlendFactor::BlendColor,
-            BlendFactor::OneMinusBlendColor => wgt::BlendFactor::OneMinusBlendColor,
-        }
-    }
-}
-
 #[repr(C)]
 #[allow(non_snake_case)]
 pub struct BlendDescriptor {
-    pub operation: BlendOperation,
-    pub srcFactor: BlendFactor,
-    pub dstFactor: BlendFactor,
+    pub operation: wgt::BlendOperation,
+    pub srcFactor: wgt::BlendFactor,
+    pub dstFactor: wgt::BlendFactor,
 }
 
 impl BlendDescriptor {
     fn to_wgpu(&self) -> wgt::BlendState {
         wgt::BlendState {
-            src_factor: self.srcFactor.to_wgpu(),
-            dst_factor: self.dstFactor.to_wgpu(),
-            operation: self.operation.to_wgpu(),
+            src_factor: self.srcFactor,
+            dst_factor: self.dstFactor,
+            operation: self.operation,
         }
     }
 }
@@ -927,7 +869,6 @@ impl ColorStateDescriptor<'_> {
             alpha_blend: self.alphaBlend.to_wgpu(),
             color_blend: self.colorBlend.to_wgpu(),
             write_mask: self.writeMask,
-
         }
     }
 }


### PR DESCRIPTION
Edit(@kvark): solid step towards #6 

First effort trying to better align wgpu-native with webgpu-headers. Snake case was replaced with camel case, and the descriptor was rewritten to be closer to the structs that are defined in webgpu-headers.

Only the single function `wgpuDeviceCreateRenderPipeline` was changed in this pr to gauge interest. If merged, we'd be leaving wgpu-native in an inconsistent state.