### PR TITLE
Implement `wgpuGenerateReport`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,7 @@ name = "wgpu-native"
 version = "0.6.0"
 dependencies = [
  "bindgen",
+ "cfg_aliases",
  "lazy_static",
  "log",
  "naga",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
 default = []
-#metal-auto-capture = ["gfx-backend-metal/auto-capture"]
-#vulkan-portability = ["wgc/gfx-backend-vulkan"]
+angle = ["wgc/angle"]
+vulkan-portability = ["wgc/vulkan-portability"]
 
 [dependencies.wgc]
 package = "wgpu-core"
@@ -51,6 +51,7 @@ features = ["spv-in"]
 
 [build-dependencies]
 bindgen = "0.60.1"
+cfg_aliases = "0.1"
 
 [workspace]
 resolver = "2"

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,27 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
+    // Setup cfg aliases
+    cfg_aliases::cfg_aliases! {
+        // Vendors/systems
+        wasm: { target_arch = "wasm32" },
+        apple: { any(target_os = "ios", target_os = "macos") },
+        unix_wo_apple: {all(unix, not(apple))},
+
+        // Backends
+        vulkan: { all(not(wasm), any(windows, unix_wo_apple, feature = "vulkan-portability")) },
+        metal: { all(not(wasm), apple) },
+        dx12: { all(not(wasm), windows) },
+        dx11: { all(not(wasm), windows) },
+        gl: {
+            any(
+                unix_wo_apple,
+                feature = "angle",
+                wasm
+            )
+        },
+    }
+
     println!("cargo:rerun-if-changed=ffi/webgpu-headers/webgpu.h");
     println!("cargo:rerun-if-changed=ffi/wgpu.h");
 

--- a/examples/framework.c
+++ b/examples/framework.c
@@ -1,6 +1,6 @@
+#include "unused.h"
 #include "webgpu-headers/webgpu.h"
 #include "wgpu.h"
-#include "unused.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -80,4 +80,53 @@ void logCallback(WGPULogLevel level, const char *msg) {
 void initializeLog() {
   wgpuSetLogCallback(logCallback);
   wgpuSetLogLevel(WGPULogLevel_Warn);
+}
+
+#define printStorageReport(report, prefix)                                     \
+  printf("%snumOccupied=%zu\n", prefix, report.numOccupied);                   \
+  printf("%snumVacant=%zu\n", prefix, report.numVacant);                       \
+  printf("%snumError=%zu\n", prefix, report.numError);                         \
+  printf("%selementSize=%zu\n", prefix, report.elementSize)
+
+#define printHubReport(report, prefix)                                         \
+  printStorageReport(report.adapters, prefix "adapter.");                      \
+  printStorageReport(report.devices, prefix "devices.");                       \
+  printStorageReport(report.pipelineLayouts, prefix "pipelineLayouts.");       \
+  printStorageReport(report.shaderModules, prefix "shaderModules.");           \
+  printStorageReport(report.bindGroupLayouts, prefix "bindGroupLayouts.");     \
+  printStorageReport(report.bindGroups, prefix "bindGroups.");                 \
+  printStorageReport(report.commandBuffers, prefix "commandBuffers.");         \
+  printStorageReport(report.renderBundles, prefix "renderBundles.");           \
+  printStorageReport(report.renderPipelines, prefix "renderPipelines.");       \
+  printStorageReport(report.computePipelines, prefix "computePipelines.");     \
+  printStorageReport(report.querySets, prefix "querySets.");                   \
+  printStorageReport(report.textures, prefix "textures.");                     \
+  printStorageReport(report.textureViews, prefix "textureViews.");             \
+  printStorageReport(report.samplers, prefix "samplers.")
+
+void printGlobalReport(WGPUGlobalReport report) {
+  printf("struct WGPUGlobalReport {\n");
+  printStorageReport(report.surfaces, "\tsurfaces.");
+
+  switch (report.backendType) {
+  case WGPUBackendType_D3D11:
+    printHubReport(report.dx11, "\tdx11.");
+    break;
+  case WGPUBackendType_D3D12:
+    printHubReport(report.dx12, "\tdx12.");
+    break;
+  case WGPUBackendType_Metal:
+    printHubReport(report.metal, "\tmetal.");
+    break;
+  case WGPUBackendType_Vulkan:
+    printHubReport(report.vulkan, "\tvulkan.");
+    break;
+  case WGPUBackendType_OpenGL:
+    printHubReport(report.gl, "\tgl.");
+    break;
+  default:
+    printf("WARN:printGlobalReport: invalid backened type: %d",
+           report.backendType);
+  }
+  printf("}\n");
 }

--- a/examples/framework.h
+++ b/examples/framework.h
@@ -13,3 +13,5 @@ void request_device_callback(WGPURequestDeviceStatus status,
 void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata);
 
 void initializeLog();
+
+void printGlobalReport(WGPUGlobalReport report);

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -48,9 +48,9 @@ static void handleGlfwKey(GLFWwindow *window, int key, int scancode, int action,
   UNUSED(mods);
 
   if (key == GLFW_KEY_R && (action == GLFW_PRESS || action == GLFW_REPEAT)) {
-    char *usage = wgpuGetResourceUsageString();
-    printf("%s\n", usage);
-    WGPU_FREE(char, usage, 1);
+    WGPUGlobalReport report;
+    wgpuGenerateReport(&report);
+    printGlobalReport(report);
   }
 }
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -9,10 +9,11 @@
 // first parameter `type` has to be type of derefrenced value
 // for example ->
 //
-//      char* str = wgpuGetResourceUsageString();
-//      WGPU_FREE(char, str, 1); // notice `char` instead of `char *`
+//      size_t count;
+//      WGPUTextureFormat* formats = wgpuSurfaceGetSupportedFormats(surface, adapter, &count);
+//      WGPU_FREE(WGPUTextureFormat, str, count); // notice `WGPUTextureFormat` instead of `WGPUTextureFormat *`
 //
-#define WGPU_FREE(type, ptr, count) wgpuFree(ptr, count * sizeof(type), _Alignof(type))
+#define WGPU_FREE(type, ptr, len) wgpuFree(ptr, len * sizeof(type), _Alignof(type))
 
 typedef enum WGPUNativeSType {
     // Start at 6 to prevent collisions with webgpu STypes
@@ -74,11 +75,48 @@ typedef struct WGPUWrappedSubmissionIndex {
     WGPUSubmissionIndex submissionIndex;
 } WGPUWrappedSubmissionIndex;
 
+typedef struct WGPUStorageReport {
+    size_t numOccupied;
+    size_t numVacant;
+    size_t numError;
+    size_t elementSize;
+} WGPUStorageReport;
+
+typedef struct WGPUHubReport {
+    WGPUStorageReport adapters;
+    WGPUStorageReport devices;
+    WGPUStorageReport pipelineLayouts;
+    WGPUStorageReport shaderModules;
+    WGPUStorageReport bindGroupLayouts;
+    WGPUStorageReport bindGroups;
+    WGPUStorageReport commandBuffers;
+    WGPUStorageReport renderBundles;
+    WGPUStorageReport renderPipelines;
+    WGPUStorageReport computePipelines;
+    WGPUStorageReport querySets;
+    WGPUStorageReport buffers;
+    WGPUStorageReport textures;
+    WGPUStorageReport textureViews;
+    WGPUStorageReport samplers;
+} WGPUHubReport;
+
+typedef struct WGPUGlobalReport {
+    WGPUStorageReport surfaces;
+    WGPUBackendType backendType;
+    WGPUHubReport vulkan;
+    WGPUHubReport metal;
+    WGPUHubReport dx12;
+    WGPUHubReport dx11;
+    WGPUHubReport gl;
+} WGPUGlobalReport;
+
 typedef void (*WGPULogCallback)(WGPULogLevel level, const char *msg);
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+void wgpuGenerateReport(WGPUGlobalReport * report);
 
 WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, uint32_t commandCount, WGPUCommandBuffer const * commands);
 
@@ -90,10 +128,6 @@ void wgpuSetLogCallback(WGPULogCallback callback);
 void wgpuSetLogLevel(WGPULogLevel level);
 
 uint32_t wgpuGetVersion(void);
-
-// Returns resource usage C string
-// caller owns the string and must WGPU_FREE() it
-char* wgpuGetResourceUsageString();
 
 // Returns slice of supported texture formats
 // caller owns the formats slice and must WGPU_FREE() it

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -554,3 +554,70 @@ pub fn map_stencil_face_state(value: native::WGPUStencilFaceState) -> wgt::Stenc
         pass_op: map_stencil_operation(value.passOp).unwrap(),
     }
 }
