### PR TITLE
Add pre-field to the version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,5 +159,9 @@ pub unsafe extern "C" fn wgpu_get_version() -> std::os::raw::c_uint {
     let major: u32 = env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap();
     let minor: u32 = env!("CARGO_PKG_VERSION_MINOR").parse().unwrap();
     let patch: u32 = env!("CARGO_PKG_VERSION_PATCH").parse().unwrap();
-    (major << 16) + (minor << 8) + patch
+    let pre: u32 = match env!("CARGO_PKG_VERSION_PRE").parse::<u32>() {
+        Ok(n) => n,
+        Err(e) => 0,
+    };
+    (major << 24) + (minor << 16) + (patch << 8) + pre
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ pub unsafe extern "C" fn wgpu_get_version() -> std::os::raw::c_uint {
     let patch: u32 = env!("CARGO_PKG_VERSION_PATCH").parse().unwrap();
     let pre: u32 = match env!("CARGO_PKG_VERSION_PRE").parse::<u32>() {
         Ok(n) => n,
-        Err(e) => 0,
+        Err(_e) => 0,
     };
     (major << 24) + (minor << 16) + (patch << 8) + pre
 }


### PR DESCRIPTION
See #80. In this way, we can also use the pre-field of the version number. While major/minor/patch are always integer, the pre field can be a string. When this happens (when Rust can't convert it to u32) the pre field is set to 0. 

This change does introduce a backwards incompatibility. To test whether the version int consists of 3 or 4 values, one can test `if version_int < 65536`.

