### PR TITLE
Only define EnumConstant=i32 on msvc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,10 +120,10 @@ macro_rules! follow_chain {
     }}};
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", target_env = "msvc"))]
 pub type EnumConstant = i32;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(all(target_os = "windows", target_env = "msvc")))]
 pub type EnumConstant = u32;
 
 /// Creates a function which maps native constants to wgpu enums.


### PR DESCRIPTION
Following up to #161 & #162 :

I encountered this issue again but only when using the gnu toolchain.
Did some searching and found this https://github.com/rust-lang/rust-bindgen/issues/1361
Making i32 specific to MSVC could be a solution.