### PR TITLE
Implement some functions, mainly debug ones

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -74,6 +74,11 @@ uint32_t wgpuGetVersion(void);
 char* wgpuGetResourceUsageString();
 
 void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void* const data);
+void wgpuRenderPassEncoderInsertDebugMarkerColor(WGPURenderPassEncoder renderPassEncoder, char const * markerLabel, uint32_t color);
+void wgpuRenderPassEncoderPushDebugGroupColor(WGPURenderPassEncoder renderPassEncoder, char const * groupLabel, uint32_t color);
+
+void wgpuComputePassEncoderInsertDebugMarkerColor(WGPUComputePassEncoder computePassEncoder, char const * markerLabel, uint32_t color);
+void wgpuComputePassEncoderPushDebugGroupColor(WGPUComputePassEncoder computePassEncoder, char const * groupLabel, uint32_t color);
 
 void wgpuBufferDrop(WGPUBuffer buffer);
 void wgpuCommandEncoderDrop(WGPUCommandEncoder commandEncoder);

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -74,11 +74,6 @@ uint32_t wgpuGetVersion(void);
 char* wgpuGetResourceUsageString();
 
 void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void* const data);
-void wgpuRenderPassEncoderInsertDebugMarkerColor(WGPURenderPassEncoder renderPassEncoder, char const * markerLabel, uint32_t color);
-void wgpuRenderPassEncoderPushDebugGroupColor(WGPURenderPassEncoder renderPassEncoder, char const * groupLabel, uint32_t color);
-
-void wgpuComputePassEncoderInsertDebugMarkerColor(WGPUComputePassEncoder computePassEncoder, char const * markerLabel, uint32_t color);
-void wgpuComputePassEncoderPushDebugGroupColor(WGPUComputePassEncoder computePassEncoder, char const * groupLabel, uint32_t color);
 
 void wgpuBufferDrop(WGPUBuffer buffer);
 void wgpuCommandEncoderDrop(WGPUCommandEncoder commandEncoder);

