### PR TITLE
Add device name

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,11 +1,11 @@
 use crate::conv::{map_adapter_options, map_device_descriptor, map_shader_module};
 use crate::{conv, follow_chain, handle_device_error, make_slice, native, OwnedLabel, GLOBAL};
 use lazy_static::lazy_static;
-use std::ffi::CString;
 use std::{
     borrow::Cow,
     collections::HashMap,
     convert::TryInto,
+    ffi::CString,
     marker::PhantomData,
     num::{NonZeroU32, NonZeroU64, NonZeroU8},
     path::Path,


### PR DESCRIPTION
The wgpuAdapterProperties.name field was not working properly because there was the need to allocate a CString, which needs to be freed in some way. I took the approach to create a lazy_static HashMap which tracks the allocated CString by adapter id and prevents allocating the string multiple times. Of course the CString stays inside the hash map until the application exists, but I think this is the best approach without adding additional functions to the api!