### PR TITLE
Add surfaceGetPreferredFormat

### DIFF
--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -27,6 +27,11 @@
 #endif
 #include <GLFW/glfw3native.h>
 
+void preferred_texture_callback(WGPUTextureFormat format, void* userdata)
+{
+    *(WGPUTextureFormat*)userdata = format;
+}
+
 int main()
 {
     initializeLog();
@@ -137,6 +142,9 @@ int main()
             .bindGroupLayouts = NULL,
             .bindGroupLayoutCount = 0 });
 
+    WGPUTextureFormat swapChainFormat;
+    wgpuSurfaceGetPreferredFormat(surface, adapter, preferred_texture_callback, &swapChainFormat);
+
     WGPURenderPipeline pipeline = wgpuDeviceCreateRenderPipeline(
         device,
         &(WGPURenderPipelineDescriptor) {
@@ -164,7 +172,7 @@ int main()
                 .entryPoint = "fs_main",
                 .targetCount = 1,
                 .targets = &(WGPUColorTargetState) {
-                    .format = WGPUTextureFormat_BGRA8Unorm,
+                    .format = swapChainFormat,
                     .blend = &(WGPUBlendState) {
                         .color = (WGPUBlendComponent) {
                             .srcFactor = WGPUBlendFactor_One,
@@ -190,7 +198,7 @@ int main()
     WGPUSwapChain swapChain = wgpuDeviceCreateSwapChain(device, surface,
         &(WGPUSwapChainDescriptor) {
             .usage = WGPUTextureUsage_RenderAttachment,
-            .format = WGPUTextureFormat_BGRA8Unorm,
+            .format = swapChainFormat,
             .width = prevWidth,
             .height = prevHeight,
             .presentMode = WGPUPresentMode_Fifo,
@@ -208,7 +216,7 @@ int main()
             swapChain = wgpuDeviceCreateSwapChain(device, surface,
                 &(WGPUSwapChainDescriptor) {
                     .usage = WGPUTextureUsage_RenderAttachment,
-                    .format = WGPUTextureFormat_BGRA8Unorm,
+                    .format = swapChainFormat,
                     .width = prevWidth,
                     .height = prevHeight,
                     .presentMode = WGPUPresentMode_Fifo,

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -327,6 +327,49 @@ pub fn map_texture_format(value: crate::EnumConstant) -> Option<wgt::TextureForm
     }
 }
 
+pub fn to_native_texture_format(rs_type: wgt::TextureFormat) -> crate::EnumConstant {
+    match rs_type {
+        wgt::TextureFormat::R8Unorm => native::WGPUTextureFormat_R8Unorm,
+        wgt::TextureFormat::R8Snorm => native::WGPUTextureFormat_R8Snorm,
+        wgt::TextureFormat::R8Uint => native::WGPUTextureFormat_R8Uint,
+        wgt::TextureFormat::R8Sint => native::WGPUTextureFormat_R8Sint,
+        wgt::TextureFormat::R16Uint => native::WGPUTextureFormat_R16Uint,
+        wgt::TextureFormat::R16Sint => native::WGPUTextureFormat_R16Sint,
+        wgt::TextureFormat::R16Float => native::WGPUTextureFormat_R16Float,
+        wgt::TextureFormat::Rg8Unorm => native::WGPUTextureFormat_RG8Unorm,
+        wgt::TextureFormat::Rg8Snorm => native::WGPUTextureFormat_RG8Snorm,
+        wgt::TextureFormat::Rg8Uint => native::WGPUTextureFormat_RG8Uint,
+        wgt::TextureFormat::Rg8Sint => native::WGPUTextureFormat_RG8Sint,
+        wgt::TextureFormat::R32Float => native::WGPUTextureFormat_R32Float,
+        wgt::TextureFormat::R32Uint => native::WGPUTextureFormat_R32Uint,
+        wgt::TextureFormat::R32Sint => native::WGPUTextureFormat_R32Sint,
+        wgt::TextureFormat::Rg16Uint => native::WGPUTextureFormat_RG16Uint,
+        wgt::TextureFormat::Rg16Sint => native::WGPUTextureFormat_RG16Sint,
+        wgt::TextureFormat::Rg16Float => native::WGPUTextureFormat_RG16Float,
+        wgt::TextureFormat::Rgba8Unorm => native::WGPUTextureFormat_RGBA8Unorm,
+        wgt::TextureFormat::Rgba8UnormSrgb => native::WGPUTextureFormat_RGBA8UnormSrgb,
+        wgt::TextureFormat::Rgba8Snorm => native::WGPUTextureFormat_RGBA8Snorm,
+        wgt::TextureFormat::Rgba8Uint => native::WGPUTextureFormat_RGBA8Uint,
+        wgt::TextureFormat::Rgba8Sint => native::WGPUTextureFormat_RGBA8Sint,
+        wgt::TextureFormat::Bgra8Unorm => native::WGPUTextureFormat_BGRA8Unorm,
+        wgt::TextureFormat::Bgra8UnormSrgb => native::WGPUTextureFormat_BGRA8UnormSrgb,
+        wgt::TextureFormat::Rgb10a2Unorm => native::WGPUTextureFormat_RGB10A2Unorm,
+        wgt::TextureFormat::Rg32Float => native::WGPUTextureFormat_RG32Float,
+        wgt::TextureFormat::Rg32Uint => native::WGPUTextureFormat_RG32Uint,
+        wgt::TextureFormat::Rg32Sint => native::WGPUTextureFormat_RG32Sint,
+        wgt::TextureFormat::Rgba16Uint => native::WGPUTextureFormat_RGBA16Uint,
+        wgt::TextureFormat::Rgba16Sint => native::WGPUTextureFormat_RGBA16Sint,
+        wgt::TextureFormat::Rgba16Float => native::WGPUTextureFormat_RGBA16Float,
+        wgt::TextureFormat::Rgba32Float => native::WGPUTextureFormat_RGBA32Float,
+        wgt::TextureFormat::Rgba32Uint => native::WGPUTextureFormat_RGBA32Uint,
+        wgt::TextureFormat::Rgba32Sint => native::WGPUTextureFormat_RGBA32Sint,
+        wgt::TextureFormat::Depth32Float => native::WGPUTextureFormat_Depth32Float,
+        wgt::TextureFormat::Depth24Plus => native::WGPUTextureFormat_Depth24Plus,
+        wgt::TextureFormat::Depth24PlusStencil8 => native::WGPUTextureFormat_Depth24PlusStencil8,
+        _ => unimplemented!(),
+    }
+}
+
 pub fn map_stencil_face_state(value: native::WGPUStencilFaceState) -> wgt::StencilFaceState {
     wgt::StencilFaceState {
         compare: map_compare_function(value.compare).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,3 +274,19 @@ unsafe fn map_surface(
 
     panic!("Error: Unsupported Surface");
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuSurfaceGetPreferredFormat(
+    surface: id::SurfaceId,
+    adapter: id::AdapterId,
+    callback: native::WGPUSurfaceGetPreferredFormatCallback,
+    userdata: *mut std::os::raw::c_void,
+) {
+    let preferred_format = match wgc::gfx_select!(adapter => GLOBAL.adapter_get_swap_chain_preferred_format(adapter, surface))
+    {
+        Ok(format) => conv::to_native_texture_format(format),
+        Err(err) => panic!("Could not get preferred swap chain format: {}", err),
+    };
+
+    (callback.unwrap())(preferred_format, userdata);
+}


### PR DESCRIPTION
Adds wgpuSurfaceGetPreferredFormat and updates the triangle example. 

Right now, `map_enum!` only converts native types to Rust types, so I had to manually map the `wgt::TextureFormat` to `native::WGPUTextureFormat`. In the future, it might be prudent to rework `map_enum!` to create mapping functions for both directions. 