### PR TITLE
correctly handle nullable arguments in functions

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -152,7 +152,7 @@ def check_rust_wrapper_args():
                     if argname in funcs[funcname]:
                         # This arg is a pointer in C, so we must make it a ref or pointer
                         c_arg = funcs[funcname][argname]
-                        ok = typ.startswith(("&", "*"))
+                        ok = typ.startswith(("&", "*", "Option<&"))
                         message = f"  {'✔' if ok else '✖'} {argname}: {typ}"
                         print(message)
                         if not ok:

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,12 +10,15 @@ use wgc::{
 #[no_mangle]
 pub unsafe extern "C" fn wgpuCommandEncoderFinish(
     command_encoder: native::WGPUCommandEncoder,
-    descriptor: &native::WGPUCommandBufferDescriptor,
+    descriptor: Option<&native::WGPUCommandBufferDescriptor>,
 ) -> native::WGPUCommandBuffer {
     let command_encoder = command_encoder.expect("invalid command encoder");
 
-    let desc = wgt::CommandBufferDescriptor {
-        label: OwnedLabel::new(descriptor.label).into_cow(),
+    let desc = match descriptor {
+        Some(descriptor) => wgt::CommandBufferDescriptor {
+            label: OwnedLabel::new(descriptor.label).into_cow(),
+        },
+        None => wgt::CommandBufferDescriptor::default(),
     };
 
     let (id, error) =
@@ -125,12 +128,15 @@ pub extern "C" fn wgpuCommandEncoderCopyBufferToTexture(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuCommandEncoderBeginComputePass(
     command_encoder: native::WGPUCommandEncoder,
-    descriptor: &native::WGPUComputePassDescriptor,
+    descriptor: Option<&native::WGPUComputePassDescriptor>,
 ) -> native::WGPUComputePassEncoder {
     let command_encoder = command_encoder.expect("invalid command encoder");
 
-    let desc = wgc::command::ComputePassDescriptor {
-        label: OwnedLabel::new(descriptor.label).into_cow(),
+    let desc = match descriptor {
+        Some(descriptor) => wgc::command::ComputePassDescriptor {
+            label: OwnedLabel::new(descriptor.label).into_cow(),
+        },
+        None => wgc::command::ComputePassDescriptor::default(),
     };
     let pass = wgc::command::ComputePass::new(command_encoder, &desc);
     Box::into_raw(Box::new(pass))


### PR DESCRIPTION
- [`descriptor` is nullable in `wgpuCommandEncoderBeginComputePass`](https://github.com/webgpu-native/webgpu-headers/blob/64db862b70cee7a5a6dc89dc7d920a0300125f4a/webgpu.h#L1412)
- [`descriptor` is nullable in `wgpuCommandEncoderFinish`](https://github.com/webgpu-native/webgpu-headers/blob/64db862b70cee7a5a6dc89dc7d920a0300125f4a/webgpu.h#L1419)
- [`descriptor` is nullable in `wgpuDeviceCreateCommandEncoder`](https://github.com/webgpu-native/webgpu-headers/blob/64db862b70cee7a5a6dc89dc7d920a0300125f4a/webgpu.h#L1448)
- [`descriptor` is nullable in `wgpuDeviceCreateSampler`](https://github.com/webgpu-native/webgpu-headers/blob/64db862b70cee7a5a6dc89dc7d920a0300125f4a/webgpu.h#L1456)
- [`descriptor` is nullable in `wgpuTextureCreateView`](https://github.com/webgpu-native/webgpu-headers/blob/64db862b70cee7a5a6dc89dc7d920a0300125f4a/webgpu.h#L1550)