### PR TITLE
Update Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
             install_deps_command: |
                                 # choco exit with code 1 after successful install
                                 choco install -y --force llvm | exit 0
+                                echo "LIBCLANG_PATH=C:\Program Files\LLVM\lib" >> $GITHUB_ENV
           - os: windows-2019
             name: Windows Nightly
             channel: nightly
@@ -71,6 +72,7 @@ jobs:
             install_deps_command: |
                                 # choco exit with code 1 after successful install ¯\_(ツ)_/¯
                                 choco install -y --force cmake make llvm | exit 0
+                                echo "LIBCLANG_PATH=C:\Program Files\LLVM\lib" >> $GITHUB_ENV
                                 curl -sL -o glfw.zip https://github.com/glfw/glfw/archive/3.3.zip
                                 unzip -qq glfw.zip -d $GITHUB_WORKSPACE
                                 cd $GITHUB_WORKSPACE/glfw-3.3/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ log = "0.4"
 # gfx-backend-vulkan = { version = "0.7", features = [] }
 
 [build-dependencies]
-bindgen = "0.53.1"
+bindgen = "0.58.1"
 
 [workspace]
 members = [


### PR DESCRIPTION
bindgen 0.53.1 doesn't work on Apple M1, yielding the wonderfully cryptic:

```
thread 'main' panicked at 'libclang error; possible causes include:
  - Invalid flag syntax
  - Unrecognized flags
  - Invalid flag arguments
  - File I/O errors
  - Host vs. target architecture mismatch
  If you encounter an error missing from this list, please file an issue or a PR!', /Users/marc/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.53.3/src/ir/context.rs:573:15
```
Bindgen 0.58.1 (and possibly earlier versions) does allow this project to build and run successfully on M1.