### PR TITLE
add meson.build 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,20 @@
+project('wgpu-native','c',version : '0.6.0')
+cargo = find_program('cargo')
+
+#build by cargo
+run_command(cargo,'build','--release')
+#mark cargo artifact to static library
+wgpu_native =static_library('wgpu_native',objects : 'target/release/libwgpu_native.a')
+
+dep_wgpu_native=declare_dependency(
+link_with:wgpu_native,
+include_directories: ['ffi/']
+)
+
+pkg = import('pkgconfig')
+pkg.generate(name : 'wgpu-native',
+             description : 'Headers for using wgpu-native',
+             libraries : [wgpu_native],
+             version : meson.project_version(),
+             )
+install_subdir('include', install_dir : '')

--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,20 @@
-project('wgpu-native','c',version : '0.6.0')
+
+project('wgpu-native', 'c', version : '0.6.0', license : 'MPL 2.0')
+
 cargo = find_program('cargo')
+#determin whitch dir contain platform library
+if host_machine.system() == 'Linux'
+    lib_path='target/release/libwgpu_native.a'
+elif host_machine.system() == 'windows'
+    lib_path='target/release/wgpu_native.lib'
+endif
 
 #build by cargo
 run_command(cargo,'build','--release')
 #mark cargo artifact to static library
-wgpu_native =static_library('wgpu_native',objects : 'target/release/libwgpu_native.a')
+wgpu_native = static_library('wgpu_native', objects : lib_path, install : true)
 
-dep_wgpu_native=declare_dependency(
+dep_wgpu_native = declare_dependency(
 link_with:wgpu_native,
 include_directories: ['ffi/']
 )

--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,13 @@
 
 project('wgpu-native', 'c', version : '0.6.0', license : 'MPL 2.0')
 
+inc_dirs = [include_directories('ffi', is_system: true)]
+
 cargo = find_program('cargo')
-#determin whitch dir contain platform library
-if host_machine.system() == 'linux'
+#determin which dir contain platform library
+if ['linux','android','darwin','cygwin','freebsd','netbsd','openbsd'].contains(host_machine.system())
     lib_path='target/release/libwgpu_native.a'
-elif host_machine.system() == 'windows'
+else
     lib_path='target/release/wgpu_native.lib'
 endif
 
@@ -16,7 +18,7 @@ wgpu_native = static_library('wgpu_native', objects : lib_path, install : true)
 
 dep_wgpu_native = declare_dependency(
 link_with:wgpu_native,
-include_directories: ['ffi/']
+include_directories: inc_dirs
 )
 
 pkg = import('pkgconfig')

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('wgpu-native', 'c', version : '0.6.0', license : 'MPL 2.0')
 
 cargo = find_program('cargo')
 #determin whitch dir contain platform library
-if host_machine.system() == 'Linux'
+if host_machine.system() == 'linux'
     lib_path='target/release/libwgpu_native.a'
 elif host_machine.system() == 'windows'
     lib_path='target/release/wgpu_native.lib'


### PR DESCRIPTION
This PR aims to add dependency resolving for meson user

If user want to build by meson it is not easy  due to lack of cargo support .
but this PR makes it easy i.e. user just write wgpu-native.wrap in subprojects