--- a/src/command.rs
+++ b/src/command.rs
@@ -167,8 +167,8 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuCommandEncoderInsertDebugMarker(encoder: id::CommandEncoderId, label: *const c_char) {
-    gfx_select!(encoder => GLOBAL.command_encoder_insert_debug_marker(encoder, CStr::from_ptr(label).to_str().unwrap()))
+pub unsafe extern "C" fn wgpuCommandEncoderInsertDebugMarker(encoder: id::CommandEncoderId, marker_label: *const c_char) {
+    gfx_select!(encoder => GLOBAL.command_encoder_insert_debug_marker(encoder, CStr::from_ptr(marker_label).to_str().unwrap()))
         .expect("Unable to insert debug marker");
 }
 
@@ -179,8 +179,8 @@ pub extern "C" fn wgpuCommandEncoderPopDebugGroup(encoder: id::CommandEncoderId)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuCommandEncoderPushDebugGroup(encoder: id::CommandEncoderId, label: *const c_char) {
-    gfx_select!(encoder => GLOBAL.command_encoder_push_debug_group(encoder, CStr::from_ptr(label).to_str().unwrap()))
+pub unsafe extern "C" fn wgpuCommandEncoderPushDebugGroup(encoder: id::CommandEncoderId, group_label: *const c_char) {
+    gfx_select!(encoder => GLOBAL.command_encoder_push_debug_group(encoder, CStr::from_ptr(group_label).to_str().unwrap()))
         .expect("Unable to push debug group");
 }
 
@@ -282,9 +282,9 @@ pub unsafe extern "C" fn wgpuComputePassEncoderDispatchIndirect(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuComputePassEncoderInsertDebugMarker(pass: id::ComputePassEncoderId, label: *const c_char) {
+pub unsafe extern "C" fn wgpuComputePassEncoderInsertDebugMarker(pass: id::ComputePassEncoderId, marker_label: *const c_char) {
     let pass = pass.as_mut().expect("Compute pass invalid");
-    compute_ffi::wgpu_compute_pass_insert_debug_marker(pass, label, 0);
+    compute_ffi::wgpu_compute_pass_insert_debug_marker(pass, marker_label, 0);
 }
 
 #[no_mangle]
@@ -294,9 +294,9 @@ pub unsafe extern "C" fn wgpuComputePassEncoderPopDebugGroup(pass: id::ComputePa
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuComputePassEncoderPushDebugGroup(pass: id::ComputePassEncoderId, label: *const c_char) {
+pub unsafe extern "C" fn wgpuComputePassEncoderPushDebugGroup(pass: id::ComputePassEncoderId, group_label: *const c_char) {
     let pass = pass.as_mut().expect("Compute pass invalid");
-    compute_ffi::wgpu_compute_pass_push_debug_group(pass, label, 0);
+    compute_ffi::wgpu_compute_pass_push_debug_group(pass, group_label, 0);
 }
 
 #[no_mangle]
@@ -455,9 +455,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetScissorRect(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuRenderPassEncoderInsertDebugMarker(pass: id::RenderPassEncoderId, label: *const c_char) {
+pub unsafe extern "C" fn wgpuRenderPassEncoderInsertDebugMarker(pass: id::RenderPassEncoderId, marker_label: *const c_char) {
     let pass = pass.as_mut().expect("Render pass invalid");
-    render_ffi::wgpu_render_pass_insert_debug_marker(pass, label, 0);
+    render_ffi::wgpu_render_pass_insert_debug_marker(pass, marker_label, 0);
 }
 
 #[no_mangle]
@@ -467,7 +467,7 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderPopDebugGroup(pass: id::RenderPass
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuRenderPassEncoderPushDebugGroup(pass: id::RenderPassEncoderId, label: *const c_char) {
+pub unsafe extern "C" fn wgpuRenderPassEncoderPushDebugGroup(pass: id::RenderPassEncoderId, group_label: *const c_char) {
     let pass = pass.as_mut().expect("Render pass invalid");
-    render_ffi::wgpu_render_pass_push_debug_group(pass, label, 0);
+    render_ffi::wgpu_render_pass_push_debug_group(pass, group_label, 0);
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,7 @@
 use crate::{conv, make_slice, native, OwnedLabel, GLOBAL};
 use std::{borrow::Cow, num::NonZeroU64};
+use std::ffi::CStr;
+use std::os::raw::c_char;
 use wgc::{
     command::{compute_ffi, render_ffi},
     gfx_select, id,
@@ -165,6 +167,24 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wgpuCommandEncoderInsertDebugMarker(encoder: id::CommandEncoderId, label: *const c_char) {
+    gfx_select!(encoder => GLOBAL.command_encoder_insert_debug_marker(encoder, CStr::from_ptr(label).to_str().unwrap()))
+        .expect("Unable to insert debug marker");
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuCommandEncoderPopDebugGroup(encoder: id::CommandEncoderId) {
+    gfx_select!(encoder => GLOBAL.command_encoder_pop_debug_group(encoder))
+        .expect("Unable to pop debug group");
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuCommandEncoderPushDebugGroup(encoder: id::CommandEncoderId, label: *const c_char) {
+    gfx_select!(encoder => GLOBAL.command_encoder_push_debug_group(encoder, CStr::from_ptr(label).to_str().unwrap()))
+        .expect("Unable to push debug group");
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wgpuComputePassEncoderEnd(pass: id::ComputePassEncoderId) {
     let pass = Box::from_raw(pass);
     let encoder_id = pass.parent_id();
@@ -259,6 +279,36 @@ pub unsafe extern "C" fn wgpuComputePassEncoderDispatchIndirect(
 ) {
     let pass = pass.as_mut().expect("Compute pass invalid");
     compute_ffi::wgpu_compute_pass_dispatch_indirect(pass, indirect_buffer, indirect_offset);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePassEncoderInsertDebugMarker(pass: id::ComputePassEncoderId, label: *const c_char) {
+    let pass = pass.as_mut().expect("Compute pass invalid");
+    compute_ffi::wgpu_compute_pass_insert_debug_marker(pass, label, 0);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePassEncoderInsertDebugMarkerColor(pass: id::ComputePassEncoderId, label: *const c_char, color: u32) {
+    let pass = pass.as_mut().expect("Compute pass invalid");
+    compute_ffi::wgpu_compute_pass_insert_debug_marker(pass, label, color);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePassEncoderPopDebugGroup(pass: id::ComputePassEncoderId) {
+    let pass = pass.as_mut().expect("Compute pass invalid");
+    compute_ffi::wgpu_compute_pass_pop_debug_group(pass);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePassEncoderPushDebugGroup(pass: id::ComputePassEncoderId, label: *const c_char) {
+    let pass = pass.as_mut().expect("Compute pass invalid");
+    compute_ffi::wgpu_compute_pass_push_debug_group(pass, label, 0);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePassEncoderPushDebugGroupColor(pass: id::ComputePassEncoderId, label: *const c_char, color: u32) {
+    let pass = pass.as_mut().expect("Compute pass invalid");
+    compute_ffi::wgpu_compute_pass_push_debug_group(pass, label, color);
 }
 
 #[no_mangle]
@@ -414,4 +464,34 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetScissorRect(
 ) {
     let pass = pass.as_mut().expect("Render pass invalid");
     render_ffi::wgpu_render_pass_set_scissor_rect(pass, x, y, w, h);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPassEncoderInsertDebugMarker(pass: id::RenderPassEncoderId, label: *const c_char) {
+    let pass = pass.as_mut().expect("Render pass invalid");
+    render_ffi::wgpu_render_pass_insert_debug_marker(pass, label, 0);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPassEncoderInsertDebugMarkerColor(pass: id::RenderPassEncoderId, label: *const c_char, color: u32) {
+    let pass = pass.as_mut().expect("Render pass invalid");
+    render_ffi::wgpu_render_pass_insert_debug_marker(pass, label, color);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPassEncoderPopDebugGroup(pass: id::RenderPassEncoderId) {
+    let pass = pass.as_mut().expect("Render pass invalid");
+    render_ffi::wgpu_render_pass_pop_debug_group(pass);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPassEncoderPushDebugGroup(pass: id::RenderPassEncoderId, label: *const c_char) {
+    let pass = pass.as_mut().expect("Render pass invalid");
+    render_ffi::wgpu_render_pass_push_debug_group(pass, label, 0);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPassEncoderPushDebugGroupColor(pass: id::RenderPassEncoderId, label: *const c_char, color: u32) {
+    let pass = pass.as_mut().expect("Render pass invalid");
+    render_ffi::wgpu_render_pass_push_debug_group(pass, label, color);
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -288,12 +288,6 @@ pub unsafe extern "C" fn wgpuComputePassEncoderInsertDebugMarker(pass: id::Compu
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuComputePassEncoderInsertDebugMarkerColor(pass: id::ComputePassEncoderId, label: *const c_char, color: u32) {
-    let pass = pass.as_mut().expect("Compute pass invalid");
-    compute_ffi::wgpu_compute_pass_insert_debug_marker(pass, label, color);
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn wgpuComputePassEncoderPopDebugGroup(pass: id::ComputePassEncoderId) {
     let pass = pass.as_mut().expect("Compute pass invalid");
     compute_ffi::wgpu_compute_pass_pop_debug_group(pass);
@@ -303,12 +297,6 @@ pub unsafe extern "C" fn wgpuComputePassEncoderPopDebugGroup(pass: id::ComputePa
 pub unsafe extern "C" fn wgpuComputePassEncoderPushDebugGroup(pass: id::ComputePassEncoderId, label: *const c_char) {
     let pass = pass.as_mut().expect("Compute pass invalid");
     compute_ffi::wgpu_compute_pass_push_debug_group(pass, label, 0);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn wgpuComputePassEncoderPushDebugGroupColor(pass: id::ComputePassEncoderId, label: *const c_char, color: u32) {
-    let pass = pass.as_mut().expect("Compute pass invalid");
-    compute_ffi::wgpu_compute_pass_push_debug_group(pass, label, color);
 }
 
 #[no_mangle]
@@ -473,12 +461,6 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderInsertDebugMarker(pass: id::Render
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuRenderPassEncoderInsertDebugMarkerColor(pass: id::RenderPassEncoderId, label: *const c_char, color: u32) {
-    let pass = pass.as_mut().expect("Render pass invalid");
-    render_ffi::wgpu_render_pass_insert_debug_marker(pass, label, color);
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn wgpuRenderPassEncoderPopDebugGroup(pass: id::RenderPassEncoderId) {
     let pass = pass.as_mut().expect("Render pass invalid");
     render_ffi::wgpu_render_pass_pop_debug_group(pass);
@@ -488,10 +470,4 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderPopDebugGroup(pass: id::RenderPass
 pub unsafe extern "C" fn wgpuRenderPassEncoderPushDebugGroup(pass: id::RenderPassEncoderId, label: *const c_char) {
     let pass = pass.as_mut().expect("Render pass invalid");
     render_ffi::wgpu_render_pass_push_debug_group(pass, label, 0);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn wgpuRenderPassEncoderPushDebugGroupColor(pass: id::RenderPassEncoderId, label: *const c_char, color: u32) {
-    let pass = pass.as_mut().expect("Render pass invalid");
-    render_ffi::wgpu_render_pass_push_debug_group(pass, label, color);
 }


### PR DESCRIPTION
Implemented:
- `insert debug marker`, `push debug group`, `pop debug group` functions
- `get bind group layout` functions
- empty implementation of `device destroy` function

WebGPU doesn't have the color parameter for debug markers and groups but WGPU does (even tho it seems like colors are not implemented currently) so I added new functions for them in `wgpu.h`. Hopefully that's fine.