### PR TITLE
check for undefined constants instead of zero values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,22 +102,25 @@ lib-native-release: Cargo.lock Cargo.toml Makefile $(WILDCARD_SOURCE)
 	cargo build --release $(EXTRA_BUILD_ARGS)
 
 example-compute: lib-native examples/compute/main.c
-	cd examples/compute && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. $(GENERATOR_PLATFORM) && cmake --build .
+	cd examples/compute && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .. $(GENERATOR_PLATFORM) && cmake --build .
 
 run-example-compute: example-compute
 	cd examples/compute && "$(OUTPUT_DIR)/compute" 1 2 3 4
 
 example-triangle: lib-native examples/triangle/main.c
-	cd examples/triangle && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. $(GENERATOR_PLATFORM) && cmake --build .
+	cd examples/triangle && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .. $(GENERATOR_PLATFORM) && cmake --build .
 
-run-example-triangle: example-triangle
+example-triangle-release: lib-native-release examples/triangle/main.c
+	cd examples/triangle && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .. $(GENERATOR_PLATFORM) && cmake --build .
+
+run-example-triangle-release: example-triangle-release
 	cd examples/triangle && "$(OUTPUT_DIR)/triangle"
 
 build-helper:
 	cargo build -p helper
 
 example-capture: lib-native build-helper examples/capture/main.c
-	cd examples/capture && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. $(GENERATOR_PLATFORM) && cmake --build .
+	cd examples/capture && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .. $(GENERATOR_PLATFORM) && cmake --build .
 
 run-example-capture: example-capture
 	cd examples/capture && "$(OUTPUT_DIR)/capture"

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ run-example-compute: example-compute
 example-triangle: lib-native examples/triangle/main.c
 	cd examples/triangle && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .. $(GENERATOR_PLATFORM) && cmake --build .
 
+run-example-triangle: example-triangle
+	cd examples/triangle && "$(OUTPUT_DIR)/triangle"
+
 example-triangle-release: lib-native-release examples/triangle/main.c
 	cd examples/triangle && $(CREATE_BUILD_DIR) && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .. $(GENERATOR_PLATFORM) && cmake --build .
 

--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -3,6 +3,21 @@
 #include "unused.h"
 #include "webgpu-headers/webgpu.h"
 #include "wgpu.h"
