### PR TITLE
Add build for linux-arm7

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -128,7 +128,7 @@ jobs:
       CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: /usr/bin/arm-linux-gnueabihf-gcc
     steps:
     # Common part (same for nearly each build)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Set WGPU_NATIVE_VERSION
@@ -148,7 +148,7 @@ jobs:
       run: make package
     # Upload (same for each build)
     - name: Upload
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: dist
         name: dist

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -117,6 +117,43 @@ jobs:
         name: dist
 
   # -----
+  linux-armv7:
+    # Config
+    name: release - linux-armv7
+    runs-on: ubuntu-latest
+    env:
+      TARGET: armv7-unknown-linux-gnueabihf
+      ARCHIVE_NAME: wgpu-linux-armv7
+      BINDGEN_EXTRA_CLANG_ARGS: -I/usr/arm-linux-gnueabihf/include/
+      CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: /usr/bin/arm-linux-gnueabihf-gcc
+    steps:
+    # Common part (same for nearly each build)
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set WGPU_NATIVE_VERSION
+      run: echo "WGPU_NATIVE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      shell: bash
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ env.TARGET }}
+        profile: minimal
+        override: true
+    # Build
+    - name: Install clang
+      run: sudo apt update && sudo apt install -y gcc-arm-linux-gnueabihf
+    - name: Build
+      run: make package
+    # Upload (same for each build)
+    - name: Upload
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist
+        name: dist
+
+  # -----
   windows-x86_64:
     # Config
     name: release - windows-x86_64
@@ -276,7 +313,7 @@ jobs:
   # plus a file containing the commit sha.
   publish:
     name: Publish Github release
-    needs: [linux-x86_64, linux-i686, windows-x86_64, windows-i686, macos-x86_64, macos-arm64]
+    needs: [linux-x86_64, linux-i686, linux-armv7, windows-x86_64, windows-i686, macos-x86_64, macos-arm64]
     runs-on: ubuntu-18.04
     if: success() && contains(github.ref, 'tags/v')
     steps:


### PR DESCRIPTION
Todo:
* [x] Test the binary on a Raspberry Pi.
* [x] We should probably change the name of the build and artefact.

I'm not very familiar with all the different [architectures that Rust can build](https://doc.rust-lang.org/nightly/rustc/platform-support.html), but from what I understood, armv7 is a good target if one wants to support e.g. Raspberry Pi (versions 2/3/4) . This architecture is 32bit, so a better name would be arm32 or maybe armv7. Thoughts? Also, would this binary run on aarch64 machines (which is armv8, IIUC)?

The CD build on my fork: https://github.com/almarklein/wgpu-native/actions/runs/1589649623

Some links that helped me find the right tweaks:
* https://chacin.dev/blog/cross-compiling-rust-for-the-raspberry-pi/
* https://github.com/rust-lang/rust/issues/28924
* https://reposhub.com/rust/embedded/japaric-rust-cross.html