### PR TITLE
support userdata in log callback

### DIFF
--- a/examples/framework.c
+++ b/examples/framework.c
@@ -52,7 +52,9 @@ void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata) {
   UNUSED(userdata);
 }
 
-void logCallback(WGPULogLevel level, const char *msg) {
+void logCallback(WGPULogLevel level, const char *msg, void *userdata) {
+  UNUSED(userdata);
+
   char *level_str;
   switch (level) {
   case WGPULogLevel_Error:
@@ -77,7 +79,7 @@ void logCallback(WGPULogLevel level, const char *msg) {
 }
 
 void initializeLog() {
-  wgpuSetLogCallback(logCallback);
+  wgpuSetLogCallback(logCallback, NULL);
   wgpuSetLogLevel(WGPULogLevel_Warn);
 }
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -133,7 +133,7 @@ typedef struct WGPUGlobalReport {
     WGPUHubReport gl;
 } WGPUGlobalReport;
 
-typedef void (*WGPULogCallback)(WGPULogLevel level, const char *msg);
+typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void * userdata);
 
 #ifdef __cplusplus
 extern "C" {
@@ -146,7 +146,7 @@ WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, uint32_t commandCou
 // Returns true if the queue is empty, or false if there are more queue submissions still in flight.
 bool wgpuDevicePoll(WGPUDevice device, bool wait, WGPUWrappedSubmissionIndex const * wrappedSubmissionIndex);
 
-void wgpuSetLogCallback(WGPULogCallback callback);
+void wgpuSetLogCallback(WGPULogCallback callback, void * userdata);
 
 void wgpuSetLogLevel(WGPULogLevel level);
 


### PR DESCRIPTION
https://github.com/gfx-rs/wgpu-native/issues/212#issue-1337939897

>Related to this issue: the WGPU log callback does not currently provide a way to provide a userdata pointer to its call, unlike the other callbacks, and doing so is pretty important for interoperability between non-Rust/non-C languages and the API.