+#include <stdio.h>
+
+static void handle_device_lost(WGPUDeviceLostReason reason, char const *message,
+                               void *userdata) {
+  UNUSED(userdata);
+
+  printf("DEVICE LOST (%d): %s\n", reason, message);
+}
+
+static void handle_uncaptured_error(WGPUErrorType type, char const *message,
+                                    void *userdata) {
+  UNUSED(userdata);
+
+  printf("UNCAPTURED ERROR (%d): %s\n", type, message);
+}
 
 int main(int argc, char *argv[]) {
   UNUSED(argc);
@@ -31,10 +46,7 @@ int main(int argc, char *argv[]) {
                                .requiredLimits =
                                    &(WGPURequiredLimits){
                                        .nextInChain = NULL,
-                                       .limits =
-                                           (WGPULimits){
-                                               .maxBindGroups = 1,
-                                           },
+                                       .limits = WGPULimits_DEFAULT,
                                    },
                                .defaultQueue =
                                    (WGPUQueueDescriptor){
@@ -43,6 +55,9 @@ int main(int argc, char *argv[]) {
                                    },
                            },
                            request_device_callback, (void *)&device);
+
+  wgpuDeviceSetUncapturedErrorCallback(device, handle_uncaptured_error, NULL);
+  wgpuDeviceSetDeviceLostCallback(device, handle_device_lost, NULL);
 
   BufferDimensions bufferDimensions = buffer_dimensions_new(width, height);
   uint64_t bufferSize =
@@ -77,25 +92,14 @@ int main(int argc, char *argv[]) {
   WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(
       device, &(WGPUCommandEncoderDescriptor){.label = NULL});
 
-  WGPUTextureView outputAttachment = wgpuTextureCreateView(
-      texture, &(WGPUTextureViewDescriptor){
-                   .nextInChain = NULL,
-                   .label = NULL,
-                   .format = WGPUTextureFormat_Undefined,
-                   .dimension = WGPUTextureViewDimension_Undefined,
-                   .aspect = WGPUTextureAspect_All,
-                   .arrayLayerCount = 0,
-                   .baseArrayLayer = 0,
-                   .baseMipLevel = 0,
-                   .mipLevelCount = 0,
-               });
+  WGPUTextureView outputAttachment = wgpuTextureCreateView(texture, NULL);
 
   WGPURenderPassEncoder renderPass = wgpuCommandEncoderBeginRenderPass(
       encoder, &(WGPURenderPassDescriptor){
                    .colorAttachments =
                        &(WGPURenderPassColorAttachment){
                            .view = outputAttachment,
-                           .resolveTarget = 0,
+                           .resolveTarget = NULL,
                            .loadOp = WGPULoadOp_Clear,
                            .storeOp = WGPUStoreOp_Store,
                            .clearValue =
@@ -129,7 +133,7 @@ int main(int argc, char *argv[]) {
               (WGPUTextureDataLayout){
                   .offset = 0,
                   .bytesPerRow = bufferDimensions.padded_bytes_per_row,
-                  .rowsPerImage = 0,
+                  .rowsPerImage = WGPU_COPY_STRIDE_UNDEFINED,
               }},
       &textureExtent);
 

--- a/examples/framework.c
+++ b/examples/framework.c
@@ -78,7 +78,7 @@ void logCallback(WGPULogLevel level, const char *msg, void *userdata) {
   printf("[%s] %s\n", level_str, msg);
 }
 
-void initializeLog() {
+void initializeLog(void) {
   wgpuSetLogCallback(logCallback, NULL);
   wgpuSetLogLevel(WGPULogLevel_Warn);
 }

--- a/examples/framework.h
+++ b/examples/framework.h
@@ -1,5 +1,35 @@
 #include "wgpu.h"
 
+#define WGPULimits_DEFAULT                                                     \
+  (WGPULimits) {                                                               \
+    .maxBindGroups = WGPU_LIMIT_U32_UNDEFINED,                                 \
+    .maxTextureDimension1D = WGPU_LIMIT_U32_UNDEFINED,                         \
+    .maxTextureDimension2D = WGPU_LIMIT_U32_UNDEFINED,                         \
+    .maxTextureDimension3D = WGPU_LIMIT_U32_UNDEFINED,                         \
+    .maxTextureArrayLayers = WGPU_LIMIT_U32_UNDEFINED,                         \
+    .maxDynamicUniformBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,     \
+    .maxDynamicStorageBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,     \
+    .maxSampledTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,              \
+    .maxSamplersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,                     \
+    .maxStorageBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,               \
+    .maxStorageTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,              \
+    .maxUniformBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,               \
+    .maxUniformBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,                   \
+    .maxStorageBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,                   \
+    .minUniformBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,               \
+    .minStorageBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,               \
+    .maxVertexBuffers = WGPU_LIMIT_U32_UNDEFINED,                              \
+    .maxVertexAttributes = WGPU_LIMIT_U32_UNDEFINED,                           \
+    .maxVertexBufferArrayStride = WGPU_LIMIT_U32_UNDEFINED,                    \
+    .maxInterStageShaderComponents = WGPU_LIMIT_U32_UNDEFINED,                 \
+    .maxComputeWorkgroupStorageSize = WGPU_LIMIT_U32_UNDEFINED,                \
+    .maxComputeInvocationsPerWorkgroup = WGPU_LIMIT_U32_UNDEFINED,             \
+    .maxComputeWorkgroupSizeX = WGPU_LIMIT_U32_UNDEFINED,                      \
+    .maxComputeWorkgroupSizeY = WGPU_LIMIT_U32_UNDEFINED,                      \
+    .maxComputeWorkgroupSizeZ = WGPU_LIMIT_U32_UNDEFINED,                      \
+    .maxComputeWorkgroupsPerDimension = WGPU_LIMIT_U32_UNDEFINED,              \
+  }
+
 WGPUShaderModuleDescriptor load_wgsl(const char *name);
 
 void request_adapter_callback(WGPURequestAdapterStatus status,
@@ -12,7 +42,7 @@ void request_device_callback(WGPURequestDeviceStatus status,
 
 void readBufferMap(WGPUBufferMapAsyncStatus status, void *userdata);
 
-void initializeLog();
+void initializeLog(void);
 
 void printGlobalReport(WGPUGlobalReport report);
 void printAdapterFeatures(WGPUAdapter adapter);

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -57,7 +57,9 @@ static void handleGlfwKey(GLFWwindow *window, int key, int scancode, int action,
   }
 }
 
-int main() {
+int main(int argc, char *argv[]) {
+  UNUSED(argc);
+  UNUSED(argv);
   initializeLog();
 
   if (!glfwInit()) {
@@ -186,10 +188,7 @@ int main() {
                                .requiredLimits =
                                    &(WGPURequiredLimits){
                                        .nextInChain = NULL,
-                                       .limits =
-                                           (WGPULimits){
-                                               .maxBindGroups = 1,
-                                           },
+                                       .limits = WGPULimits_DEFAULT,
                                    },
                                .defaultQueue =
                                    (WGPUQueueDescriptor){
@@ -325,7 +324,7 @@ int main() {
                      .colorAttachments =
                          &(WGPURenderPassColorAttachment){
                              .view = nextTexture,
-                             .resolveTarget = 0,
+                             .resolveTarget = NULL,
                              .loadOp = WGPULoadOp_Clear,
                              .storeOp = WGPUStoreOp_Store,
                              .clearValue =

--- a/src/command.rs
+++ b/src/command.rs
@@ -85,8 +85,9 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearBuffer(
         buffer,
         offset,
         match size {
+            0 => panic!("invalid size"),
             conv::WGPU_WHOLE_SIZE => None,
-            _ => NonZeroU64::new(size),
+            _ => Some(NonZeroU64::new_unchecked(size)),
         }
     ))
     .expect("Unable to clear buffer")
@@ -567,8 +568,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetIndexBuffer(
         conv::map_index_format(index_format).expect("Index format cannot be undefined"),
         offset,
         match size {
+            0 => panic!("invalid size"),
             conv::WGPU_WHOLE_SIZE => None,
-            _ => NonZeroU64::new(size),
+            _ => Some(NonZeroU64::new_unchecked(size)),
         },
     );
 }
@@ -590,8 +592,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetVertexBuffer(
         buffer,
         offset,
         match size {
+            0 => panic!("invalid size"),
             conv::WGPU_WHOLE_SIZE => None,
-            _ => NonZeroU64::new(size),
+            _ => Some(NonZeroU64::new_unchecked(size)),
         },
     );
 }
@@ -859,8 +862,9 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetIndexBuffer(
         conv::map_index_format(format).unwrap(),
         offset,
         match size {
+            0 => panic!("invalid size"),
             conv::WGPU_WHOLE_SIZE => None,
-            _ => NonZeroU64::new(size),
+            _ => Some(NonZeroU64::new_unchecked(size)),
         },
     );
 }
@@ -893,8 +897,9 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetVertexBuffer(
         buffer,
         offset,
         match size {
+            0 => panic!("invalid size"),
             conv::WGPU_WHOLE_SIZE => None,
-            _ => NonZeroU64::new(size),
+            _ => Some(NonZeroU64::new_unchecked(size)),
         },
     );
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,4 @@
-use crate::native::{IntoHandle, IntoHandleWithContext, UnwrapId, Handle};
+use crate::native::{Handle, IntoHandle, IntoHandleWithContext, UnwrapId};
 use crate::{conv, handle_device_error, make_slice, native, Context, OwnedLabel};
 use std::ffi::CStr;
 use std::os::raw::c_char;

--- a/src/command.rs
+++ b/src/command.rs
@@ -84,7 +84,11 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearBuffer(
         command_encoder,
         buffer,
         offset,
-        NonZeroU64::new(size)))
+        match size {
+            conv::WGPU_WHOLE_SIZE => None,
+            _ => NonZeroU64::new(size),
+        }
+    ))
     .expect("Unable to clear buffer")
 }
 
@@ -562,7 +566,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetIndexBuffer(
         buffer,
         conv::map_index_format(index_format).expect("Index format cannot be undefined"),
         offset,
-        NonZeroU64::new(size),
+        match size {
+            conv::WGPU_WHOLE_SIZE => None,
+            _ => NonZeroU64::new(size),
+        },
     );
 }
 
@@ -582,7 +589,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetVertexBuffer(
         slot,
         buffer,
         offset,
-        NonZeroU64::new(size),
+        match size {
+            conv::WGPU_WHOLE_SIZE => None,
+            _ => NonZeroU64::new(size),
+        },
     );
 }
 
@@ -848,7 +858,10 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetIndexBuffer(
         buffer,
         conv::map_index_format(format).unwrap(),
         offset,
-        NonZeroU64::new(size),
+        match size {
+            conv::WGPU_WHOLE_SIZE => None,
+            _ => NonZeroU64::new(size),
+        },
     );
 }
 
@@ -879,6 +892,9 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetVertexBuffer(
         slot,
         buffer,
         offset,
-        NonZeroU64::new(size),
+        match size {
+            conv::WGPU_WHOLE_SIZE => None,
+            _ => NonZeroU64::new(size),
+        },
     );
 }

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -180,6 +180,12 @@ map_enum!(
     Compute
 );
 
+pub const WGPU_WHOLE_SIZE: ::std::os::raw::c_ulonglong = native::WGPU_WHOLE_SIZE as _;
+pub const WGPU_LIMIT_U64_UNDEFINED: ::std::os::raw::c_ulonglong =
+    native::WGPU_LIMIT_U64_UNDEFINED as _;
+// it's SIZE_MAX in headers but it's not available in some compilers
+pub const WGPU_WHOLE_MAP_SIZE: usize = usize::MAX;
+
 pub fn map_extent3d(native: &native::WGPUExtent3D) -> wgt::Extent3d {
     wgt::Extent3d {
         width: native.width,
@@ -246,7 +252,7 @@ pub fn map_device_descriptor<'a>(
     extras: Option<&native::WGPUDeviceExtras>,
 ) -> (wgt::DeviceDescriptor<Label<'a>>, Option<String>) {
     let limits = unsafe { des.requiredLimits.as_ref() }.map_or(
-        wgt::Limits::downlevel_defaults(),
+        wgt::Limits::default(),
         |required_limits| unsafe {
             follow_chain!(
                 map_required_limits(required_limits,
@@ -310,91 +316,91 @@ pub fn map_required_limits(
 ) -> wgt::Limits {
     let limits = required_limits.limits;
     let mut wgt_limits = wgt::Limits::default();
-    if limits.maxTextureDimension1D != 0 {
+    if limits.maxTextureDimension1D != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_texture_dimension_1d = limits.maxTextureDimension1D;
     }
-    if limits.maxTextureDimension2D != 0 {
+    if limits.maxTextureDimension2D != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_texture_dimension_2d = limits.maxTextureDimension2D;
     }
-    if limits.maxTextureDimension3D != 0 {
+    if limits.maxTextureDimension3D != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_texture_dimension_3d = limits.maxTextureDimension3D;
     }
-    if limits.maxTextureArrayLayers != 0 {
+    if limits.maxTextureArrayLayers != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_texture_array_layers = limits.maxTextureArrayLayers;
     }
-    if limits.maxBindGroups != 0 {
+    if limits.maxBindGroups != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_bind_groups = limits.maxBindGroups;
     }
-    if limits.maxDynamicUniformBuffersPerPipelineLayout != 0 {
+    if limits.maxDynamicUniformBuffersPerPipelineLayout != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_dynamic_uniform_buffers_per_pipeline_layout =
             limits.maxDynamicUniformBuffersPerPipelineLayout;
     }
-    if limits.maxDynamicStorageBuffersPerPipelineLayout != 0 {
+    if limits.maxDynamicStorageBuffersPerPipelineLayout != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_dynamic_storage_buffers_per_pipeline_layout =
             limits.maxDynamicStorageBuffersPerPipelineLayout;
     }
-    if limits.maxSampledTexturesPerShaderStage != 0 {
+    if limits.maxSampledTexturesPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_sampled_textures_per_shader_stage = limits.maxSampledTexturesPerShaderStage;
     }
-    if limits.maxSamplersPerShaderStage != 0 {
+    if limits.maxSamplersPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_samplers_per_shader_stage = limits.maxSamplersPerShaderStage;
     }
-    if limits.maxStorageBuffersPerShaderStage != 0 {
+    if limits.maxStorageBuffersPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_storage_buffers_per_shader_stage = limits.maxStorageBuffersPerShaderStage;
     }
-    if limits.maxStorageTexturesPerShaderStage != 0 {
+    if limits.maxStorageTexturesPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_storage_textures_per_shader_stage = limits.maxStorageTexturesPerShaderStage;
     }
-    if limits.maxUniformBuffersPerShaderStage != 0 {
+    if limits.maxUniformBuffersPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_uniform_buffers_per_shader_stage = limits.maxUniformBuffersPerShaderStage;
     }
-    if limits.maxUniformBufferBindingSize != 0 {
+    if limits.maxUniformBufferBindingSize != native::WGPU_LIMIT_U64_UNDEFINED as u64 {
         wgt_limits.max_uniform_buffer_binding_size = limits.maxUniformBufferBindingSize as u32;
     }
-    if limits.maxStorageBufferBindingSize != 0 {
+    if limits.maxStorageBufferBindingSize != native::WGPU_LIMIT_U64_UNDEFINED as u64 {
         wgt_limits.max_storage_buffer_binding_size = limits.maxStorageBufferBindingSize as u32;
     }
-    if limits.minUniformBufferOffsetAlignment != 0 {
+    if limits.minUniformBufferOffsetAlignment != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.min_uniform_buffer_offset_alignment = limits.minUniformBufferOffsetAlignment;
     }
-    if limits.minStorageBufferOffsetAlignment != 0 {
+    if limits.minStorageBufferOffsetAlignment != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.min_storage_buffer_offset_alignment = limits.minStorageBufferOffsetAlignment;
     }
-    if limits.maxVertexBuffers != 0 {
+    if limits.maxVertexBuffers != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_vertex_buffers = limits.maxVertexBuffers;
     }
-    if limits.maxVertexAttributes != 0 {
+    if limits.maxVertexAttributes != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_vertex_attributes = limits.maxVertexAttributes;
     }
-    if limits.maxVertexBufferArrayStride != 0 {
+    if limits.maxVertexBufferArrayStride != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_vertex_buffer_array_stride = limits.maxVertexBufferArrayStride;
     }
-    if limits.maxInterStageShaderComponents != 0 {
+    if limits.maxInterStageShaderComponents != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_inter_stage_shader_components = limits.maxInterStageShaderComponents;
     }
-    if limits.maxComputeWorkgroupStorageSize != 0 {
+    if limits.maxComputeWorkgroupStorageSize != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroup_storage_size = limits.maxComputeWorkgroupStorageSize;
     }
-    if limits.maxComputeInvocationsPerWorkgroup != 0 {
+    if limits.maxComputeInvocationsPerWorkgroup != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_invocations_per_workgroup = limits.maxComputeInvocationsPerWorkgroup;
     }
-    if limits.maxComputeWorkgroupSizeX != 0 {
+    if limits.maxComputeWorkgroupSizeX != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroup_size_x = limits.maxComputeWorkgroupSizeX;
     }
-    if limits.maxComputeWorkgroupSizeY != 0 {
+    if limits.maxComputeWorkgroupSizeY != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroup_size_y = limits.maxComputeWorkgroupSizeY;
     }
-    if limits.maxComputeWorkgroupSizeZ != 0 {
+    if limits.maxComputeWorkgroupSizeZ != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroup_size_z = limits.maxComputeWorkgroupSizeZ;
     }
-    if limits.maxComputeWorkgroupsPerDimension != 0 {
+    if limits.maxComputeWorkgroupsPerDimension != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroups_per_dimension = limits.maxComputeWorkgroupsPerDimension;
     }
     if let Some(extras) = extras {
-        if extras.maxPushConstantSize != 0 {
+        if extras.maxPushConstantSize != native::WGPU_LIMIT_U32_UNDEFINED {
             wgt_limits.max_push_constant_size = extras.maxPushConstantSize;
         }
-        if extras.maxBufferSize != 0 {
+        if extras.maxBufferSize != native::WGPU_LIMIT_U64_UNDEFINED as u64 {
             wgt_limits.max_buffer_size = extras.maxBufferSize;
         }
     }
@@ -479,8 +485,14 @@ pub fn map_image_copy_buffer(
 pub fn map_texture_data_layout(native: &native::WGPUTextureDataLayout) -> wgt::ImageDataLayout {
     wgt::ImageDataLayout {
         offset: native.offset,
-        bytes_per_row: NonZeroU32::new(native.bytesPerRow),
-        rows_per_image: NonZeroU32::new(native.rowsPerImage),
+        bytes_per_row: match native.bytesPerRow {
+            native::WGPU_COPY_STRIDE_UNDEFINED => None,
+            _ => NonZeroU32::new(native.bytesPerRow),
+        },
+        rows_per_image: match native.rowsPerImage {
+            native::WGPU_COPY_STRIDE_UNDEFINED => None,
+            _ => NonZeroU32::new(native.rowsPerImage),
+        },
     }
 }
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -486,12 +486,14 @@ pub fn map_texture_data_layout(native: &native::WGPUTextureDataLayout) -> wgt::I
     wgt::ImageDataLayout {
         offset: native.offset,
         bytes_per_row: match native.bytesPerRow {
+            0 => panic!("invalid bytesPerRow"),
             native::WGPU_COPY_STRIDE_UNDEFINED => None,
-            _ => NonZeroU32::new(native.bytesPerRow),
+            _ => Some(unsafe { NonZeroU32::new_unchecked(native.bytesPerRow) }),
         },
         rows_per_image: match native.rowsPerImage {
+            0 => panic!("invalid rowsPerImage"),
             native::WGPU_COPY_STRIDE_UNDEFINED => None,
-            _ => NonZeroU32::new(native.rowsPerImage),
+            _ => Some(unsafe { NonZeroU32::new_unchecked(native.bytesPerRow) }),
         },
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -482,8 +482,9 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
                 },
                 has_dynamic_offset: entry.buffer.hasDynamicOffset,
                 min_binding_size: match entry.buffer.minBindingSize {
+                    0 => panic!("invalid minBindingSize"),
                     conv::WGPU_WHOLE_SIZE => None,
-                    _ => NonZeroU64::new(entry.buffer.minBindingSize),
+                    _ => Some(NonZeroU64::new_unchecked(entry.buffer.minBindingSize)),
                 },
             }
         } else {
@@ -529,8 +530,9 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroup(
                         buffer_id: buffer,
                         offset: entry.offset,
                         size: match entry.size {
+                            0 => panic!("invalid size"),
                             conv::WGPU_WHOLE_SIZE => None,
-                            _ => NonZeroU64::new(entry.size),
+                            _ => Some(NonZeroU64::new_unchecked(entry.size)),
                         },
                     },
                 ),
@@ -1079,13 +1081,15 @@ pub unsafe extern "C" fn wgpuTextureCreateView(
                 aspect: conv::map_texture_aspect(descriptor.aspect),
                 base_mip_level: descriptor.baseMipLevel,
                 mip_level_count: match descriptor.mipLevelCount {
+                    0 => panic!("invalid mipLevelCount"),
                     native::WGPU_MIP_LEVEL_COUNT_UNDEFINED => None,
-                    _ => NonZeroU32::new(descriptor.mipLevelCount),
+                    _ => Some(NonZeroU32::new_unchecked(descriptor.mipLevelCount)),
                 },
                 base_array_layer: descriptor.baseArrayLayer,
                 array_layer_count: match descriptor.arrayLayerCount {
+                    0 => panic!("invalid arrayLayerCount"),
                     native::WGPU_ARRAY_LAYER_COUNT_UNDEFINED => None,
-                    _ => NonZeroU32::new(descriptor.arrayLayerCount),
+                    _ => Some(NonZeroU32::new_unchecked(descriptor.arrayLayerCount)),
                 },
             },
         },

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,9 @@
 use crate::conv::{
     map_adapter_options, map_device_descriptor, map_pipeline_layout_descriptor, map_shader_module,
 };
-use crate::native::{Handle, IntoHandle, UnwrapId, IntoHandleWithContext, unwrap_swap_chain_handle};
+use crate::native::{
+    unwrap_swap_chain_handle, Handle, IntoHandle, IntoHandleWithContext, UnwrapId,
+};
 use crate::{conv, follow_chain, handle_device_error, make_slice, native, OwnedLabel};
 use std::{
     borrow::Cow,
@@ -11,7 +13,7 @@ use std::{
     path::Path,
 };
 use thiserror::Error;
-use wgc::{gfx_select};
+use wgc::gfx_select;
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
@@ -799,7 +801,7 @@ pub unsafe extern "C" fn wgpuBufferGetMappedRange(
 ) -> *mut u8 {
     let (buffer, context) = buffer.unwrap_handle();
 
-    gfx_select!(buffer => GLOBAL.buffer_get_mapped_range(
+    gfx_select!(buffer => context.buffer_get_mapped_range(
         buffer,
         offset as u64,
         match size {
@@ -1005,7 +1007,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateSwapChain(
             context: context.clone(),
             surface_id: surface,
             device_id: device,
-        }.into_handle()
+        }
+        .into_handle()
     }
 }
 
@@ -1206,7 +1209,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderBundleEncoder(
         Ok(encoder) => native::WGPURenderBundleEncoderImpl {
             context: context.clone(),
             encoder,
-        }.into_handle(),
+        }
+        .into_handle(),
         Err(error) => {
             handle_device_error(device, &error);
             std::ptr::null_mut()
@@ -1313,17 +1317,23 @@ pub unsafe extern "C" fn wgpuCommandEncoderDrop(command_encoder: native::WGPUCom
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuRenderPassEncoderDrop(render_pass_encoder: native::WGPURenderPassEncoder) {
+pub unsafe extern "C" fn wgpuRenderPassEncoderDrop(
+    render_pass_encoder: native::WGPURenderPassEncoder,
+) {
     render_pass_encoder.drop();
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuComputePassEncoderDrop(compute_pass_encoder: native::WGPUComputePassEncoder) {
+pub unsafe extern "C" fn wgpuComputePassEncoderDrop(
+    compute_pass_encoder: native::WGPUComputePassEncoder,
+) {
     compute_pass_encoder.drop();
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuRenderBundleEncoderDrop(render_bundle_encoder: native::WGPURenderBundleEncoder) {
+pub unsafe extern "C" fn wgpuRenderBundleEncoderDrop(
+    render_bundle_encoder: native::WGPURenderBundleEncoder,
+) {
     render_bundle_encoder.drop();
 }
 


### PR DESCRIPTION
Align better with other webgpu-headers implementations for unset/undefined values.
Currently we take zero for indicating unset/undefined values. But webgpu-headers defines [constants](https://github.com/webgpu-native/webgpu-headers/blob/69c87bd5017fefd058fdd2b997831da8933fc9c7/webgpu.h#L55-L61) which should be used instead.

This introduces one breaking change; `WGPULimits` struct will have to be declared like this:

```diff
- (WGPULimits){
-     .maxBindGroups = 1,
- }
+ (WGPULimits){
+     .maxBindGroups = 1,
+     .maxTextureDimension1D = WGPU_LIMIT_U32_UNDEFINED,
+     .maxTextureDimension2D = WGPU_LIMIT_U32_UNDEFINED,
+     .maxTextureDimension3D = WGPU_LIMIT_U32_UNDEFINED,
+     .maxTextureArrayLayers = WGPU_LIMIT_U32_UNDEFINED,
+     .maxDynamicUniformBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,
+     .maxDynamicStorageBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,
+     .maxSampledTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+     .maxSamplersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+     .maxStorageBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+     .maxStorageTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+     .maxUniformBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,
+     .maxUniformBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,
+     .maxStorageBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,
+     .minUniformBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,
+     .minStorageBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,
+     .maxVertexBuffers = WGPU_LIMIT_U32_UNDEFINED,
+     .maxVertexAttributes = WGPU_LIMIT_U32_UNDEFINED,
+     .maxVertexBufferArrayStride = WGPU_LIMIT_U32_UNDEFINED,
+     .maxInterStageShaderComponents = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeWorkgroupStorageSize = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeInvocationsPerWorkgroup = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeWorkgroupSizeX = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeWorkgroupSizeY = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeWorkgroupSizeZ = WGPU_LIMIT_U32_UNDEFINED,
+     .maxComputeWorkgroupsPerDimension = WGPU_LIMIT_U32_UNDEFINED,
+ }
```

Fixes https://github.com/gfx-rs/wgpu-native/issues/214