### PR TITLE
remove `WGPUDeviceExtras.{nativeFeatures, label}`

### DIFF
--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -1,8 +1,8 @@
 #include "framework.h"
 #include "helper.h"
+#include "unused.h"
 #include "webgpu-headers/webgpu.h"
 #include "wgpu.h"
-#include "unused.h"
 
 int main(int argc, char *argv[]) {
   UNUSED(argc);
@@ -22,34 +22,25 @@ int main(int argc, char *argv[]) {
                              request_adapter_callback, (void *)&adapter);
 
   WGPUDevice device;
-  wgpuAdapterRequestDevice(
-      adapter,
-      &(WGPUDeviceDescriptor){
-          .nextInChain =
-              (const WGPUChainedStruct *)&(WGPUDeviceExtras){
-                  .chain =
-                      (WGPUChainedStruct){
-                          .next = NULL,
-                          .sType = (WGPUSType)WGPUSType_DeviceExtras,
-                      },
-                  .label = "Device",
-                  .tracePath = NULL,
-              },
-          .requiredLimits =
-              &(WGPURequiredLimits){
-                  .nextInChain = NULL,
-                  .limits =
-                      (WGPULimits){
-                          .maxBindGroups = 1,
-                      },
-              },
-          .defaultQueue =
-            (WGPUQueueDescriptor){
-                .nextInChain = NULL,
-                .label = NULL,
-            },
-      },
-      request_device_callback, (void *)&device);
+  wgpuAdapterRequestDevice(adapter,
+                           &(WGPUDeviceDescriptor){
+                               .nextInChain = NULL,
+                               .label = "Device",
+                               .requiredLimits =
+                                   &(WGPURequiredLimits){
+                                       .nextInChain = NULL,
+                                       .limits =
+                                           (WGPULimits){
+                                               .maxBindGroups = 1,
+                                           },
+                                   },
+                               .defaultQueue =
+                                   (WGPUQueueDescriptor){
+                                       .nextInChain = NULL,
+                                       .label = NULL,
+                                   },
+                           },
+                           request_device_callback, (void *)&device);
 
   BufferDimensions bufferDimensions = buffer_dimensions_new(width, height);
   uint64_t bufferSize =

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -21,35 +21,25 @@ int main() {
                              request_adapter_callback, (void *)&adapter);
 
   WGPUDevice device;
-  wgpuAdapterRequestDevice(
-      adapter,
-      &(WGPUDeviceDescriptor){
-          .nextInChain =
-              (const WGPUChainedStruct *)&(WGPUDeviceExtras){
-                  .chain =
-                      (WGPUChainedStruct){
-                          .next = NULL,
-                          .sType = (WGPUSType)WGPUSType_DeviceExtras,
-                      },
-
-                  .label = "Device",
-                  .tracePath = NULL,
-              },
-          .requiredLimits =
-              &(WGPURequiredLimits){
-                  .nextInChain = NULL,
-                  .limits =
-                      (WGPULimits){
-                          .maxBindGroups = 1,
-                      },
-              },
-          .defaultQueue =
-            (WGPUQueueDescriptor){
-                .nextInChain = NULL,
-                .label = NULL,
-            },
-      },
-      request_device_callback, (void *)&device);
+  wgpuAdapterRequestDevice(adapter,
+                           &(WGPUDeviceDescriptor){
+                               .nextInChain = NULL,
+                               .label = "Device",
+                               .requiredLimits =
+                                   &(WGPURequiredLimits){
+                                       .nextInChain = NULL,
+                                       .limits =
+                                           (WGPULimits){
+                                               .maxBindGroups = 1,
+                                           },
+                                   },
+                               .defaultQueue =
+                                   (WGPUQueueDescriptor){
+                                       .nextInChain = NULL,
+                                       .label = NULL,
+                                   },
+                           },
+                           request_device_callback, (void *)&device);
 
   WGPUShaderModuleDescriptor shaderSource = load_wgsl("shader.wgsl");
   WGPUShaderModule shader = wgpuDeviceCreateShaderModule(device, &shaderSource);

--- a/examples/framework.c
+++ b/examples/framework.c
@@ -47,8 +47,7 @@ void request_device_callback(WGPURequestDeviceStatus status,
   *(WGPUDevice *)userdata = received;
 }
 
-void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata)
-{
+void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata) {
   UNUSED(status);
   UNUSED(userdata);
 }

