### PR TITLE
Mentioning stable julia wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The bindings are based on the WebGPU-native header found at `ffi/webgpu-headers/
 - [bindc-wgpu](https://github.com/gecko0307/bindbc-wgpu) - D wrapper ([package](https://code.dlang.org/packages/bindbc-wgpu))
 - [porky11/wgpu](https://gitlab.com/scopes-libraries/wgpu) - experimental [Scopes](http://scopes.rocks) wrapper
 - [cshenton/WebGPU.jl](https://github.com/cshenton/WebGPU.jl) - experimental Julia wrapper
+- [dvijaha/WGPUNative.jl](https://github.com/dvijaha/WGPUNative.jl) - stable Julia wrapper
 - [kgpu/wgpuj](https://github.com/kgpu/kgpu/tree/master/wgpuj) - Java/Kotlin wrapper
 - [rajveermalviya/go-webgpu](https://github.com/rajveermalviya/go-webgpu) - Go wrapper
 


### PR DESCRIPTION
Adding a julia wrapper. 

This wrapper is being used by two derivative projects

https://github.com/dvijaha/WGSLTypes.jl.git
https://github.com/dvijaha/WGPUCompute.jl.git

Please let me know if licences need work.