### PR TITLE
 add checks for undefined value constants instead of zero values

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -78,6 +78,17 @@ fn main() {
             .raw_line(line);
     }
 
+    // See https://github.com/rust-lang/rust-bindgen/issues/923
+    builder = builder
+        .blocklist_item("WGPU_LIMIT_U64_UNDEFINED")
+        .raw_line("pub const WGPU_LIMIT_U64_UNDEFINED: u64 = 0xffffffffffffffff;");
+    builder = builder
+        .blocklist_item("WGPU_WHOLE_MAP_SIZE")
+        .raw_line("pub const WGPU_WHOLE_MAP_SIZE: usize = usize::MAX;");
+    builder = builder
+        .blocklist_item("WGPU_WHOLE_SIZE")
+        .raw_line("pub const WGPU_WHOLE_SIZE: usize = 0xffffffffffffffff;");
+
     // See https://github.com/rust-lang/rust-bindgen/issues/1780
     if let Ok("ios") = env::var("CARGO_CFG_TARGET_OS").as_ref().map(|x| &**x) {
         let output = Command::new("xcrun")

--- a/build.rs
+++ b/build.rs
@@ -78,17 +78,6 @@ fn main() {
             .raw_line(line);
     }
 
-    // See https://github.com/rust-lang/rust-bindgen/issues/923
-    builder = builder
-        .blocklist_item("WGPU_LIMIT_U64_UNDEFINED")
-        .raw_line("pub const WGPU_LIMIT_U64_UNDEFINED: u64 = 0xffffffffffffffff;");
-    builder = builder
-        .blocklist_item("WGPU_WHOLE_MAP_SIZE")
-        .raw_line("pub const WGPU_WHOLE_MAP_SIZE: usize = usize::MAX;");
-    builder = builder
-        .blocklist_item("WGPU_WHOLE_SIZE")
-        .raw_line("pub const WGPU_WHOLE_SIZE: usize = 0xffffffffffffffff;");
-
     // See https://github.com/rust-lang/rust-bindgen/issues/1780
     if let Ok("ios") = env::var("CARGO_CFG_TARGET_OS").as_ref().map(|x| &**x) {
         let output = Command::new("xcrun")

--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -22,37 +22,62 @@ int main(int argc, char *argv[]) {
                              request_adapter_callback, (void *)&adapter);
 
   WGPUDevice device;
-  wgpuAdapterRequestDevice(adapter,
-                           &(WGPUDeviceDescriptor){
-                               .nextInChain = NULL,
-                               .label = "Device",
-                               .requiredLimits =
-                                   &(WGPURequiredLimits){
-                                       .nextInChain = NULL,
-                                       .limits =
-                                           (WGPULimits){
-                                               .maxBindGroups = 1,
-                                           },
-                                   },
-                               .defaultQueue =
-                                   (WGPUQueueDescriptor){
-                                       .nextInChain = NULL,
-                                       .label = NULL,
-                                   },
-                           },
-                           request_device_callback, (void *)&device);
+  wgpuAdapterRequestDevice(
+      adapter,
+      &(WGPUDeviceDescriptor){
+          .nextInChain = NULL,
+          .label = "Device",
+          .requiredLimits =
+              &(WGPURequiredLimits){
+                  .nextInChain = NULL,
+                  .limits =
+                      (WGPULimits){
+                          .maxBindGroups = 1,
+                          .maxTextureDimension1D = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxTextureDimension2D = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxTextureDimension3D = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxTextureArrayLayers = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxDynamicUniformBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxDynamicStorageBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxSampledTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxSamplersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxStorageBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxStorageTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxUniformBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxUniformBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,
+                          .maxStorageBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,
+                          .minUniformBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,
+                          .minStorageBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxVertexBuffers = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxVertexAttributes = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxVertexBufferArrayStride = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxInterStageShaderComponents = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupStorageSize = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeInvocationsPerWorkgroup = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupSizeX = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupSizeY = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupSizeZ = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupsPerDimension = WGPU_LIMIT_U32_UNDEFINED,
+                      },
+              },
+          .defaultQueue =
+              (WGPUQueueDescriptor){
+                  .nextInChain = NULL,
+                  .label = NULL,
+              },
+      },
+      request_device_callback, (void *)&device);
 
   BufferDimensions bufferDimensions = buffer_dimensions_new(width, height);
-  uint64_t bufferSize =
-      bufferDimensions.padded_bytes_per_row * bufferDimensions.height;
-  WGPUBuffer outputBuffer = wgpuDeviceCreateBuffer(
-      device, &(WGPUBufferDescriptor){
-                  .nextInChain = NULL,
-                  .label = "Output Buffer",
-                  .usage = WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst,
-                  .size = bufferSize,
-                  .mappedAtCreation = false,
-              });
+  uint64_t bufferSize = bufferDimensions.padded_bytes_per_row * bufferDimensions.height;
+  WGPUBuffer outputBuffer =
+      wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
+                                         .nextInChain = NULL,
+                                         .label = "Output Buffer",
+                                         .usage = WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst,
+                                         .size = bufferSize,
+                                         .mappedAtCreation = false,
+                                     });
 
   WGPUExtent3D textureExtent = (WGPUExtent3D){
       .width = bufferDimensions.width,
@@ -60,53 +85,52 @@ int main(int argc, char *argv[]) {
       .depthOrArrayLayers = 1,
   };
   WGPUTexture texture = wgpuDeviceCreateTexture(
-      device,
-      &(WGPUTextureDescriptor){
-          .nextInChain = NULL,
-          .label = NULL,
-          .size = textureExtent,
-          .mipLevelCount = 1,
-          .sampleCount = 1,
-          .dimension = WGPUTextureDimension_2D,
-          .format = WGPUTextureFormat_RGBA8UnormSrgb,
-          .usage = WGPUTextureUsage_RenderAttachment | WGPUTextureUsage_CopySrc,
-      });
+      device, &(WGPUTextureDescriptor){
+                  .nextInChain = NULL,
+                  .label = NULL,
+                  .size = textureExtent,
+                  .mipLevelCount = 1,
+                  .sampleCount = 1,
+                  .dimension = WGPUTextureDimension_2D,
+                  .format = WGPUTextureFormat_RGBA8UnormSrgb,
+                  .usage = WGPUTextureUsage_RenderAttachment | WGPUTextureUsage_CopySrc,
+              });
 
-  WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(
-      device, &(WGPUCommandEncoderDescriptor){.label = NULL});
+  WGPUCommandEncoder encoder =
+      wgpuDeviceCreateCommandEncoder(device, &(WGPUCommandEncoderDescriptor){.label = NULL});
 
-  WGPUTextureView outputAttachment = wgpuTextureCreateView(
-      texture, &(WGPUTextureViewDescriptor){
-                   .nextInChain = NULL,
-                   .label = NULL,
-                   .format = WGPUTextureFormat_Undefined,
-                   .dimension = WGPUTextureViewDimension_Undefined,
-                   .aspect = WGPUTextureAspect_All,
-                   .arrayLayerCount = 0,
-                   .baseArrayLayer = 0,
-                   .baseMipLevel = 0,
-                   .mipLevelCount = 0,
-               });
+  WGPUTextureView outputAttachment =
+      wgpuTextureCreateView(texture, &(WGPUTextureViewDescriptor){
+                                         .nextInChain = NULL,
+                                         .label = NULL,
+                                         .format = WGPUTextureFormat_Undefined,
+                                         .dimension = WGPUTextureViewDimension_Undefined,
+                                         .aspect = WGPUTextureAspect_All,
+                                         .arrayLayerCount = WGPU_ARRAY_LAYER_COUNT_UNDEFINED,
+                                         .baseArrayLayer = 0,
+                                         .baseMipLevel = 0,
+                                         .mipLevelCount = WGPU_MIP_LEVEL_COUNT_UNDEFINED,
+                                     });
 
