### PR TITLE
Support for setting TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -10,17 +10,9 @@ typedef enum WGPUNativeSType {
     WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeSType;
 
-typedef struct WGPUAdapterExtras {
-    WGPUChainedStruct chain;
-    WGPUBackendType backend;
-} WGPUAdapterExtras;
-
-typedef struct WGPUDeviceExtras {
-    WGPUChainedStruct chain;
-    uint32_t maxBindGroups;
-    const char* label;
-    const char* tracePath;
-} WGPUDeviceExtras;
+typedef enum WGPUNativeFeature {
+    WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 0x10000000
+} WGPUNativeFeature;
 
 typedef enum WGPULogLevel {
     WGPULogLevel_Off = 0x00000000,
@@ -31,6 +23,22 @@ typedef enum WGPULogLevel {
     WGPULogLevel_Trace = 0x00000005,
     WGPULogLevel_Force32 = 0x7FFFFFFF
 } WGPULogLevel;
+
+typedef struct WGPUAdapterExtras {
+    WGPUChainedStruct chain;
+    WGPUBackendType backend;
+} WGPUAdapterExtras;
+
+typedef struct WGPUDeviceExtras {
+    WGPUChainedStruct chain;
+    uint32_t maxBindGroups;
+    WGPUNativeFeature nativeFeatures;
+
+    const char* label;
+    const char* tracePath;
+} WGPUDeviceExtras;
+
+
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, const char *msg);
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -195,10 +195,17 @@ pub fn map_device_descriptor<'a>(
     extras: Option<&native::WGPUDeviceExtras>,
 ) -> (wgt::DeviceDescriptor<Label<'a>>, Option<String>) {
     if let Some(extras) = extras {
+        let mut features = wgt::Features::empty();
+        if (extras.nativeFeatures
+            & native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES)
+            > 0
+        {
+            features |= wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
+        }
         (
             wgt::DeviceDescriptor {
                 label: OwnedLabel::new(extras.label).into_cow(),
-                features: wgt::Features::empty(),
+                features: features,
                 limits: wgt::Limits {
                     max_bind_groups: extras.maxBindGroups,
                     ..wgt::Limits::default()


### PR DESCRIPTION
This adds support for specifying native features. Implemented only one feature for now, but is easy to extend later. I called it `nativeFeatures` because it can be expected that `webgpu.h` will specify generic features at some point.