### PR TITLE
Update to latest webgpu.h

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -52,6 +52,7 @@ fn main() {
     builder = builder.blocklist_item("WGPUBindGroupEntry").raw_line(
         "#[repr(C)]
             pub struct WGPUBindGroupEntry {
+                pub nextInChain: * const crate::native::WGPUChainedStruct,
                 pub binding: u32,
                 pub buffer: Option<wgc::id::BufferId>,
                 pub offset: u64,
@@ -69,6 +70,8 @@ fn main() {
             pub struct WGPURequestAdapterOptions {
                 pub nextInChain: * const crate::native::WGPUChainedStruct,
                 pub compatibleSurface: Option<wgc::id::SurfaceId>,
+                pub powerPreference: crate::native::WGPUPowerPreference,
+                pub forceFallbackAdapter: bool,
             }",
         );
 

--- a/checks.py
+++ b/checks.py
@@ -158,7 +158,7 @@ def check_rust_wrapper_args():
                         #print(f"  {status} {argname}: {typ}\n       {' '*len(argname)}{c_arg}")
                 missing = set(funcs[funcname]).difference(covered)
                 if missing:
-                    message = f"missing: {missing}"
+                    message = f"{funcname} has missing args: {missing}"
                     print(message)
                     fails.append(message)
 

--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -29,9 +29,14 @@ int main(
                     .next = NULL,
                     .sType = WGPUSType_DeviceExtras,
                 },
-                .maxBindGroups = 1,
                 .label = "Device",
                 .tracePath = NULL,
+            },
+            .requiredLimits = &(WGPURequiredLimits) {
+                .nextInChain = NULL,
+                .limits = (WGPULimits) {
+                    .maxBindGroups = 1,
+                },
             },
         },
         request_device_callback, (void*)&device);

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -30,9 +30,15 @@ int main()
                     .next = NULL,
                     .sType = WGPUSType_DeviceExtras,
                 },
-                .maxBindGroups = 1,
+                
                 .label = "Device",
                 .tracePath = NULL,
+            },
+            .requiredLimits = &(WGPURequiredLimits) {
+                .nextInChain = NULL,
+                .limits = (WGPULimits) {
+                    .maxBindGroups = 1,
+                },
             },
         },
         request_device_callback, (void*)&device);
@@ -100,7 +106,7 @@ int main()
     WGPUComputePipeline computePipeline = wgpuDeviceCreateComputePipeline(device,
         &(WGPUComputePipelineDescriptor) {
             .layout = pipelineLayout,
-            .computeStage = (WGPUProgrammableStageDescriptor) {
+            .compute = (WGPUProgrammableStageDescriptor) {
                 .module = shader,
                 .entryPoint = "main" } });
 
@@ -137,3 +143,4 @@ int main()
 
     return 0;
 }
+

--- a/examples/framework.c
+++ b/examples/framework.c
@@ -27,12 +27,12 @@ WGPUShaderModuleDescriptor load_wgsl(const char *name) {
     };
 }
 
-void request_adapter_callback(WGPUAdapter received, void* userdata)
+void request_adapter_callback(WGPURequestAdapterStatus status, WGPUAdapter received, char* message, void* userdata)
 {
     *(WGPUAdapter*)userdata = received;
 }
 
-void request_device_callback(WGPUDevice received, void* userdata)
+void request_device_callback(WGPURequestDeviceStatus status, WGPUDevice received, char* message, void* userdata)
 {
     *(WGPUDevice*)userdata = received;
 }
@@ -58,3 +58,4 @@ void initializeLog() {
     wgpuSetLogCallback(logCallback);
     wgpuSetLogLevel(WGPULogLevel_Warn);
 }
+

--- a/examples/framework.h
+++ b/examples/framework.h
@@ -2,10 +2,11 @@
 
 WGPUShaderModuleDescriptor load_wgsl(const char *name);
 
-void request_adapter_callback(WGPUAdapter received, void* userdata);
+void request_adapter_callback(WGPURequestAdapterStatus status, WGPUAdapter received, char* message, void* userdata);
 
-void request_device_callback(WGPUDevice received, void* userdata);
+void request_device_callback(WGPURequestDeviceStatus status, WGPUDevice received, char* message, void* userdata);
 
 void readBufferMap(WGPUBufferMapAsyncStatus status, uint8_t* userdata);
 
 void initializeLog();
+

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -27,11 +27,6 @@
 #endif
 #include <GLFW/glfw3native.h>
 
-void preferred_texture_callback(WGPUTextureFormat format, void* userdata)
-{
-    *(WGPUTextureFormat*)userdata = format;
-}
-
 int main()
 {
     initializeLog();
@@ -126,9 +121,14 @@ int main()
                     .next = NULL,
                     .sType = WGPUSType_DeviceExtras,
                 },
-                .maxBindGroups = 1,
                 .label = "Device",
                 .tracePath = NULL,
+            },
+            .requiredLimits = &(WGPURequiredLimits) {
+                .nextInChain = NULL,
+                .limits = (WGPULimits) {
+                    .maxBindGroups = 1,
+                },
             },
         },
         request_device_callback,
@@ -142,8 +142,7 @@ int main()
             .bindGroupLayouts = NULL,
             .bindGroupLayoutCount = 0 });
 