-  WGPURenderPassEncoder renderPass = wgpuCommandEncoderBeginRenderPass(
-      encoder, &(WGPURenderPassDescriptor){
-                   .colorAttachments =
-                       &(WGPURenderPassColorAttachment){
-                           .view = outputAttachment,
-                           .resolveTarget = 0,
-                           .loadOp = WGPULoadOp_Clear,
-                           .storeOp = WGPUStoreOp_Store,
-                           .clearValue =
-                               (WGPUColor){
-                                   .r = 1.0,
-                                   .g = 0.0,
-                                   .b = 0.0,
-                                   .a = 1.0,
-                               },
-                       },
-                   .colorAttachmentCount = 1,
-                   .depthStencilAttachment = NULL,
-               });
+  WGPURenderPassEncoder renderPass =
+      wgpuCommandEncoderBeginRenderPass(encoder, &(WGPURenderPassDescriptor){
+                                                     .colorAttachments =
+                                                         &(WGPURenderPassColorAttachment){
+                                                             .view = outputAttachment,
+                                                             .resolveTarget = NULL,
+                                                             .loadOp = WGPULoadOp_Clear,
+                                                             .storeOp = WGPUStoreOp_Store,
+                                                             .clearValue =
+                                                                 (WGPUColor){
+                                                                     .r = 1.0,
+                                                                     .g = 0.0,
+                                                                     .b = 0.0,
+                                                                     .a = 1.0,
+                                                                 },
+                                                         },
+                                                     .colorAttachmentCount = 1,
+                                                     .depthStencilAttachment = NULL,
+                                                 });
   wgpuRenderPassEncoderEnd(renderPass);
 
   wgpuCommandEncoderCopyTextureToBuffer(
@@ -121,27 +145,24 @@ int main(int argc, char *argv[]) {
                   .z = 0,
               },
       },
-      &(WGPUImageCopyBuffer){
-          .buffer = outputBuffer,
-          .layout =
-              (WGPUTextureDataLayout){
-                  .offset = 0,
-                  .bytesPerRow = bufferDimensions.padded_bytes_per_row,
-                  .rowsPerImage = 0,
-              }},
+      &(WGPUImageCopyBuffer){.buffer = outputBuffer,
+                             .layout =
+                                 (WGPUTextureDataLayout){
+                                     .offset = 0,
+                                     .bytesPerRow = bufferDimensions.padded_bytes_per_row,
+                                     .rowsPerImage = WGPU_COPY_STRIDE_UNDEFINED,
+                                 }},
       &textureExtent);
 
   WGPUQueue queue = wgpuDeviceGetQueue(device);
-  WGPUCommandBuffer cmdBuffer = wgpuCommandEncoderFinish(
-      encoder, &(WGPUCommandBufferDescriptor){.label = NULL});
+  WGPUCommandBuffer cmdBuffer =
+      wgpuCommandEncoderFinish(encoder, &(WGPUCommandBufferDescriptor){.label = NULL});
   wgpuQueueSubmit(queue, 1, &cmdBuffer);
 
-  wgpuBufferMapAsync(outputBuffer, WGPUMapMode_Read, 0, bufferSize,
-                     readBufferMap, NULL);
+  wgpuBufferMapAsync(outputBuffer, WGPUMapMode_Read, 0, bufferSize, readBufferMap, NULL);
   wgpuDevicePoll(device, true, NULL);
 
-  uint8_t *data =
-      (uint8_t *)wgpuBufferGetMappedRange(outputBuffer, 0, bufferSize);
+  uint8_t *data = (uint8_t *)wgpuBufferGetMappedRange(outputBuffer, 0, bufferSize);
   const char *filename = "red.png";
   save_png(filename, data, &bufferDimensions);
 

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -21,61 +21,86 @@ int main() {
                              request_adapter_callback, (void *)&adapter);
 
   WGPUDevice device;
-  wgpuAdapterRequestDevice(adapter,
-                           &(WGPUDeviceDescriptor){
-                               .nextInChain = NULL,
-                               .label = "Device",
-                               .requiredLimits =
-                                   &(WGPURequiredLimits){
-                                       .nextInChain = NULL,
-                                       .limits =
-                                           (WGPULimits){
-                                               .maxBindGroups = 1,
-                                           },
-                                   },
-                               .defaultQueue =
-                                   (WGPUQueueDescriptor){
-                                       .nextInChain = NULL,
-                                       .label = NULL,
-                                   },
-                           },
-                           request_device_callback, (void *)&device);
+  wgpuAdapterRequestDevice(
+      adapter,
+      &(WGPUDeviceDescriptor){
+          .nextInChain = NULL,
+          .label = "Device",
+          .requiredLimits =
+              &(WGPURequiredLimits){
+                  .nextInChain = NULL,
+                  .limits =
+                      (WGPULimits){
+                          .maxBindGroups = 1,
+                          .maxTextureDimension1D = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxTextureDimension2D = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxTextureDimension3D = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxTextureArrayLayers = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxDynamicUniformBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxDynamicStorageBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxSampledTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxSamplersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxStorageBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxStorageTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxUniformBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxUniformBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,
+                          .maxStorageBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,
+                          .minUniformBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,
+                          .minStorageBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxVertexBuffers = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxVertexAttributes = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxVertexBufferArrayStride = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxInterStageShaderComponents = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupStorageSize = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeInvocationsPerWorkgroup = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupSizeX = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupSizeY = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupSizeZ = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupsPerDimension = WGPU_LIMIT_U32_UNDEFINED,
+                      },
+              },
+          .defaultQueue =
+              (WGPUQueueDescriptor){
+                  .nextInChain = NULL,
+                  .label = NULL,
+              },
+      },
+      request_device_callback, (void *)&device);
 
   WGPUShaderModuleDescriptor shaderSource = load_wgsl("shader.wgsl");
   WGPUShaderModule shader = wgpuDeviceCreateShaderModule(device, &shaderSource);
 
-  WGPUBuffer stagingBuffer = wgpuDeviceCreateBuffer(
-      device, &(WGPUBufferDescriptor){
-                  .nextInChain = NULL,
-                  .label = "StagingBuffer",
-                  .usage = WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst,
-                  .size = numbersSize,
-                  .mappedAtCreation = false,
-              });
-  WGPUBuffer storageBuffer = wgpuDeviceCreateBuffer(
-      device, &(WGPUBufferDescriptor){
-                  .nextInChain = NULL,
-                  .label = "StorageBuffer",
-                  .usage = WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst |
-                           WGPUBufferUsage_CopySrc,
-                  .size = numbersSize,
-                  .mappedAtCreation = false,
-              });
+  WGPUBuffer stagingBuffer =
+      wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
+                                         .nextInChain = NULL,
+                                         .label = "StagingBuffer",
+                                         .usage = WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst,
+                                         .size = numbersSize,
+                                         .mappedAtCreation = false,
+                                     });
+  WGPUBuffer storageBuffer =
+      wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
+                                         .nextInChain = NULL,
+                                         .label = "StorageBuffer",
+                                         .usage = WGPUBufferUsage_Storage |
+                                                  WGPUBufferUsage_CopyDst | WGPUBufferUsage_CopySrc,
+                                         .size = numbersSize,
+                                         .mappedAtCreation = false,
+                                     });
 
-  WGPUComputePipeline computePipeline = wgpuDeviceCreateComputePipeline(
-      device, &(WGPUComputePipelineDescriptor){
-                  .nextInChain = NULL,
-                  .label = "Compute Pipeline",
-                  .layout = NULL,
-                  .compute =
-                      (WGPUProgrammableStageDescriptor){
-                          .module = shader,
-                          .entryPoint = "main",
-                      },
-              });
+  WGPUComputePipeline computePipeline =
+      wgpuDeviceCreateComputePipeline(device, &(WGPUComputePipelineDescriptor){
+                                                  .nextInChain = NULL,
+                                                  .label = "Compute Pipeline",
+                                                  .layout = NULL,
+                                                  .compute =
+                                                      (WGPUProgrammableStageDescriptor){
+                                                          .module = shader,
+                                                          .entryPoint = "main",
+                                                      },
+                                              });
 