--- a/examples/helper.h
+++ b/examples/helper.h
@@ -1,3 +1,4 @@
+#include <stddef.h>
 
 typedef struct BufferDimensions {
   size_t width;

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -28,21 +28,22 @@
 #endif
 #include <GLFW/glfw3native.h>
 
-static void handle_device_lost(WGPUDeviceLostReason reason, char const * message, void * userdata)
-{
+static void handle_device_lost(WGPUDeviceLostReason reason, char const *message,
+                               void *userdata) {
   UNUSED(userdata);
 
   printf("DEVICE LOST (%d): %s\n", reason, message);
 }
 
-static void handle_uncaptured_error(WGPUErrorType type, char const * message, void * userdata)
-{
+static void handle_uncaptured_error(WGPUErrorType type, char const *message,
+                                    void *userdata) {
   UNUSED(userdata);
 
   printf("UNCAPTURED ERROR (%d): %s\n", type, message);
 }
 
-static void handleGlfwKey(GLFWwindow *window, int key, int scancode, int action, int mods) {
+static void handleGlfwKey(GLFWwindow *window, int key, int scancode, int action,
+                          int mods) {
   UNUSED(window);
   UNUSED(scancode);
   UNUSED(mods);
@@ -104,7 +105,8 @@ int main() {
         &(WGPUSurfaceDescriptor){
             .label = NULL,
             .nextInChain =
-                (const WGPUChainedStruct *)&(WGPUSurfaceDescriptorFromXlibWindow){
+                (const WGPUChainedStruct *)&(
+                    WGPUSurfaceDescriptorFromXlibWindow){
                     .chain =
                         (WGPUChainedStruct){
                             .next = NULL,
@@ -173,34 +175,25 @@ int main() {
   printAdapterFeatures(adapter);
 
   WGPUDevice device;
-  wgpuAdapterRequestDevice(
-      adapter,
-      &(WGPUDeviceDescriptor){
-          .nextInChain =
-              (const WGPUChainedStruct *)&(WGPUDeviceExtras){
-                  .chain =
-                      (WGPUChainedStruct){
-                          .next = NULL,
-                          .sType = WGPUSType_DeviceExtras,
-                      },
-                  .label = "Device",
-                  .tracePath = NULL,
-              },
-          .requiredLimits =
-              &(WGPURequiredLimits){
-                  .nextInChain = NULL,
-                  .limits =
-                      (WGPULimits){
-                          .maxBindGroups = 1,
-                      },
-              },
-          .defaultQueue =
-            (WGPUQueueDescriptor){
-                .nextInChain = NULL,
-                .label = NULL,
-            },
-      },
-      request_device_callback, (void *)&device);
+  wgpuAdapterRequestDevice(adapter,
+                           &(WGPUDeviceDescriptor){
+                               .nextInChain = NULL,
+                               .label = "Device",
+                               .requiredLimits =
+                                   &(WGPURequiredLimits){
+                                       .nextInChain = NULL,
+                                       .limits =
+                                           (WGPULimits){
+                                               .maxBindGroups = 1,
+                                           },
+                                   },
+                               .defaultQueue =
+                                   (WGPUQueueDescriptor){
+                                       .nextInChain = NULL,
+                                       .label = NULL,
+                                   },
+                           },
+                           request_device_callback, (void *)&device);
 
   wgpuDeviceSetUncapturedErrorCallback(device, handle_uncaptured_error, NULL);
   wgpuDeviceSetDeviceLostCallback(device, handle_device_lost, NULL);
@@ -310,7 +303,8 @@ int main() {
       nextTexture = wgpuSwapChainGetCurrentTextureView(swapChain);
 
       if (attempt == 0 && !nextTexture) {
-        printf("wgpuSwapChainGetCurrentTextureView() failed; trying to create a new swap chain...\n");
+        printf("wgpuSwapChainGetCurrentTextureView() failed; trying to create "
+               "a new swap chain...\n");
         prevWidth = 0;
         prevHeight = 0;
         continue;

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -27,8 +27,8 @@ typedef enum WGPUNativeSType {
 } WGPUNativeSType;
 
 typedef enum WGPUNativeFeature {
-    WGPUNativeFeature_PUSH_CONSTANTS = 0x04000000,
-    WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 0x10000000
+    WGPUNativeFeature_PUSH_CONSTANTS = 0x60000001,
+    WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 0x60000002
 } WGPUNativeFeature;
 
 typedef enum WGPULogLevel {
@@ -48,8 +48,6 @@ typedef struct WGPUAdapterExtras {
 
 typedef struct WGPUDeviceExtras {
     WGPUChainedStruct chain;
-    WGPUNativeFeature nativeFeatures;
-    const char* label;
     const char* tracePath;
 } WGPUDeviceExtras;
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -210,43 +210,26 @@ pub fn map_device_descriptor<'a>(
     des: &native::WGPUDeviceDescriptor,
     extras: Option<&native::WGPUDeviceExtras>,
 ) -> (wgt::DeviceDescriptor<Label<'a>>, Option<String>) {
-    let required_limits = unsafe { *des.requiredLimits };
-    let mut features = wgt::Features::empty();
-    let limits = unsafe {
-        follow_chain!(
-            map_required_limits(required_limits,
-            WGPUSType_RequiredLimitsExtras => native::WGPURequiredLimitsExtras)
-        )
-    };
-    if let Some(extras) = extras {
-        // Handle native features speficied in extras
-        if (extras.nativeFeatures
-            & native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES)
-            > 0
-        {
-            features |= wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
-        }
-        if (extras.nativeFeatures & native::WGPUNativeFeature_PUSH_CONSTANTS) > 0 {
-            features |= wgt::Features::PUSH_CONSTANTS
-        }
-        return (
-            wgt::DeviceDescriptor {
-                label: OwnedLabel::new(extras.label).into_cow(),
-                features,
-                limits,
-            },
-            OwnedLabel::new(extras.tracePath).into_inner(),
-        );
-    } else {
-        (
-            wgt::DeviceDescriptor {
-                label: None,
-                features,
-                limits: wgt::Limits::default(),
-            },
-            None,
-        )
-    }
+    let limits = unsafe { des.requiredLimits.as_ref() }.map_or(
+        wgt::Limits::downlevel_defaults(),
+        |required_limits| unsafe {
+            follow_chain!(
+                map_required_limits(required_limits,
+                WGPUSType_RequiredLimitsExtras => native::WGPURequiredLimitsExtras)
+            )
+        },
+    );
+
+    (
+        wgt::DeviceDescriptor {
+            label: OwnedLabel::new(des.label).into_cow(),
+            features: map_features(unsafe {
+                make_slice(des.requiredFeatures, des.requiredFeaturesCount as usize)
+            }),
+            limits,
+        },
+        extras.and_then(|extras| OwnedLabel::new(extras.tracePath).into_inner()),
+    )
 }
 
 pub fn map_pipeline_layout_descriptor<'a>(
@@ -282,7 +265,7 @@ pub fn map_pipeline_layout_descriptor<'a>(
 }
 
 pub fn map_required_limits(
-    required_limits: native::WGPURequiredLimits,
+    required_limits: &native::WGPURequiredLimits,
     extras: Option<&native::WGPURequiredLimitsExtras>,
 ) -> wgt::Limits {
     let limits = required_limits.limits;
@@ -791,7 +774,19 @@ pub fn write_global_report(
     }
 }
 
-pub fn features_to_slice(features: wgt::Features) -> Vec<native::WGPUFeatureName> {
+pub fn map_features(features: &[native::WGPUFeatureName]) -> wgt::Features {
+    let mut temp = wgt::Features::empty();
+
+    features.iter().for_each(|f| {
+        if let Some(feature) = map_feature(*f) {
+            temp.insert(feature);
+        };
+    });
+
+    temp
+}
+
+pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureName> {
     let mut temp = Vec::new();
 
     if features.contains(wgt::Features::DEPTH_CLIP_CONTROL) {
@@ -822,7 +817,7 @@ pub fn features_to_slice(features: wgt::Features) -> Vec<native::WGPUFeatureName
         temp.push(native::WGPUFeatureName_IndirectFirstInstance);
     }
 
-    // extras
+    // native only features
     if features.contains(wgt::Features::PUSH_CONSTANTS) {
         temp.push(native::WGPUNativeFeature_PUSH_CONSTANTS);
     }
@@ -848,7 +843,7 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUFeatureName_TextureCompressionASTC => Some(Features::TEXTURE_COMPRESSION_ASTC_LDR),
         native::WGPUFeatureName_IndirectFirstInstance => Some(Features::INDIRECT_FIRST_INSTANCE),
 
-        // extras
+        // native only features
         native::WGPUNativeFeature_PUSH_CONSTANTS => Some(Features::PUSH_CONSTANTS),
         native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES => Some(Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES),
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -150,13 +150,11 @@ pub unsafe extern "C" fn wgpuAdapterEnumerateFeatures(
         _ => panic!("Calling wgpuAdapterEnumerateFeatures() on an invalid adapter."),
     };
 
-    let temp = conv::features_to_slice(adapter_features);
+    let temp = conv::features_to_native(adapter_features);
 
     if !features.is_null() {
         let out_slice = std::slice::from_raw_parts_mut(features, temp.len());
-        temp.iter().enumerate().for_each(|(i, feature)| {
-            out_slice[i] = *feature;
-        });
+        out_slice.copy_from_slice(&temp);
     }
 
     temp.len()
@@ -194,13 +192,11 @@ pub unsafe extern "C" fn wgpuDeviceEnumerateFeatures(
         _ => panic!("Calling wgpuDeviceEnumerateFeatures() on an invalid device."),
     };
 
-    let temp = conv::features_to_slice(device_features);
+    let temp = conv::features_to_native(device_features);
 
     if !features.is_null() {
         let out_slice = std::slice::from_raw_parts_mut(features, temp.len());
-        temp.iter().enumerate().for_each(|(i, feature)| {
-            out_slice[i] = *feature;
-        });
+        out_slice.copy_from_slice(&temp);
     }
 
     temp.len()


### PR DESCRIPTION
change how we take in native-only features (`WGPUNativeFeature`) while
requesting device.
Instead of having separate `WGPUDeviceExtras.nativeFeatures` in `wgpu.h`
take it in via `WGPUDeviceDescriptor.requiredFeatures`, same way as
other webgpu features

same for `label`, use `WGPUDeviceDescriptor.label`

helps #198