### PR TITLE
Implement VERTEX_WRITABLE_STORAGE native feature

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -14,7 +14,8 @@ typedef enum WGPUNativeSType {
 
 typedef enum WGPUNativeFeature {
     WGPUNativeFeature_PUSH_CONSTANTS = 0x04000000,
-    WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 0x10000000
+    WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 0x10000000,
+    WGPUNativeFeature_VERTEX_WRITABLE_STORAGE = 0x1000000000
 } WGPUNativeFeature;
 
 typedef enum WGPULogLevel {

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -846,8 +846,6 @@ pub fn features_to_slice(features: wgt::Features) -> Vec<native::WGPUFeatureName
 pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
     use wgt::Features;
 
-    let a = native::WGPUNativeFeature_PUSH_CONSTANTS as u64;
-
     match feature {
         native::WGPUFeatureName_DepthClipControl => Some(Features::DEPTH_CLIP_CONTROL),
         native::WGPUFeatureName_Depth24UnormStencil8 => Some(Features::DEPTH24UNORM_STENCIL8),

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -830,10 +830,13 @@ pub fn features_to_slice(features: wgt::Features) -> Vec<native::WGPUFeatureName
 
     // extras
     if features.contains(wgt::Features::PUSH_CONSTANTS) {
-        temp.push(native::WGPUNativeFeature_PUSH_CONSTANTS);
+        temp.push(native::WGPUNativeFeature_PUSH_CONSTANTS as u32);
     }
     if features.contains(wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES) {
-        temp.push(native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES);
+        temp.push(native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES as u32);
+    }
+    if features.contains(wgt::Features::VERTEX_WRITABLE_STORAGE) {
+        temp.push(native::WGPUNativeFeature_VERTEX_WRITABLE_STORAGE as u32);
     }
 
     temp
@@ -855,10 +858,12 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUFeatureName_IndirectFirstInstance => Some(Features::INDIRECT_FIRST_INSTANCE),
 
         // extras
-        native::WGPUNativeFeature_PUSH_CONSTANTS => Some(Features::PUSH_CONSTANTS),
-        native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES => Some(Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES),
+        _ => match feature as u64 {
+            native::WGPUNativeFeature_PUSH_CONSTANTS => Some(Features::PUSH_CONSTANTS),
+            native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES => Some(Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES),
+            native::WGPUNativeFeature_VERTEX_WRITABLE_STORAGE => Some(Features::VERTEX_WRITABLE_STORAGE),
 
-
-        _ => None,
+            _ => None,
+        },
     }
 }

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -830,13 +830,13 @@ pub fn features_to_slice(features: wgt::Features) -> Vec<native::WGPUFeatureName
 
     // extras
     if features.contains(wgt::Features::PUSH_CONSTANTS) {
-        temp.push(native::WGPUNativeFeature_PUSH_CONSTANTS as u32);
+        temp.push(native::WGPUNativeFeature_PUSH_CONSTANTS.try_into().unwrap());
     }
     if features.contains(wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES) {
-        temp.push(native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES as u32);
+        temp.push(native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES.try_into().unwrap());
     }
     if features.contains(wgt::Features::VERTEX_WRITABLE_STORAGE) {
-        temp.push(native::WGPUNativeFeature_VERTEX_WRITABLE_STORAGE as u32);
+        temp.push(native::WGPUNativeFeature_VERTEX_WRITABLE_STORAGE.try_into().unwrap());
     }
 
     temp
@@ -845,6 +845,8 @@ pub fn features_to_slice(features: wgt::Features) -> Vec<native::WGPUFeatureName
 #[rustfmt::skip]
 pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
     use wgt::Features;
+
+    let a = native::WGPUNativeFeature_PUSH_CONSTANTS as u64;
 
     match feature {
         native::WGPUFeatureName_DepthClipControl => Some(Features::DEPTH_CLIP_CONTROL),
@@ -858,7 +860,7 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUFeatureName_IndirectFirstInstance => Some(Features::INDIRECT_FIRST_INSTANCE),
 
         // extras
-        _ => match feature as u64 {
+        _ => match feature as native::WGPUNativeFeature {
             native::WGPUNativeFeature_PUSH_CONSTANTS => Some(Features::PUSH_CONSTANTS),
             native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES => Some(Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES),
             native::WGPUNativeFeature_VERTEX_WRITABLE_STORAGE => Some(Features::VERTEX_WRITABLE_STORAGE),

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -223,6 +223,12 @@ pub fn map_device_descriptor<'a>(
         {
             features |= wgt::Features::PUSH_CONSTANTS
         }
+        if (extras.nativeFeatures
+            & native::WGPUNativeFeature_VERTEX_WRITABLE_STORAGE)
+            > 0
+        {
+            features |= wgt::Features::VERTEX_WRITABLE_STORAGE;
+        }
         return (
             wgt::DeviceDescriptor {
                 label: OwnedLabel::new(extras.label).into_cow(),


### PR DESCRIPTION
Support for enabling `VERTEX_WRITABLE_STORAGE` native feature.
This bumps the enum size from 32 bit to 64 bit but I don't think there is any way around this.