### PR TITLE
Update webgpu-headers submodule

### DIFF
--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -51,7 +51,7 @@ int main(
     WGPUExtent3D textureExtent = (WGPUExtent3D) {
         .width = bufferDimensions.width,
         .height = bufferDimensions.height,
-        .depth = 1,
+        .depthOrArrayLayers = 1,
     };
     WGPUTexture texture = wgpuDeviceCreateTexture(device,
         &(WGPUTextureDescriptor) {
@@ -74,9 +74,9 @@ int main(
         .nextInChain = NULL,
         .label = NULL,
         .format = WGPUTextureFormat_Undefined,
-        .dimension = WGPUTextureViewDimension_Undefined, 
+        .dimension = WGPUTextureViewDimension_Undefined,
         .aspect = WGPUTextureAspect_All,
-        .arrayLayerCount = 0, 
+        .arrayLayerCount = 0,
         .baseArrayLayer = 0,
         .baseMipLevel = 0,
         .mipLevelCount = 0,
@@ -84,8 +84,8 @@ int main(
 
     WGPURenderPassEncoder renderPass = wgpuCommandEncoderBeginRenderPass(encoder,
         &(WGPURenderPassDescriptor) {
-            .colorAttachments = &(WGPURenderPassColorAttachmentDescriptor) {
-                .attachment = outputAttachment,
+            .colorAttachments = &(WGPURenderPassColorAttachment) {
+                .view = outputAttachment,
                 .resolveTarget = 0,
                 .loadOp = WGPULoadOp_Clear,
                 .storeOp = WGPUStoreOp_Store,
@@ -110,7 +110,7 @@ int main(
                     .x = 0,
                     .y = 0,
                     .z = 0,
-                },  
+                },
             },
             &(WGPUImageCopyBuffer) {
                 .buffer = outputBuffer,

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -58,8 +58,8 @@ int main()
         [ns_window.contentView setWantsLayer:YES];
         metal_layer = [CAMetalLayer layer];
         [ns_window.contentView setLayer:metal_layer];
-        surface = wgpuInstanceCreateSurface(NULL, &(WGPUSurfaceDescriptor) { 
-            .label = NULL, 
+        surface = wgpuInstanceCreateSurface(NULL, &(WGPUSurfaceDescriptor) {
+            .label = NULL,
             .nextInChain = (const WGPUChainedStruct*)&(WGPUSurfaceDescriptorFromMetalLayer) {
                 .chain = (WGPUChainedStruct) {
                     .next = NULL,
@@ -67,7 +67,7 @@ int main()
                 },
                 .layer = metal_layer,
             },
-        });    
+        });
     }
 #elif WGPU_TARGET == WGPU_TARGET_LINUX_X11
     {
@@ -93,8 +93,8 @@ int main()
     {
         HWND hwnd = glfwGetWin32Window(window);
         HINSTANCE hinstance = GetModuleHandle(NULL);
-        surface = wgpuInstanceCreateSurface(NULL, &(WGPUSurfaceDescriptor) { 
-            .label = NULL, 
+        surface = wgpuInstanceCreateSurface(NULL, &(WGPUSurfaceDescriptor) {
+            .label = NULL,
             .nextInChain = (const WGPUChainedStruct*)&(WGPUSurfaceDescriptorFromWindowsHWND) {
                 .chain = (WGPUChainedStruct) {
                     .next = NULL,
@@ -163,7 +163,7 @@ int main()
                 .cullMode = WGPUCullMode_None
             },
             .multisample = (WGPUMultisampleState) {
-                .count = 1, 
+                .count = 1,
                 .mask = ~0,
                 .alphaToCoverageEnabled = false,
             },
@@ -188,7 +188,7 @@ int main()
                     .writeMask = WGPUColorWriteMask_All
                 },
             },
-            .depthStencil = NULL, 
+            .depthStencil = NULL,
             });
 
     int prevWidth = 0;
@@ -234,8 +234,8 @@ int main()
 
         WGPURenderPassEncoder renderPass = wgpuCommandEncoderBeginRenderPass(encoder,
             &(WGPURenderPassDescriptor) {
-                .colorAttachments = &(WGPURenderPassColorAttachmentDescriptor) {
-                    .attachment = nextTexture,
+                .colorAttachments = &(WGPURenderPassColorAttachment) {
+                    .view = nextTexture,
                     .resolveTarget = 0,
                     .loadOp = WGPULoadOp_Clear,
                     .storeOp = WGPUStoreOp_Store,

--- a/src/command.rs
+++ b/src/command.rs
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
 ) -> id::RenderPassEncoderId {
     let depth_stencil_attachment = descriptor.depthStencilAttachment.as_ref().map(|desc| {
         wgc::command::RenderPassDepthStencilAttachment {
-            view: desc.attachment,
+            view: desc.view,
             depth: wgc::command::PassChannel {
                 load_op: conv::map_load_op(desc.depthLoadOp),
                 store_op: conv::map_store_op(desc.depthStoreOp),
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
             )
             .iter()
             .map(|color_attachment| wgc::command::RenderPassColorAttachment {
-                view: color_attachment.attachment,
+                view: color_attachment.view,
                 resolve_target: Some(color_attachment.resolveTarget),
                 channel: wgc::command::PassChannel {
                     load_op: conv::map_load_op(color_attachment.loadOp),
@@ -345,7 +345,7 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetPushConstants(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuRenderPassEncoderSetBlendColor(
+pub unsafe extern "C" fn wgpuRenderPassEncoderSetBlendConstant(
     pass: id::RenderPassEncoderId,
     color: &native::WGPUColor,
 ) {

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -101,17 +101,17 @@ map_enum!(
     "Unknown blend factor",
     Zero: Zero,
     One: One,
-    SrcColor: Src,
-    OneMinusSrcColor: OneMinusSrc,
+    Src: Src,
+    OneMinusSrc: OneMinusSrc,
     SrcAlpha: SrcAlpha,
     OneMinusSrcAlpha: OneMinusSrcAlpha,
-    DstColor: Dst,
-    OneMinusDstColor: OneMinusDst,
+    Dst: Dst,
+    OneMinusDst: OneMinusDst,
     DstAlpha: DstAlpha,
     OneMinusDstAlpha: OneMinusDstAlpha,
     SrcAlphaSaturated: SrcAlphaSaturated,
-    BlendColor: Constant,
-    OneMinusBlendColor: OneMinusConstant
+    Constant: Constant,
+    OneMinusConstant: OneMinusConstant
 );
 map_enum!(
     map_blend_operation,
@@ -177,7 +177,7 @@ pub fn map_extent3d(native: &native::WGPUExtent3D) -> wgt::Extent3d {
     wgt::Extent3d {
         width: native.width,
         height: native.height,
-        depth_or_array_layers: native.depth,
+        depth_or_array_layers: native.depthOrArrayLayers,
     }
 }
 


### PR DESCRIPTION
The webgpu-headers repo was 3 commits ahead. This PR bumps the commit from [8b8c2a77dd5a94a64d987b664e2ec320e34a3dc5](https://github.com/webgpu-native/webgpu-headers/commit/8b8c2a77dd5a94a64d987b664e2ec320e34a3dc5) to [c8e0b39f6f6f1edded5c4adf7d46aa4d2a95befe](https://github.com/webgpu-native/webgpu-headers/commit/c8e0b39f6f6f1edded5c4adf7d46aa4d2a95befe) (the latest commit, from April 2021). Also see [the diff](https://github.com/webgpu-native/webgpu-headers/compare/8b8c2a77dd5a94a64d987b664e2ec320e34a3dc5...c8e0b39f6f6f1edded5c4adf7d46aa4d2a95befe). Only a few local changes needed.