-    WGPUTextureFormat swapChainFormat;
-    wgpuSurfaceGetPreferredFormat(surface, adapter, preferred_texture_callback, &swapChainFormat);
+    WGPUTextureFormat swapChainFormat = wgpuSurfaceGetPreferredFormat(surface, adapter);
 
     WGPURenderPipeline pipeline = wgpuDeviceCreateRenderPipeline(
         device,

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -31,22 +31,10 @@ typedef struct WGPUAdapterExtras {
 
 typedef struct WGPUDeviceExtras {
     WGPUChainedStruct chain;
-    uint32_t maxTextureDimension1D;
-    uint32_t maxTextureDimension2D;
-    uint32_t maxTextureDimension3D;
-    uint32_t maxTextureArrayLayers;
-    uint32_t maxBindGroups;
-    uint32_t maxDynamicStorageBuffersPerPipelineLayout;
-    uint32_t maxStorageBuffersPerShaderStage;
-    uint32_t maxStorageBufferBindingSize;
-
     WGPUNativeFeature nativeFeatures;
-
     const char* label;
     const char* tracePath;
 } WGPUDeviceExtras;
-
-
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, const char *msg);
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1,7 +1,7 @@
 use crate::{make_slice, map_enum, native, Label, OwnedLabel};
+use naga;
 use std::{borrow::Cow, ffi::CStr, num::NonZeroU32};
 use wgc::{id, pipeline::ShaderModuleSource};
-use naga;
 
 map_enum!(
     map_load_op,
@@ -11,7 +11,6 @@ map_enum!(
     Clear,
     Load
 );
-/*  Temporary explicit map functions while webgpu.h uses Clear instead of Discard.
 map_enum!(
     map_store_op,
     WGPUStoreOp,
@@ -20,14 +19,6 @@ map_enum!(
     Discard,
     Store
 );
-*/
-pub fn map_store_op(value: native::WGPUStoreOp) -> wgc::command::StoreOp {
-    match value {
-        native::WGPUStoreOp_Clear => wgc::command::StoreOp::Discard,
-        native::WGPUStoreOp_Store => wgc::command::StoreOp::Store,
-        x => panic!("Unknown store op: {}", x),
-    }
-}
 map_enum!(
     map_address_mode,
     WGPUAddressMode,

--- a/src/device.rs
+++ b/src/device.rs
@@ -133,7 +133,7 @@ fn write_limits_struct(
 ) {
     let mut limits = supported_limits.limits; // This makes a copy - we copy back at the end
     limits.maxTextureDimension1D = wgt_limits.max_texture_dimension_1d;
-    limits.maxTextureDimension2D = 2; //wgt_limits.max_texture_dimension_2d;
+    limits.maxTextureDimension2D = wgt_limits.max_texture_dimension_2d;
     limits.maxTextureDimension3D = wgt_limits.max_texture_dimension_3d;
     limits.maxTextureArrayLayers = wgt_limits.max_texture_array_layers;
     limits.maxBindGroups = wgt_limits.max_bind_groups;

--- a/src/device.rs
+++ b/src/device.rs
@@ -104,11 +104,11 @@ pub unsafe extern "C" fn wgpuAdapterGetProperties(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuAdapterGetLimits(
     adapter: id::AdapterId,
-    supported_limits: &mut native::WGPUSupportedLimits,
+    limits: &mut native::WGPUSupportedLimits,
 ) -> bool {
     let result = gfx_select!(adapter => GLOBAL.adapter_limits(adapter));
     match result {
-        Ok(wgt_limits) => write_limits_struct(wgt_limits, supported_limits),
+        Ok(wgt_limits) => write_limits_struct(wgt_limits, limits),
         _ => panic!("Calling wgpuAdapterGetLimits() on an invalid adapter."),
     }
     return false; // todo: what is the purpose of this return value?
@@ -117,11 +117,11 @@ pub unsafe extern "C" fn wgpuAdapterGetLimits(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuDeviceGetLimits(
     device: id::DeviceId,
-    supported_limits: &mut native::WGPUSupportedLimits,
+    limits: &mut native::WGPUSupportedLimits,
 ) -> bool {
     let result = gfx_select!(device => GLOBAL.device_limits(device));
     match result {
-        Ok(wgt_limits) => write_limits_struct(wgt_limits, supported_limits),
+        Ok(wgt_limits) => write_limits_struct(wgt_limits, limits),
         _ => panic!("Calling wgpuDeviceGetLimits() on an invalid device."),
     }
     return false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,14 +279,11 @@ unsafe fn map_surface(
 pub unsafe extern "C" fn wgpuSurfaceGetPreferredFormat(
     surface: id::SurfaceId,
     adapter: id::AdapterId,
-    callback: native::WGPUSurfaceGetPreferredFormatCallback,
-    userdata: *mut std::os::raw::c_void,
-) {
+) -> native::WGPUTextureFormat {
     let preferred_format = match wgc::gfx_select!(adapter => GLOBAL.adapter_get_swap_chain_preferred_format(adapter, surface))
     {
         Ok(format) => conv::to_native_texture_format(format),
         Err(err) => panic!("Could not get preferred swap chain format: {}", err),
     };
-
-    (callback.unwrap())(preferred_format, userdata);
+    return preferred_format;
 }


### PR DESCRIPTION
The most notable changes are:
* The power_preference can now be set in `request_adapter`.
* The descriptor for `request_adapter` now includes required limits. We supported a few limits via the `WGPUDeviceExtras` struc t- these are now removed.
* New methods `wgpuDeviceGetLimits` and `wgpuAdapterGetLimits`.
* The signature of `WGPURequestAdapterCallback` and `WGPURequestDeviceCallback` have changed.
* Struct field rename: compute_stage -> compute.

Tested by running the examples and by running the wgpu-py test suite.