### PR TITLE
Add link to new contributor guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ Automated 32 and 64-bit builds for MacOS, Windows and Linux are available as Git
 ## Usage
 
 This repository contains C-language examples that link to the native library targets and perform basic rendering and computation. Please refer to our [Getting Started](https://github.com/gfx-rs/wgpu-native/wiki/Getting-Started) page at the wiki for more information.
+
+There's also a (small) [contributor guide](https://github.com/gfx-rs/wgpu-native/wiki/Contributing).


### PR DESCRIPTION
I added a small contributor guide to the readme. It's still quite minimal, containing some tips for common tasks, so we should probably expand that over time.