### PR TITLE
`extern "C"` required for C++ compatibility

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -38,6 +38,10 @@ typedef struct WGPUDeviceExtras {
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, const char *msg);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void wgpuDevicePoll(WGPUDevice device, bool force_wait);
 
 void wgpuSetLogCallback(WGPULogCallback callback);
@@ -63,5 +67,9 @@ void wgpuShaderModuleDrop(WGPUShaderModule shaderModule);
 void wgpuCommandBufferDrop(WGPUCommandBuffer commandBuffer);
 void wgpuRenderBundleDrop(WGPURenderBundle renderBundle);
 void wgpuComputePipelineDrop(WGPUComputePipeline computePipeline);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif


### PR DESCRIPTION
Without `extern "C"` a simple C++ program like this will fail to link:
```c++
#include "wgpu.h"
main() { wgpuSetLogLevel(WGPULogLevel_Trace); }
```

See also: #158

I've copied the `extern "C"` stuff from the `webgpu.h` header. Although, I don't understand why they include the function pointer typedefs in the `extern "C"` scope. I'm pretty sure it has no effect, since `extern "C"` only prevents C++ name mangling for linker symbols.