### PR TITLE
Remove difference in EnumConstant type (windows)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,10 +120,6 @@ macro_rules! follow_chain {
     }}};
 }
 
-#[cfg(target_os = "windows")]
-pub type EnumConstant = i32;
-
-#[cfg(not(target_os = "windows"))]
 pub type EnumConstant = u32;
 
 /// Creates a function which maps native constants to wgpu enums.


### PR DESCRIPTION
Referring to #161 

Creating pull request to check CI since it's green without it on windows.