+
+pub fn map_storage_report(report: wgc::hub::StorageReport) -> native::WGPUStorageReport {
+    native::WGPUStorageReport {
+        numOccupied: report.num_occupied,
+        numVacant: report.num_error,
+        numError: report.num_error,
+        elementSize: report.element_size,
+    }
+}
+
+pub fn map_hub_report(report: wgc::hub::HubReport) -> native::WGPUHubReport {
+    native::WGPUHubReport {
+        adapters: map_storage_report(report.adapters),
+        devices: map_storage_report(report.devices),
+        pipelineLayouts: map_storage_report(report.pipeline_layouts),
+        shaderModules: map_storage_report(report.shader_modules),
+        bindGroupLayouts: map_storage_report(report.bind_group_layouts),
+        bindGroups: map_storage_report(report.bind_groups),
+        commandBuffers: map_storage_report(report.command_buffers),
+        renderBundles: map_storage_report(report.render_bundles),
+        renderPipelines: map_storage_report(report.render_pipelines),
+        computePipelines: map_storage_report(report.compute_pipelines),
+        querySets: map_storage_report(report.query_sets),
+        buffers: map_storage_report(report.buffers),
+        textures: map_storage_report(report.textures),
+        textureViews: map_storage_report(report.texture_views),
+        samplers: map_storage_report(report.samplers),
+    }
+}
+
+#[inline]
+pub unsafe fn write_global_report(
+    native_report: &mut native::WGPUGlobalReport,
+    report: wgc::hub::GlobalReport,
+) {
+    native_report.surfaces = map_storage_report(report.surfaces);
+
+    #[cfg(vulkan)]
+    if let Some(vulkan) = report.vulkan {
+        native_report.vulkan = map_hub_report(vulkan);
+        native_report.backendType = native::WGPUBackendType_Vulkan;
+    }
+
+    #[cfg(metal)]
+    if let Some(metal) = report.metal {
+        native_report.metal = map_hub_report(metal);
+        native_report.backendType = native::WGPUBackendType_Metal;
+    }
+
+    #[cfg(dx12)]
+    if let Some(dx12) = report.dx12 {
+        native_report.dx12 = map_hub_report(dx12);
+        native_report.backendType = native::WGPUBackendType_D3D12;
+    }
+
+    #[cfg(dx11)]
+    if let Some(dx11) = report.dx11 {
+        native_report.dx11 = map_hub_report(dx11);
+        native_report.backendType = native::WGPUBackendType_D3D11;
+    }
+
+    #[cfg(gl)]
+    if let Some(gl) = report.gl {
+        native_report.gl = map_hub_report(gl);
+        native_report.backendType = native::WGPUBackendType_OpenGL;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,14 +214,6 @@ pub extern "C" fn wgpuCreateInstance(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuGetResourceUsageString() -> *const std::os::raw::c_char {
-    let c_string = CString::new(format!("{:?}", GLOBAL.generate_report())).unwrap();
-    let ptr = c_string.as_ptr();
-    std::mem::forget(c_string);
-    ptr
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn wgpuInstanceCreateSurface(
     _: native::WGPUInstance,
     descriptor: *const native::WGPUSurfaceDescriptor,
@@ -347,6 +339,11 @@ pub unsafe extern "C" fn wgpuSurfaceGetSupportedFormats(
     let ptr = native_formats.as_ptr();
     std::mem::forget(native_formats);
     ptr
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuGenerateReport(native_report: &mut native::WGPUGlobalReport) {
+    conv::write_global_report(native_report, GLOBAL.generate_report());
 }
 
 struct DeviceCallback<T> {


### PR DESCRIPTION
replaces `wgpuGetResourceUsageString`

string returned by `wgpuGetResourceUsageString` had to be parsed by wrapper into a language native struct.
populating a struct & accessing the fields directly is much better.