### PR TITLE
Show memory report in debug builds

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -70,6 +70,9 @@ void wgpuSetLogLevel(WGPULogLevel level);
 
 uint32_t wgpuGetVersion(void);
 
+// Returns resource usage C string; caller owns the string and must free() it
+char* wgpuGetResourceUsageString();
+
 void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void* const data);
 
 void wgpuBufferDrop(WGPUBuffer buffer);

--- a/src/device.rs
+++ b/src/device.rs
@@ -782,6 +782,8 @@ pub extern "C" fn wgpuSwapChainPresent(swap_chain: id::SurfaceId) {
     let device_id = get_device_from_surface(surface_id);
     gfx_select!(device_id => GLOBAL.surface_present(surface_id))
         .expect("Unable to present swap chain");
+    #[cfg(debug_assertions)]
+    log::debug!("Memory report: {:?}", GLOBAL.generate_report());
 }
 
 #[no_mangle]

--- a/src/device.rs
+++ b/src/device.rs
@@ -779,8 +779,6 @@ pub extern "C" fn wgpuSwapChainPresent(swap_chain: id::SurfaceId) {
     let device_id = get_device_from_surface(surface_id);
     gfx_select!(device_id => GLOBAL.surface_present(surface_id))
         .expect("Unable to present swap chain");
-    #[cfg(debug_assertions)]
-    log::debug!("Memory report: {:?}", GLOBAL.generate_report());
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,14 @@ pub extern "C" fn wgpuCreateInstance(
 }
 
 #[no_mangle]
+pub extern "C" fn wgpuGetResourceUsageString() -> *const std::os::raw::c_char {
+    let c_string = CString::new(format!("{:?}", GLOBAL.generate_report())).unwrap();
+    let ptr = c_string.as_ptr();
+    std::mem::forget(c_string);
+    ptr
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wgpuInstanceCreateSurface(
     _: native::WGPUInstance,
     descriptor: *const native::WGPUSurfaceDescriptor,


### PR DESCRIPTION
`log::debug!()` after `wgpuSwapChainPresent()` which is assumed to be called roughly once per frame. This is useful for detecting memory leaks.

See also: #186