### PR TITLE
Addressed 'unused parameter' warnings

### DIFF
--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -2,8 +2,12 @@
 #include "helper.h"
 #include "webgpu-headers/webgpu.h"
 #include "wgpu.h"
+#include "unused.h"
 
 int main(int argc, char *argv[]) {
+  UNUSED(argc);
+  UNUSED(argv);
+
   initializeLog();
 
   int width = 100;

--- a/examples/framework.c
+++ b/examples/framework.c
@@ -1,5 +1,6 @@
 #include "webgpu-headers/webgpu.h"
 #include "wgpu.h"
+#include "unused.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -31,16 +32,26 @@ WGPUShaderModuleDescriptor load_wgsl(const char *name) {
 void request_adapter_callback(WGPURequestAdapterStatus status,
                               WGPUAdapter received, const char *message,
                               void *userdata) {
+  UNUSED(status);
+  UNUSED(message);
+
   *(WGPUAdapter *)userdata = received;
 }
 
 void request_device_callback(WGPURequestDeviceStatus status,
                              WGPUDevice received, const char *message,
                              void *userdata) {
+  UNUSED(status);
+  UNUSED(message);
+
   *(WGPUDevice *)userdata = received;
 }
 
-void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata) {}
+void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata)
+{
+  UNUSED(status);
+  UNUSED(userdata);
+}
 
 void logCallback(WGPULogLevel level, const char *msg) {
   char *level_str;

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -2,6 +2,7 @@
 #include "wgpu.h"
 
 #include "framework.h"
+#include "unused.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -29,11 +30,15 @@
 
 static void handle_device_lost(WGPUDeviceLostReason reason, char const * message, void * userdata)
 {
+  UNUSED(userdata);
+
   printf("DEVICE LOST (%d): %s\n", reason, message);
 }
 
 static void handle_uncaptured_error(WGPUErrorType type, char const * message, void * userdata)
 {
+  UNUSED(userdata);
+
   printf("UNCAPTURED ERROR (%d): %s\n", type, message);
 }
 

--- a/examples/unused.h
+++ b/examples/unused.h
@@ -1,0 +1,1 @@
+#define UNUSED(x) (void)x


### PR DESCRIPTION
I have applied a fix for numerous 'unused parameter' warnings in the examples:

```
[...]

[ 33%] Building C object CMakeFiles/compute.dir/main.c.o
[ 66%] Building C object CMakeFiles/compute.dir/home/bob/Mozilla/github/wgpu-native/examples/framework.c.o
/home/bob/Mozilla/github/wgpu-native/examples/framework.c: In function ‘request_adapter_callback’:
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:31:56: warning: unused parameter ‘status’ [-Wunused-parameter]
   31 | void request_adapter_callback(WGPURequestAdapterStatus status,
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:32:65: warning: unused parameter ‘message’ [-Wunused-parameter]
   32 |                               WGPUAdapter received, const char *message,
      |                                                     ~~~~~~~~~~~~^~~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c: In function ‘request_device_callback’:
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:37:54: warning: unused parameter ‘status’ [-Wunused-parameter]
   37 | void request_device_callback(WGPURequestDeviceStatus status,
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:38:63: warning: unused parameter ‘message’ [-Wunused-parameter]
   38 |                              WGPUDevice received, const char *message,
      |                                                   ~~~~~~~~~~~~^~~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c: In function ‘readBufferMap’:
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:43:45: warning: unused parameter ‘status’ [-Wunused-parameter]
   43 | void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata) {}
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:43:59: warning: unused parameter ‘userdata’ [-Wunused-parameter]
   43 | void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata) {}
      |                                                     ~~~~~~^~~~~~~~

[...]

[ 33%] Building C object CMakeFiles/triangle.dir/main.c.o
/home/bob/Mozilla/github/wgpu-native/examples/triangle/main.c: In function ‘handle_device_lost’:
/home/bob/Mozilla/github/wgpu-native/examples/triangle/main.c:30:90: warning: unused parameter ‘userdata’ [-Wunused-parameter]
   30 | static void handle_device_lost(WGPUDeviceLostReason reason, char const * message, void * userdata)
      |                                                                                   ~~~~~~~^~~~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/triangle/main.c: In function ‘handle_uncaptured_error’:
/home/bob/Mozilla/github/wgpu-native/examples/triangle/main.c:35:86: warning: unused parameter ‘userdata’ [-Wunused-parameter]
   35 | static void handle_uncaptured_error(WGPUErrorType type, char const * message, void * userdata)
      |                                                                               ~~~~~~~^~~~~~~~
[ 66%] Building C object CMakeFiles/triangle.dir/home/bob/Mozilla/github/wgpu-native/examples/framework.c.o
/home/bob/Mozilla/github/wgpu-native/examples/framework.c: In function ‘request_adapter_callback’:
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:31:56: warning: unused parameter ‘status’ [-Wunused-parameter]
   31 | void request_adapter_callback(WGPURequestAdapterStatus status,
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:32:65: warning: unused parameter ‘message’ [-Wunused-parameter]
   32 |                               WGPUAdapter received, const char *message,
      |                                                     ~~~~~~~~~~~~^~~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c: In function ‘request_device_callback’:
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:37:54: warning: unused parameter ‘status’ [-Wunused-parameter]
   37 | void request_device_callback(WGPURequestDeviceStatus status,
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:38:63: warning: unused parameter ‘message’ [-Wunused-parameter]
   38 |                              WGPUDevice received, const char *message,
      |                                                   ~~~~~~~~~~~~^~~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c: In function ‘readBufferMap’:
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:43:45: warning: unused parameter ‘status’ [-Wunused-parameter]
   43 | void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata) {}
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:43:59: warning: unused parameter ‘userdata’ [-Wunused-parameter]
   43 | void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata) {}
      |                                                     ~~~~~~^~~~~~~~

[...]

/home/bob/Mozilla/github/wgpu-native/examples/capture/main.c:6:14: warning: unused parameter ‘argc’ [-Wunused-parameter]
    6 | int main(int argc, char *argv[]) {
      |          ~~~~^~~~
/home/bob/Mozilla/github/wgpu-native/examples/capture/main.c:6:26: warning: unused parameter ‘argv’ [-Wunused-parameter]
    6 | int main(int argc, char *argv[]) {
      |                    ~~~~~~^~~~~~
[ 66%] Building C object CMakeFiles/capture.dir/home/bob/Mozilla/github/wgpu-native/examples/framework.c.o
/home/bob/Mozilla/github/wgpu-native/examples/framework.c: In function ‘request_adapter_callback’:
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:31:56: warning: unused parameter ‘status’ [-Wunused-parameter]
   31 | void request_adapter_callback(WGPURequestAdapterStatus status,
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:32:65: warning: unused parameter ‘message’ [-Wunused-parameter]
   32 |                               WGPUAdapter received, const char *message,
      |                                                     ~~~~~~~~~~~~^~~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c: In function ‘request_device_callback’:
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:37:54: warning: unused parameter ‘status’ [-Wunused-parameter]
   37 | void request_device_callback(WGPURequestDeviceStatus status,
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:38:63: warning: unused parameter ‘message’ [-Wunused-parameter]
   38 |                              WGPUDevice received, const char *message,
      |                                                   ~~~~~~~~~~~~^~~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c: In function ‘readBufferMap’:
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:43:45: warning: unused parameter ‘status’ [-Wunused-parameter]
   43 | void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata) {}
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/bob/Mozilla/github/wgpu-native/examples/framework.c:43:59: warning: unused parameter ‘userdata’ [-Wunused-parameter]
   43 | void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata) {}
      |                                                     ~~~~~~^~~~~~~~

```