### PR TITLE
Update to latest wgpu-core and naga

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/naga?rev=a7ac13a#a7ac13a61d63620b8a0821db9176ed467fc282f7"
+source = "git+https://github.com/gfx-rs/naga?rev=300039e#300039e24703bc823cc932985947dfda66616e1e"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.9.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=bbeb30a2c982ac9a7bdc6f7815d46eb311678b7a#bbeb30a2c982ac9a7bdc6f7815d46eb311678b7a"
+source = "git+https://github.com/gfx-rs/wgpu?rev=9310f264f1c3d70cd8665fc7e7e15d810577c3f5#9310f264f1c3d70cd8665fc7e7e15d810577c3f5"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.9.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=bbeb30a2c982ac9a7bdc6f7815d46eb311678b7a#bbeb30a2c982ac9a7bdc6f7815d46eb311678b7a"
+source = "git+https://github.com/gfx-rs/wgpu?rev=9310f264f1c3d70cd8665fc7e7e15d810577c3f5#9310f264f1c3d70cd8665fc7e7e15d810577c3f5"
 dependencies = [
  "arrayvec",
  "ash",
@@ -1010,7 +1010,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.9.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=bbeb30a2c982ac9a7bdc6f7815d46eb311678b7a#bbeb30a2c982ac9a7bdc6f7815d46eb311678b7a"
+source = "git+https://github.com/gfx-rs/wgpu?rev=9310f264f1c3d70cd8665fc7e7e15d810577c3f5#9310f264f1c3d70cd8665fc7e7e15d810577c3f5"
 dependencies = [
  "bitflags",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 [dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "bbeb30a2c982ac9a7bdc6f7815d46eb311678b7a"
+rev = "9310f264f1c3d70cd8665fc7e7e15d810577c3f5"
 # path = "../wgpu/wgpu-core"
 version = "0.9"
 features = ["raw-window-handle", "trace"]
@@ -31,7 +31,7 @@ features = ["raw-window-handle", "trace"]
 [dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "bbeb30a2c982ac9a7bdc6f7815d46eb311678b7a"
+rev = "9310f264f1c3d70cd8665fc7e7e15d810577c3f5"
 # path = "../wgpu/wgpu-types"
 version = "0.9"
 
@@ -42,7 +42,7 @@ paste = "1.0"
 log = "0.4"
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "a7ac13a"
+rev = "300039e"
 features = ["spv-in"]
 
 # [target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies]


### PR DESCRIPTION
Another bump, mostly to include newer Naga with better error reporting and new storage class API. No additional changes required.