### PR TITLE
Make windows CD builds use windows-latest

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -118,7 +118,7 @@ jobs:
   windows-x86_64:
     # Config
     name: release - windows-x86_64
-    runs-on: vs2017-win2016
+    runs-on: windows-latest
     env:
       TARGET: x86_64-pc-windows-msvc
       ARCHIVE_NAME: wgpu-windows-x86_64
@@ -157,7 +157,7 @@ jobs:
   windows-i686:
     # Config
     name: release - windows-i686
-    runs-on: vs2017-win2016
+    runs-on: windows-latest
     env:
       TARGET: i686-pc-windows-msvc
       ARCHIVE_NAME: wgpu-windows-i686


### PR DESCRIPTION
GH was showing a warning that the env was deprecated and to be removed in a few months.

CD build on my fork (hooray for being able to manually trigger the CD build on any branch): https://github.com/almarklein/wgpu-native/actions/runs/1589756580