-  WGPUBindGroupLayout bindGroupLayout =
-      wgpuComputePipelineGetBindGroupLayout(computePipeline, 0);
+  WGPUBindGroupLayout bindGroupLayout = wgpuComputePipelineGetBindGroupLayout(computePipeline, 0);
 
   WGPUBindGroup bindGroup =
       wgpuDeviceCreateBindGroup(device, &(WGPUBindGroupDescriptor){
@@ -104,21 +129,18 @@ int main() {
   wgpuComputePassEncoderSetBindGroup(computePass, 0, bindGroup, 0, NULL);
   wgpuComputePassEncoderDispatchWorkgroups(computePass, numbersLength, 1, 1);
   wgpuComputePassEncoderEnd(computePass);
-  wgpuCommandEncoderCopyBufferToBuffer(encoder, storageBuffer, 0, stagingBuffer,
-                                       0, numbersSize);
+  wgpuCommandEncoderCopyBufferToBuffer(encoder, storageBuffer, 0, stagingBuffer, 0, numbersSize);
 
   WGPUQueue queue = wgpuDeviceGetQueue(device);
-  WGPUCommandBuffer cmdBuffer = wgpuCommandEncoderFinish(
-      encoder, &(WGPUCommandBufferDescriptor){.label = NULL});
+  WGPUCommandBuffer cmdBuffer =
+      wgpuCommandEncoderFinish(encoder, &(WGPUCommandBufferDescriptor){.label = NULL});
   wgpuQueueWriteBuffer(queue, storageBuffer, 0, &numbers, numbersSize);
   wgpuQueueSubmit(queue, 1, &cmdBuffer);
 
-  wgpuBufferMapAsync(stagingBuffer, WGPUMapMode_Read, 0, numbersSize,
-                     readBufferMap, NULL);
+  wgpuBufferMapAsync(stagingBuffer, WGPUMapMode_Read, 0, numbersSize, readBufferMap, NULL);
   wgpuDevicePoll(device, true, NULL);
 
-  uint32_t *times =
-      (uint32_t *)wgpuBufferGetMappedRange(stagingBuffer, 0, numbersSize);
+  uint32_t *times = (uint32_t *)wgpuBufferGetMappedRange(stagingBuffer, 0, numbersSize);
 
   printf("Times: [%d, %d, %d, %d]\n", times[0], times[1], times[2], times[3]);
 

--- a/examples/framework.c
+++ b/examples/framework.c
@@ -18,8 +18,7 @@ WGPUShaderModuleDescriptor load_wgsl(const char *name) {
   fclose(file);
   bytes[length] = 0;
 
-  WGPUShaderModuleWGSLDescriptor *wgslDescriptor =
-      malloc(sizeof(WGPUShaderModuleWGSLDescriptor));
+  WGPUShaderModuleWGSLDescriptor *wgslDescriptor = malloc(sizeof(WGPUShaderModuleWGSLDescriptor));
   wgslDescriptor->chain.next = NULL;
   wgslDescriptor->chain.sType = WGPUSType_ShaderModuleWGSLDescriptor;
   wgslDescriptor->code = (const char *)bytes;
@@ -29,18 +28,16 @@ WGPUShaderModuleDescriptor load_wgsl(const char *name) {
   };
 }
 
-void request_adapter_callback(WGPURequestAdapterStatus status,
-                              WGPUAdapter received, const char *message,
-                              void *userdata) {
+void request_adapter_callback(WGPURequestAdapterStatus status, WGPUAdapter received,
+                              const char *message, void *userdata) {
   UNUSED(status);
   UNUSED(message);
 
   *(WGPUAdapter *)userdata = received;
 }
 
-void request_device_callback(WGPURequestDeviceStatus status,
-                             WGPUDevice received, const char *message,
-                             void *userdata) {
+void request_device_callback(WGPURequestDeviceStatus status, WGPUDevice received,
+                             const char *message, void *userdata) {
   UNUSED(status);
   UNUSED(message);
 
@@ -83,26 +80,26 @@ void initializeLog() {
   wgpuSetLogLevel(WGPULogLevel_Warn);
 }
 
-#define printStorageReport(report, prefix)                                     \
-  printf("%snumOccupied=%zu\n", prefix, report.numOccupied);                   \
-  printf("%snumVacant=%zu\n", prefix, report.numVacant);                       \
-  printf("%snumError=%zu\n", prefix, report.numError);                         \
+#define printStorageReport(report, prefix)                                                         \
+  printf("%snumOccupied=%zu\n", prefix, report.numOccupied);                                       \
+  printf("%snumVacant=%zu\n", prefix, report.numVacant);                                           \
+  printf("%snumError=%zu\n", prefix, report.numError);                                             \
   printf("%selementSize=%zu\n", prefix, report.elementSize)
 
-#define printHubReport(report, prefix)                                         \
-  printStorageReport(report.adapters, prefix "adapter.");                      \
-  printStorageReport(report.devices, prefix "devices.");                       \
-  printStorageReport(report.pipelineLayouts, prefix "pipelineLayouts.");       \
-  printStorageReport(report.shaderModules, prefix "shaderModules.");           \
-  printStorageReport(report.bindGroupLayouts, prefix "bindGroupLayouts.");     \
-  printStorageReport(report.bindGroups, prefix "bindGroups.");                 \
-  printStorageReport(report.commandBuffers, prefix "commandBuffers.");         \
-  printStorageReport(report.renderBundles, prefix "renderBundles.");           \
-  printStorageReport(report.renderPipelines, prefix "renderPipelines.");       \
-  printStorageReport(report.computePipelines, prefix "computePipelines.");     \
-  printStorageReport(report.querySets, prefix "querySets.");                   \
-  printStorageReport(report.textures, prefix "textures.");                     \
-  printStorageReport(report.textureViews, prefix "textureViews.");             \
+#define printHubReport(report, prefix)                                                             \
+  printStorageReport(report.adapters, prefix "adapter.");                                          \
+  printStorageReport(report.devices, prefix "devices.");                                           \
+  printStorageReport(report.pipelineLayouts, prefix "pipelineLayouts.");                           \
+  printStorageReport(report.shaderModules, prefix "shaderModules.");                               \
+  printStorageReport(report.bindGroupLayouts, prefix "bindGroupLayouts.");                         \
+  printStorageReport(report.bindGroups, prefix "bindGroups.");                                     \
+  printStorageReport(report.commandBuffers, prefix "commandBuffers.");                             \
+  printStorageReport(report.renderBundles, prefix "renderBundles.");                               \
+  printStorageReport(report.renderPipelines, prefix "renderPipelines.");                           \
+  printStorageReport(report.computePipelines, prefix "computePipelines.");                         \
+  printStorageReport(report.querySets, prefix "querySets.");                                       \
+  printStorageReport(report.textures, prefix "textures.");                                         \
+  printStorageReport(report.textureViews, prefix "textureViews.");                                 \
   printStorageReport(report.samplers, prefix "samplers.")
 
 void printGlobalReport(WGPUGlobalReport report) {
@@ -126,16 +123,14 @@ void printGlobalReport(WGPUGlobalReport report) {
     printHubReport(report.gl, "\tgl.");
     break;
   default:
-    printf("WARN:printGlobalReport: invalid backened type: %d",
-           report.backendType);
+    printf("WARN:printGlobalReport: invalid backened type: %d", report.backendType);
   }
   printf("}\n");
 }
 
 void printAdapterFeatures(WGPUAdapter adapter) {
   size_t count = wgpuAdapterEnumerateFeatures(adapter, NULL);
-  WGPUFeatureName *features =
-      (WGPUFeatureName *)malloc(count * sizeof(WGPUFeatureName));
+  WGPUFeatureName *features = (WGPUFeatureName *)malloc(count * sizeof(WGPUFeatureName));
   wgpuAdapterEnumerateFeatures(adapter, features);
 
   printf("[]WGPUFeatureName {\n");

--- a/examples/framework.h
+++ b/examples/framework.h
@@ -2,13 +2,11 @@
 
 WGPUShaderModuleDescriptor load_wgsl(const char *name);
 
-void request_adapter_callback(WGPURequestAdapterStatus status,
-                              WGPUAdapter received, const char *message,
-                              void *userdata);
+void request_adapter_callback(WGPURequestAdapterStatus status, WGPUAdapter received,
+                              const char *message, void *userdata);
 
-void request_device_callback(WGPURequestDeviceStatus status,
-                             WGPUDevice received, const char *message,
-                             void *userdata);
+void request_device_callback(WGPURequestDeviceStatus status, WGPUDevice received,
+                             const char *message, void *userdata);
 
 void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata);
 

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -28,22 +28,19 @@
 #endif
 #include <GLFW/glfw3native.h>
 
-static void handle_device_lost(WGPUDeviceLostReason reason, char const *message,
-                               void *userdata) {
+static void handle_device_lost(WGPUDeviceLostReason reason, char const *message, void *userdata) {
   UNUSED(userdata);
 
   printf("DEVICE LOST (%d): %s\n", reason, message);
 }
 
-static void handle_uncaptured_error(WGPUErrorType type, char const *message,
-                                    void *userdata) {
+static void handle_uncaptured_error(WGPUErrorType type, char const *message, void *userdata) {
   UNUSED(userdata);
 
   printf("UNCAPTURED ERROR (%d): %s\n", type, message);
 }
 
-static void handleGlfwKey(GLFWwindow *window, int key, int scancode, int action,
-                          int mods) {
+static void handleGlfwKey(GLFWwindow *window, int key, int scancode, int action, int mods) {
   UNUSED(window);
   UNUSED(scancode);
   UNUSED(mods);
@@ -81,84 +78,75 @@ int main() {
     metal_layer = [CAMetalLayer layer];
     [ns_window.contentView setLayer:metal_layer];
     surface = wgpuInstanceCreateSurface(
-        NULL,
-        &(WGPUSurfaceDescriptor){
-            .label = NULL,
-            .nextInChain =
-                (const WGPUChainedStruct *)&(
-                    WGPUSurfaceDescriptorFromMetalLayer){
-                    .chain =
-                        (WGPUChainedStruct){
-                            .next = NULL,
-                            .sType = WGPUSType_SurfaceDescriptorFromMetalLayer,
-                        },
-                    .layer = metal_layer,
-                },
-        });
+        NULL, &(WGPUSurfaceDescriptor){
+                  .label = NULL,
+                  .nextInChain =
+                      (const WGPUChainedStruct *)&(WGPUSurfaceDescriptorFromMetalLayer){
+                          .chain =
+                              (WGPUChainedStruct){
+                                  .next = NULL,
+                                  .sType = WGPUSType_SurfaceDescriptorFromMetalLayer,
+                              },
+                          .layer = metal_layer,
+                      },
+              });
   }
 #elif WGPU_TARGET == WGPU_TARGET_LINUX_X11
   {
     Display *x11_display = glfwGetX11Display();
     Window x11_window = glfwGetX11Window(window);
     surface = wgpuInstanceCreateSurface(
-        NULL,
-        &(WGPUSurfaceDescriptor){
-            .label = NULL,
-            .nextInChain =
-                (const WGPUChainedStruct *)&(
-                    WGPUSurfaceDescriptorFromXlibWindow){
-                    .chain =
-                        (WGPUChainedStruct){
-                            .next = NULL,
-                            .sType = WGPUSType_SurfaceDescriptorFromXlibWindow,
-                        },
-                    .display = x11_display,
-                    .window = x11_window,
-                },
-        });
+        NULL, &(WGPUSurfaceDescriptor){
+                  .label = NULL,
+                  .nextInChain =
+                      (const WGPUChainedStruct *)&(WGPUSurfaceDescriptorFromXlibWindow){
+                          .chain =
+                              (WGPUChainedStruct){
+                                  .next = NULL,
+                                  .sType = WGPUSType_SurfaceDescriptorFromXlibWindow,
+                              },
+                          .display = x11_display,
+                          .window = x11_window,
+                      },
+              });
   }
 #elif WGPU_TARGET == WGPU_TARGET_LINUX_WAYLAND
   {
     struct wl_display *wayland_display = glfwGetWaylandDisplay();
     struct wl_surface *wayland_surface = glfwGetWaylandWindow(window);
     surface = wgpuInstanceCreateSurface(
-        NULL,
-        &(WGPUSurfaceDescriptor){
-            .label = NULL,
-            .nextInChain =
-                (const WGPUChainedStruct *)&(
-                    WGPUSurfaceDescriptorFromWaylandSurface){
-                    .chain =
-                        (WGPUChainedStruct){
-                            .next = NULL,
-                            .sType =
-                                WGPUSType_SurfaceDescriptorFromWaylandSurface,
-                        },
-                    .display = wayland_display,
-                    .surface = wayland_surface,
-                },
-        });
+        NULL, &(WGPUSurfaceDescriptor){
+                  .label = NULL,
+                  .nextInChain =
+                      (const WGPUChainedStruct *)&(WGPUSurfaceDescriptorFromWaylandSurface){
+                          .chain =
+                              (WGPUChainedStruct){
+                                  .next = NULL,
+                                  .sType = WGPUSType_SurfaceDescriptorFromWaylandSurface,
+                              },
+                          .display = wayland_display,
+                          .surface = wayland_surface,
+                      },
+              });
   }
 #elif WGPU_TARGET == WGPU_TARGET_WINDOWS
   {
     HWND hwnd = glfwGetWin32Window(window);
     HINSTANCE hinstance = GetModuleHandle(NULL);
     surface = wgpuInstanceCreateSurface(
-        NULL,
-        &(WGPUSurfaceDescriptor){
-            .label = NULL,
-            .nextInChain =
-                (const WGPUChainedStruct *)&(
-                    WGPUSurfaceDescriptorFromWindowsHWND){
-                    .chain =
-                        (WGPUChainedStruct){
-                            .next = NULL,
-                            .sType = WGPUSType_SurfaceDescriptorFromWindowsHWND,
-                        },
-                    .hinstance = hinstance,
-                    .hwnd = hwnd,
-                },
-        });
+        NULL, &(WGPUSurfaceDescriptor){
+                  .label = NULL,
+                  .nextInChain =
+                      (const WGPUChainedStruct *)&(WGPUSurfaceDescriptorFromWindowsHWND){
+                          .chain =
+                              (WGPUChainedStruct){
+                                  .next = NULL,
+                                  .sType = WGPUSType_SurfaceDescriptorFromWindowsHWND,
+                              },
+                          .hinstance = hinstance,
+                          .hwnd = hwnd,
+                      },
+              });
   }
 #else
 #error "Unsupported WGPU_TARGET"
@@ -175,25 +163,51 @@ int main() {
   printAdapterFeatures(adapter);
 
   WGPUDevice device;
-  wgpuAdapterRequestDevice(adapter,
-                           &(WGPUDeviceDescriptor){
-                               .nextInChain = NULL,
-                               .label = "Device",
-                               .requiredLimits =
-                                   &(WGPURequiredLimits){
-                                       .nextInChain = NULL,
-                                       .limits =
-                                           (WGPULimits){
-                                               .maxBindGroups = 1,
-                                           },
-                                   },
-                               .defaultQueue =
-                                   (WGPUQueueDescriptor){
-                                       .nextInChain = NULL,
-                                       .label = NULL,
-                                   },
-                           },
-                           request_device_callback, (void *)&device);
+  wgpuAdapterRequestDevice(
+      adapter,
+      &(WGPUDeviceDescriptor){
+          .nextInChain = NULL,
+          .label = "Device",
+          .requiredLimits =
+              &(WGPURequiredLimits){
+                  .nextInChain = NULL,
+                  .limits =
+                      (WGPULimits){
+                          .maxBindGroups = 1,
+                          .maxTextureDimension1D = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxTextureDimension2D = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxTextureDimension3D = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxTextureArrayLayers = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxDynamicUniformBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxDynamicStorageBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxSampledTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxSamplersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxStorageBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxStorageTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxUniformBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxUniformBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,
+                          .maxStorageBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,
+                          .minUniformBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,
+                          .minStorageBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxVertexBuffers = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxVertexAttributes = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxVertexBufferArrayStride = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxInterStageShaderComponents = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupStorageSize = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeInvocationsPerWorkgroup = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupSizeX = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupSizeY = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupSizeZ = WGPU_LIMIT_U32_UNDEFINED,
+                          .maxComputeWorkgroupsPerDimension = WGPU_LIMIT_U32_UNDEFINED,
+                      },
+              },
+          .defaultQueue =
+              (WGPUQueueDescriptor){
+                  .nextInChain = NULL,
+                  .label = NULL,
+              },
+      },
+      request_device_callback, (void *)&device);
 
   wgpuDeviceSetUncapturedErrorCallback(device, handle_uncaptured_error, NULL);
   wgpuDeviceSetDeviceLostCallback(device, handle_device_lost, NULL);
@@ -201,58 +215,59 @@ int main() {
   WGPUShaderModuleDescriptor shaderSource = load_wgsl("shader.wgsl");
   WGPUShaderModule shader = wgpuDeviceCreateShaderModule(device, &shaderSource);
 
-  WGPUTextureFormat swapChainFormat =
-      wgpuSurfaceGetPreferredFormat(surface, adapter);
+  WGPUTextureFormat swapChainFormat = wgpuSurfaceGetPreferredFormat(surface, adapter);
 
   WGPURenderPipeline pipeline = wgpuDeviceCreateRenderPipeline(
-      device,
-      &(WGPURenderPipelineDescriptor){
-          .label = "Render pipeline",
-          .vertex =
-              (WGPUVertexState){
-                  .module = shader,
-                  .entryPoint = "vs_main",
-                  .bufferCount = 0,
-                  .buffers = NULL,
-              },
-          .primitive =
-              (WGPUPrimitiveState){
-                  .topology = WGPUPrimitiveTopology_TriangleList,
-                  .stripIndexFormat = WGPUIndexFormat_Undefined,
-                  .frontFace = WGPUFrontFace_CCW,
-                  .cullMode = WGPUCullMode_None},
-          .multisample =
-              (WGPUMultisampleState){
-                  .count = 1,
-                  .mask = ~0,
-                  .alphaToCoverageEnabled = false,
-              },
-          .fragment =
-              &(WGPUFragmentState){
-                  .module = shader,
-                  .entryPoint = "fs_main",
-                  .targetCount = 1,
-                  .targets =
-                      &(WGPUColorTargetState){
-                          .format = swapChainFormat,
-                          .blend =
-                              &(WGPUBlendState){
-                                  .color =
-                                      (WGPUBlendComponent){
-                                          .srcFactor = WGPUBlendFactor_One,
-                                          .dstFactor = WGPUBlendFactor_Zero,
-                                          .operation = WGPUBlendOperation_Add,
+      device, &(WGPURenderPipelineDescriptor){
+                  .label = "Render pipeline",
+                  .vertex =
+                      (WGPUVertexState){
+                          .module = shader,
+                          .entryPoint = "vs_main",
+                          .bufferCount = 0,
+                          .buffers = NULL,
+                      },
+                  .primitive =
+                      (WGPUPrimitiveState){
+                          .topology = WGPUPrimitiveTopology_TriangleList,
+                          .stripIndexFormat = WGPUIndexFormat_Undefined,
+                          .frontFace = WGPUFrontFace_CCW,
+                          .cullMode = WGPUCullMode_None,
+                      },
+                  .multisample =
+                      (WGPUMultisampleState){
+                          .count = 1,
+                          .mask = ~0,
+                          .alphaToCoverageEnabled = false,
+                      },
+                  .fragment =
+                      &(WGPUFragmentState){
+                          .module = shader,
+                          .entryPoint = "fs_main",
+                          .targetCount = 1,
+                          .targets =
+                              &(WGPUColorTargetState){
+                                  .format = swapChainFormat,
+                                  .blend =
+                                      &(WGPUBlendState){
+                                          .color =
+                                              (WGPUBlendComponent){
+                                                  .srcFactor = WGPUBlendFactor_One,
+                                                  .dstFactor = WGPUBlendFactor_Zero,
+                                                  .operation = WGPUBlendOperation_Add,
+                                              },
+                                          .alpha =
+                                              (WGPUBlendComponent){
+                                                  .srcFactor = WGPUBlendFactor_One,
+                                                  .dstFactor = WGPUBlendFactor_Zero,
+                                                  .operation = WGPUBlendOperation_Add,
+                                              },
                                       },
-                                  .alpha =
-                                      (WGPUBlendComponent){
-                                          .srcFactor = WGPUBlendFactor_One,
-                                          .dstFactor = WGPUBlendFactor_Zero,
-                                          .operation = WGPUBlendOperation_Add,
-                                      }},
-                          .writeMask = WGPUColorWriteMask_All},
-              },
-          .depthStencil = NULL,
-      });
+                                  .writeMask = WGPUColorWriteMask_All,
+                              },
+                      },
+                  .depthStencil = NULL,
+              });
 
   int prevWidth = 0;
   int prevHeight = 0;
@@ -284,15 +299,14 @@ int main() {
         prevWidth = width;
         prevHeight = height;
 
-        swapChain = wgpuDeviceCreateSwapChain(
-            device, surface,
-            &(WGPUSwapChainDescriptor){
-                .usage = WGPUTextureUsage_RenderAttachment,
-                .format = swapChainFormat,
-                .width = prevWidth,
-                .height = prevHeight,
-                .presentMode = WGPUPresentMode_Fifo,
-            });
+        swapChain = wgpuDeviceCreateSwapChain(device, surface,
+                                              &(WGPUSwapChainDescriptor){
+                                                  .usage = WGPUTextureUsage_RenderAttachment,
+                                                  .format = swapChainFormat,
+                                                  .width = prevWidth,
+                                                  .height = prevHeight,
+                                                  .presentMode = WGPUPresentMode_Fifo,
+                                              });
       }
 
       nextTexture = wgpuSwapChainGetCurrentTextureView(swapChain);
@@ -316,36 +330,36 @@ int main() {
     WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(
         device, &(WGPUCommandEncoderDescriptor){.label = "Command Encoder"});
 
-    WGPURenderPassEncoder renderPass = wgpuCommandEncoderBeginRenderPass(
-        encoder, &(WGPURenderPassDescriptor){
-                     .colorAttachments =
-                         &(WGPURenderPassColorAttachment){
-                             .view = nextTexture,
-                             .resolveTarget = 0,
-                             .loadOp = WGPULoadOp_Clear,
-                             .storeOp = WGPUStoreOp_Store,
-                             .clearValue =
-                                 (WGPUColor){
-                                     .r = 0.0,
-                                     .g = 1.0,
-                                     .b = 0.0,
-                                     .a = 1.0,
-                                 },
-                         },
-                     .colorAttachmentCount = 1,
-                     .depthStencilAttachment = NULL,
-                 });
+    WGPURenderPassEncoder renderPass =
+        wgpuCommandEncoderBeginRenderPass(encoder, &(WGPURenderPassDescriptor){
+                                                       .colorAttachments =
+                                                           &(WGPURenderPassColorAttachment){
+                                                               .view = nextTexture,
+                                                               .resolveTarget = 0,
+                                                               .loadOp = WGPULoadOp_Clear,
+                                                               .storeOp = WGPUStoreOp_Store,
+                                                               .clearValue =
+                                                                   (WGPUColor){
+                                                                       .r = 0.0,
+                                                                       .g = 1.0,
+                                                                       .b = 0.0,
+                                                                       .a = 1.0,
+                                                                   },
+                                                           },
+                                                       .colorAttachmentCount = 1,
+                                                       .depthStencilAttachment = NULL,
+                                                   });
 
     wgpuRenderPassEncoderSetPipeline(renderPass, pipeline);
     wgpuRenderPassEncoderDraw(renderPass, 3, 1, 0, 0);
     wgpuRenderPassEncoderEnd(renderPass);
-    wgpuTextureViewDrop(nextTexture);
 
     WGPUQueue queue = wgpuDeviceGetQueue(device);
-    WGPUCommandBuffer cmdBuffer = wgpuCommandEncoderFinish(
-        encoder, &(WGPUCommandBufferDescriptor){.label = NULL});
+    WGPUCommandBuffer cmdBuffer =
+        wgpuCommandEncoderFinish(encoder, &(WGPUCommandBufferDescriptor){.label = NULL});
     wgpuQueueSubmit(queue, 1, &cmdBuffer);
     wgpuSwapChainPresent(swapChain);
+    wgpuTextureViewDrop(nextTexture);
 
     glfwPollEvents();
   }

--- a/src/command.rs
+++ b/src/command.rs
@@ -48,8 +48,8 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearBuffer(
         command_encoder,
         buffer,
         offset,
-        match size as usize {
-            native::WGPU_WHOLE_SIZE => None,
+        match size {
+            conv::WGPU_WHOLE_SIZE => None,
             _ => NonZeroU64::new(size),
         }
     ))
@@ -515,8 +515,8 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetIndexBuffer(
         buffer,
         conv::map_index_format(index_format).expect("Index format cannot be undefined"),
         offset,
-        match size as usize {
-            native::WGPU_WHOLE_SIZE => None,
+        match size {
+            conv::WGPU_WHOLE_SIZE => None,
             _ => NonZeroU64::new(size),
         },
     );
@@ -538,8 +538,8 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetVertexBuffer(
         slot,
         buffer,
         offset,
-        match size as usize {
-            native::WGPU_WHOLE_SIZE => None,
+        match size {
+            conv::WGPU_WHOLE_SIZE => None,
             _ => NonZeroU64::new(size),
         },
     );
@@ -819,8 +819,8 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetIndexBuffer(
         buffer,
         conv::map_index_format(format).unwrap(),
         offset,
-        match size as usize {
-            native::WGPU_WHOLE_SIZE => None,
+        match size {
+            conv::WGPU_WHOLE_SIZE => None,
             _ => NonZeroU64::new(size),
         },
     );
@@ -857,8 +857,8 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetVertexBuffer(
         slot,
         buffer,
         offset,
-        match size as usize {
-            native::WGPU_WHOLE_SIZE => None,
+        match size {
+            conv::WGPU_WHOLE_SIZE => None,
             _ => NonZeroU64::new(size),
         },
     );

--- a/src/command.rs
+++ b/src/command.rs
@@ -48,7 +48,11 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearBuffer(
         command_encoder,
         buffer,
         offset,
-        NonZeroU64::new(size)))
+        match size as usize {
+            native::WGPU_WHOLE_SIZE => None,
+            _ => NonZeroU64::new(size),
+        }
+    ))
     .expect("Unable to clear buffer")
 }
 
@@ -463,7 +467,14 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndirectCount(
     let buffer = buffer.expect("invalid buffer");
     let count_buffer = count_buffer.expect("invalid count buffer");
 
-    render_ffi::wgpu_render_pass_multi_draw_indirect_count(pass, buffer, offset, count_buffer, count_buffer_offset, max_count);
+    render_ffi::wgpu_render_pass_multi_draw_indirect_count(
+        pass,
+        buffer,
+        offset,
+        count_buffer,
+        count_buffer_offset,
+        max_count,
+    );
 }
 
 #[no_mangle]
@@ -479,7 +490,14 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndexedIndirectCount(
     let buffer = buffer.expect("invalid buffer");
     let count_buffer = count_buffer.expect("invalid count buffer");
 
-    render_ffi::wgpu_render_pass_multi_draw_indexed_indirect_count(pass, buffer, offset, count_buffer, count_buffer_offset, max_count);
+    render_ffi::wgpu_render_pass_multi_draw_indexed_indirect_count(
+        pass,
+        buffer,
+        offset,
+        count_buffer,
+        count_buffer_offset,
+        max_count,
+    );
 }
 
 #[no_mangle]
@@ -497,7 +515,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetIndexBuffer(
         buffer,
         conv::map_index_format(index_format).expect("Index format cannot be undefined"),
         offset,
-        NonZeroU64::new(size),
+        match size as usize {
+            native::WGPU_WHOLE_SIZE => None,
+            _ => NonZeroU64::new(size),
+        },
     );
 }
 
@@ -517,7 +538,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetVertexBuffer(
         slot,
         buffer,
         offset,
-        NonZeroU64::new(size),
+        match size as usize {
+            native::WGPU_WHOLE_SIZE => None,
+            _ => NonZeroU64::new(size),
+        },
     );
 }
 
@@ -795,7 +819,10 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetIndexBuffer(
         buffer,
         conv::map_index_format(format).unwrap(),
         offset,
-        NonZeroU64::new(size),
+        match size as usize {
+            native::WGPU_WHOLE_SIZE => None,
+            _ => NonZeroU64::new(size),
+        },
     );
 }
 
@@ -830,6 +857,9 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetVertexBuffer(
         slot,
         buffer,
         offset,
-        NonZeroU64::new(size),
+        match size as usize {
+            native::WGPU_WHOLE_SIZE => None,
+            _ => NonZeroU64::new(size),
+        },
     );
 }

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -211,7 +211,7 @@ pub fn map_device_descriptor<'a>(
     extras: Option<&native::WGPUDeviceExtras>,
 ) -> (wgt::DeviceDescriptor<Label<'a>>, Option<String>) {
     let limits = unsafe { des.requiredLimits.as_ref() }.map_or(
-        wgt::Limits::downlevel_webgl2_defaults(),
+        wgt::Limits::default(),
         |required_limits| unsafe {
             follow_chain!(
                 map_required_limits(required_limits,
@@ -270,7 +270,7 @@ pub fn map_required_limits(
     extras: Option<&native::WGPURequiredLimitsExtras>,
 ) -> wgt::Limits {
     let limits = required_limits.limits;
-    let mut wgt_limits = wgt::Limits::downlevel_webgl2_defaults();
+    let mut wgt_limits = wgt::Limits::default();
     if limits.maxTextureDimension1D != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_texture_dimension_1d = limits.maxTextureDimension1D;
     }

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -179,6 +179,11 @@ map_enum!(
     Compute
 );
 
+pub const WGPU_WHOLE_SIZE: ::std::os::raw::c_ulonglong = native::WGPU_WHOLE_SIZE as _;
+pub const WGPU_LIMIT_U64_UNDEFINED: ::std::os::raw::c_ulonglong =
+    native::WGPU_LIMIT_U64_UNDEFINED as _;
+pub const WGPU_WHOLE_MAP_SIZE: usize = native::WGPU_WHOLE_MAP_SIZE as _;
+
 pub fn map_extent3d(native: &native::WGPUExtent3D) -> wgt::Extent3d {
     wgt::Extent3d {
         width: native.width,
@@ -309,10 +314,10 @@ pub fn map_required_limits(
     if limits.maxUniformBuffersPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_uniform_buffers_per_shader_stage = limits.maxUniformBuffersPerShaderStage;
     }
-    if limits.maxUniformBufferBindingSize != native::WGPU_LIMIT_U64_UNDEFINED {
+    if limits.maxUniformBufferBindingSize != WGPU_LIMIT_U64_UNDEFINED {
         wgt_limits.max_uniform_buffer_binding_size = limits.maxUniformBufferBindingSize as u32;
     }
-    if limits.maxStorageBufferBindingSize != native::WGPU_LIMIT_U64_UNDEFINED {
+    if limits.maxStorageBufferBindingSize != WGPU_LIMIT_U64_UNDEFINED {
         wgt_limits.max_storage_buffer_binding_size = limits.maxStorageBufferBindingSize as u32;
     }
     if limits.minUniformBufferOffsetAlignment != native::WGPU_LIMIT_U32_UNDEFINED {
@@ -355,7 +360,7 @@ pub fn map_required_limits(
         if extras.maxPushConstantSize != native::WGPU_LIMIT_U32_UNDEFINED {
             wgt_limits.max_push_constant_size = extras.maxPushConstantSize;
         }
-        if extras.maxBufferSize != native::WGPU_LIMIT_U64_UNDEFINED {
+        if extras.maxBufferSize != WGPU_LIMIT_U64_UNDEFINED {
             wgt_limits.max_buffer_size = extras.maxBufferSize;
         }
     }

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -211,7 +211,7 @@ pub fn map_device_descriptor<'a>(
     extras: Option<&native::WGPUDeviceExtras>,
 ) -> (wgt::DeviceDescriptor<Label<'a>>, Option<String>) {
     let limits = unsafe { des.requiredLimits.as_ref() }.map_or(
-        wgt::Limits::downlevel_defaults(),
+        wgt::Limits::downlevel_webgl2_defaults(),
         |required_limits| unsafe {
             follow_chain!(
                 map_required_limits(required_limits,
@@ -270,92 +270,92 @@ pub fn map_required_limits(
     extras: Option<&native::WGPURequiredLimitsExtras>,
 ) -> wgt::Limits {
     let limits = required_limits.limits;
-    let mut wgt_limits = wgt::Limits::default();
-    if limits.maxTextureDimension1D != 0 {
+    let mut wgt_limits = wgt::Limits::downlevel_webgl2_defaults();
+    if limits.maxTextureDimension1D != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_texture_dimension_1d = limits.maxTextureDimension1D;
     }
-    if limits.maxTextureDimension2D != 0 {
+    if limits.maxTextureDimension2D != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_texture_dimension_2d = limits.maxTextureDimension2D;
     }
-    if limits.maxTextureDimension3D != 0 {
+    if limits.maxTextureDimension3D != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_texture_dimension_3d = limits.maxTextureDimension3D;
     }
-    if limits.maxTextureArrayLayers != 0 {
+    if limits.maxTextureArrayLayers != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_texture_array_layers = limits.maxTextureArrayLayers;
     }
-    if limits.maxBindGroups != 0 {
+    if limits.maxBindGroups != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_bind_groups = limits.maxBindGroups;
     }
-    if limits.maxDynamicUniformBuffersPerPipelineLayout != 0 {
+    if limits.maxDynamicUniformBuffersPerPipelineLayout != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_dynamic_uniform_buffers_per_pipeline_layout =
             limits.maxDynamicUniformBuffersPerPipelineLayout;
     }
-    if limits.maxDynamicStorageBuffersPerPipelineLayout != 0 {
+    if limits.maxDynamicStorageBuffersPerPipelineLayout != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_dynamic_storage_buffers_per_pipeline_layout =
             limits.maxDynamicStorageBuffersPerPipelineLayout;
     }
-    if limits.maxSampledTexturesPerShaderStage != 0 {
+    if limits.maxSampledTexturesPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_sampled_textures_per_shader_stage = limits.maxSampledTexturesPerShaderStage;
     }
-    if limits.maxSamplersPerShaderStage != 0 {
+    if limits.maxSamplersPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_samplers_per_shader_stage = limits.maxSamplersPerShaderStage;
     }
-    if limits.maxStorageBuffersPerShaderStage != 0 {
+    if limits.maxStorageBuffersPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_storage_buffers_per_shader_stage = limits.maxStorageBuffersPerShaderStage;
     }
-    if limits.maxStorageTexturesPerShaderStage != 0 {
+    if limits.maxStorageTexturesPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_storage_textures_per_shader_stage = limits.maxStorageTexturesPerShaderStage;
     }
-    if limits.maxUniformBuffersPerShaderStage != 0 {
+    if limits.maxUniformBuffersPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_uniform_buffers_per_shader_stage = limits.maxUniformBuffersPerShaderStage;
     }
-    if limits.maxUniformBufferBindingSize != 0 {
+    if limits.maxUniformBufferBindingSize != native::WGPU_LIMIT_U64_UNDEFINED {
         wgt_limits.max_uniform_buffer_binding_size = limits.maxUniformBufferBindingSize as u32;
     }
-    if limits.maxStorageBufferBindingSize != 0 {
+    if limits.maxStorageBufferBindingSize != native::WGPU_LIMIT_U64_UNDEFINED {
         wgt_limits.max_storage_buffer_binding_size = limits.maxStorageBufferBindingSize as u32;
     }
-    if limits.minUniformBufferOffsetAlignment != 0 {
+    if limits.minUniformBufferOffsetAlignment != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.min_uniform_buffer_offset_alignment = limits.minUniformBufferOffsetAlignment;
     }
-    if limits.minStorageBufferOffsetAlignment != 0 {
+    if limits.minStorageBufferOffsetAlignment != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.min_storage_buffer_offset_alignment = limits.minStorageBufferOffsetAlignment;
     }
-    if limits.maxVertexBuffers != 0 {
+    if limits.maxVertexBuffers != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_vertex_buffers = limits.maxVertexBuffers;
     }
-    if limits.maxVertexAttributes != 0 {
+    if limits.maxVertexAttributes != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_vertex_attributes = limits.maxVertexAttributes;
     }
-    if limits.maxVertexBufferArrayStride != 0 {
+    if limits.maxVertexBufferArrayStride != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_vertex_buffer_array_stride = limits.maxVertexBufferArrayStride;
     }
-    if limits.maxInterStageShaderComponents != 0 {
+    if limits.maxInterStageShaderComponents != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_inter_stage_shader_components = limits.maxInterStageShaderComponents;
     }
-    if limits.maxComputeWorkgroupStorageSize != 0 {
+    if limits.maxComputeWorkgroupStorageSize != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroup_storage_size = limits.maxComputeWorkgroupStorageSize;
     }
-    if limits.maxComputeInvocationsPerWorkgroup != 0 {
+    if limits.maxComputeInvocationsPerWorkgroup != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_invocations_per_workgroup = limits.maxComputeInvocationsPerWorkgroup;
     }
-    if limits.maxComputeWorkgroupSizeX != 0 {
+    if limits.maxComputeWorkgroupSizeX != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroup_size_x = limits.maxComputeWorkgroupSizeX;
     }
-    if limits.maxComputeWorkgroupSizeY != 0 {
+    if limits.maxComputeWorkgroupSizeY != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroup_size_y = limits.maxComputeWorkgroupSizeY;
     }
-    if limits.maxComputeWorkgroupSizeZ != 0 {
+    if limits.maxComputeWorkgroupSizeZ != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroup_size_z = limits.maxComputeWorkgroupSizeZ;
     }
-    if limits.maxComputeWorkgroupsPerDimension != 0 {
+    if limits.maxComputeWorkgroupsPerDimension != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroups_per_dimension = limits.maxComputeWorkgroupsPerDimension;
     }
     if let Some(extras) = extras {
-        if extras.maxPushConstantSize != 0 {
+        if extras.maxPushConstantSize != native::WGPU_LIMIT_U32_UNDEFINED {
             wgt_limits.max_push_constant_size = extras.maxPushConstantSize;
         }
-        if extras.maxBufferSize != 0 {
+        if extras.maxBufferSize != native::WGPU_LIMIT_U64_UNDEFINED {
             wgt_limits.max_buffer_size = extras.maxBufferSize;
         }
     }
@@ -437,7 +437,10 @@ pub fn map_texture_data_layout(native: &native::WGPUTextureDataLayout) -> wgt::I
     wgt::ImageDataLayout {
         offset: native.offset,
         bytes_per_row: NonZeroU32::new(native.bytesPerRow),
-        rows_per_image: NonZeroU32::new(native.rowsPerImage),
+        rows_per_image: match native.rowsPerImage {
+            native::WGPU_COPY_STRIDE_UNDEFINED => None,
+            _ => NonZeroU32::new(native.rowsPerImage),
+        },
     }
 }
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -182,7 +182,7 @@ map_enum!(
 pub const WGPU_WHOLE_SIZE: ::std::os::raw::c_ulonglong = native::WGPU_WHOLE_SIZE as _;
 pub const WGPU_LIMIT_U64_UNDEFINED: ::std::os::raw::c_ulonglong =
     native::WGPU_LIMIT_U64_UNDEFINED as _;
-pub const WGPU_WHOLE_MAP_SIZE: usize = native::WGPU_WHOLE_MAP_SIZE as _;
+pub const WGPU_WHOLE_MAP_SIZE: usize = usize::MAX; // SIZE_MAX
 
 pub fn map_extent3d(native: &native::WGPUExtent3D) -> wgt::Extent3d {
     wgt::Extent3d {

--- a/src/device.rs
+++ b/src/device.rs
@@ -471,8 +471,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
                     x => panic!("Unknown Buffer Type: {}", x),
                 },
                 has_dynamic_offset: entry.buffer.hasDynamicOffset,
-                min_binding_size: match entry.buffer.minBindingSize as usize {
-                    native::WGPU_WHOLE_SIZE => None,
+                min_binding_size: match entry.buffer.minBindingSize {
+                    conv::WGPU_WHOLE_SIZE => None,
                     _ => NonZeroU64::new(entry.buffer.minBindingSize),
                 },
             }
@@ -518,8 +518,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroup(
                     wgc::binding_model::BufferBinding {
                         buffer_id: buffer,
                         offset: entry.offset,
-                        size: match entry.size as usize {
-                            native::WGPU_WHOLE_SIZE => None,
+                        size: match entry.size {
+                            conv::WGPU_WHOLE_SIZE => None,
                             _ => NonZeroU64::new(entry.size),
                         },
                     },
@@ -787,7 +787,7 @@ pub unsafe extern "C" fn wgpuBufferGetMappedRange(
         buffer,
         offset as u64,
         match size {
-            native::WGPU_WHOLE_MAP_SIZE => None,
+            conv::WGPU_WHOLE_MAP_SIZE => None,
             _ => Some(size as u64),
         }
     ))

--- a/src/device.rs
+++ b/src/device.rs
@@ -442,7 +442,10 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
                     x => panic!("Unknown Buffer Type: {}", x),
                 },
                 has_dynamic_offset: entry.buffer.hasDynamicOffset,
-                min_binding_size: NonZeroU64::new(entry.buffer.minBindingSize),
+                min_binding_size: match entry.buffer.minBindingSize as usize {
+                    native::WGPU_WHOLE_SIZE => None,
+                    _ => NonZeroU64::new(entry.buffer.minBindingSize),
+                },
             }
         } else {
             panic!("No entry type specified.");
@@ -486,7 +489,10 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroup(
                     wgc::binding_model::BufferBinding {
                         buffer_id: buffer,
                         offset: entry.offset,
-                        size: NonZeroU64::new(entry.size),
+                        size: match entry.size as usize {
+                            native::WGPU_WHOLE_SIZE => None,
+                            _ => NonZeroU64::new(entry.size),
+                        },
                     },
                 ),
             }
@@ -748,9 +754,16 @@ pub unsafe extern "C" fn wgpuBufferGetMappedRange(
 ) -> *mut u8 {
     let buffer = buffer.expect("invalid buffer");
 
-    gfx_select!(buffer => GLOBAL.buffer_get_mapped_range(buffer, offset as u64, Some(size as u64)))
-        .expect("Unable to get mapped range")
-        .0
+    gfx_select!(buffer => GLOBAL.buffer_get_mapped_range(
+        buffer,
+        offset as u64,
+        match size {
+            native::WGPU_WHOLE_MAP_SIZE => None,
+            _ => Some(size as u64),
+        }
+    ))
+    .expect("Unable to get mapped range")
+    .0
 }
 
 #[no_mangle]
@@ -1022,9 +1035,15 @@ pub extern "C" fn wgpuTextureCreateView(
             range: wgt::ImageSubresourceRange {
                 aspect: conv::map_texture_aspect(descriptor.aspect),
                 base_mip_level: descriptor.baseMipLevel,
-                mip_level_count: NonZeroU32::new(descriptor.mipLevelCount),
+                mip_level_count: match descriptor.mipLevelCount {
+                    native::WGPU_MIP_LEVEL_COUNT_UNDEFINED => None,
+                    _ => NonZeroU32::new(descriptor.mipLevelCount),
+                },
                 base_array_layer: descriptor.baseArrayLayer,
-                array_layer_count: NonZeroU32::new(descriptor.arrayLayerCount),
+                array_layer_count: match descriptor.arrayLayerCount {
+                    native::WGPU_ARRAY_LAYER_COUNT_UNDEFINED => None,
+                    _ => NonZeroU32::new(descriptor.arrayLayerCount),
+                },
             },
         },
         None => wgc::resource::TextureViewDescriptor::default(),


### PR DESCRIPTION
Align better with other webgpu-headers implementations for unset/undefined values.
Currently we take zero for indicating unset/undefined values. But webgpu-headers defines [constants](https://github.com/webgpu-native/webgpu-headers/blob/69c87bd5017fefd058fdd2b997831da8933fc9c7/webgpu.h#L55-L61) which should be used instead.

After this PR, wgpu-native will require users to declare structs with [those constants](https://github.com/webgpu-native/webgpu-headers/blob/69c87bd5017fefd058fdd2b997831da8933fc9c7/webgpu.h#L55-L61) to indicate undefined values. So this is a big breaking change.

One example for `WGPULimits` is:

```diff
- (WGPULimits){
-     .maxBindGroups = 1,
- }
+ (WGPULimits){
+     .maxBindGroups = 1,
+     .maxTextureDimension1D = WGPU_LIMIT_U32_UNDEFINED,
+     .maxTextureDimension2D = WGPU_LIMIT_U32_UNDEFINED,
+     .maxTextureDimension3D = WGPU_LIMIT_U32_UNDEFINED,
+     .maxTextureArrayLayers = WGPU_LIMIT_U32_UNDEFINED,
+     .maxDynamicUniformBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,
+     .maxDynamicStorageBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,
+     .maxSampledTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+     .maxSamplersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+     .maxStorageBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+     .maxStorageTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+     .maxUniformBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+     .maxUniformBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,
+     .maxStorageBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,
+     .minUniformBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,
+     .minStorageBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,
+     .maxVertexBuffers = WGPU_LIMIT_U32_UNDEFINED,
+     .maxVertexAttributes = WGPU_LIMIT_U32_UNDEFINED,
+     .maxVertexBufferArrayStride = WGPU_LIMIT_U32_UNDEFINED,
+     .maxInterStageShaderComponents = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeWorkgroupStorageSize = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeInvocationsPerWorkgroup = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeWorkgroupSizeX = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeWorkgroupSizeY = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeWorkgroupSizeZ = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeWorkgroupsPerDimension = WGPU_LIMIT_U32_UNDEFINED,
+ }
```

Fixes #214 