### PR TITLE
Fix triangle example (do not use empty bind groups)

### DIFF
--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -132,28 +132,10 @@ int main()
     WGPUShaderModuleDescriptor shaderSource = load_wgsl("shader.wgsl");
     WGPUShaderModule shader = wgpuDeviceCreateShaderModule(device, &shaderSource);
 
-    WGPUBindGroupLayout bindGroupLayout = wgpuDeviceCreateBindGroupLayout(device,
-        &(WGPUBindGroupLayoutDescriptor) {
-            .label = "bind group layout",
-            .entries = NULL,
-            .entryCount = 0,
-        });
-    WGPUBindGroup bindGroup = wgpuDeviceCreateBindGroup(device,
-        &(WGPUBindGroupDescriptor) {
-            .label = "bind group",
-            .layout = bindGroupLayout,
-            .entries = NULL,
-            .entryCount = 0,
-        });
-
-    WGPUBindGroupLayout bindGroupLayouts[1] = {
-        bindGroupLayout
-    };
-
     WGPUPipelineLayout pipelineLayout = wgpuDeviceCreatePipelineLayout(device,
         &(WGPUPipelineLayoutDescriptor) {
-            .bindGroupLayouts = bindGroupLayouts,
-            .bindGroupLayoutCount = 1 });
+            .bindGroupLayouts = NULL,
+            .bindGroupLayoutCount = 0 });
 
     WGPURenderPipeline pipeline = wgpuDeviceCreateRenderPipeline(
         device,
@@ -261,7 +243,6 @@ int main()
             });
 
         wgpuRenderPassEncoderSetPipeline(renderPass, pipeline);
-        wgpuRenderPassEncoderSetBindGroup(renderPass, 0, bindGroup, 0, NULL);
         wgpuRenderPassEncoderDraw(renderPass, 3, 1, 0, 0);
         wgpuRenderPassEncoderEndPass(renderPass);
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -299,9 +299,6 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroup(
         layout: descriptor.layout,
         entries: Cow::Borrowed(&entries),
     };
-    if entries.len() == 0 {
-        panic!("Bind groups with zero entries not allowed.");
-    }
     check_error(gfx_select!(device => GLOBAL.device_create_bind_group(device, &desc, PhantomData)))
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -299,6 +299,9 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroup(
         layout: descriptor.layout,
         entries: Cow::Borrowed(&entries),
     };
+    if entries.len() == 0 {
+        panic!("Bind groups with zero entries not allowed.");
+    }
     check_error(gfx_select!(device => GLOBAL.device_create_bind_group(device, &desc, PhantomData)))
 }
 


### PR DESCRIPTION
The triangle example in wgpu-py started failing for me recently. Indeed the example in wgpu-native fails too now (for my system at least). This fixes it.