### PR TITLE
Feature/enumerate adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,18 +192,23 @@ jobs:
           make example-capture
           make example-compute
           make example-triangle
+          make example-enumerate_adapters
       - if: ${{ matrix.run_examples }}
         name: Run examples debug
         run: |
           make run-example-capture
           make run-example-compute
+          make run-example-enumerate_adapters
       - name: Build examples release
         run: |
           make example-capture-release
           make example-compute-release
           make example-triangle-release
+          make example-enumerate_adapters-release
       - if: ${{ matrix.run_examples }}
         name: Run examples release
         run: |
           make run-example-capture-release
           make run-example-compute-release
+          make run-example-enumerate_adapters-release
+

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,18 @@ example-compute-release: examples-release
 run-example-compute-release: example-compute-release
 	cd examples/compute && "../build/RelWithDebInfo/compute/compute"
 
+example-enumerate_adapters: examples-debug
+	cd examples/build/Debug && cmake --build . --target enumerate_adapters
+
+run-example-enumerate_adapters: example-enumerate_adapters
+	cd examples/enumerate_adapters && "../build/Debug/enumerate_adapters/enumerate_adapters"
+
+example-enumerate_adapters-release: examples-release
+	cd examples/build/RelWithDebInfo && cmake --build . --target enumerate_adapters
+
+run-example-enumerate_adapters-release: example-enumerate_adapters-release
+	cd examples/triangle && "../build/RelWithDebInfo/enumerate_adapters/enumerate_adapters"
+
 example-triangle: examples-debug
 	cd examples/build/Debug && cmake --build . --target triangle
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,6 +29,7 @@ add_subdirectory(framework)
 
 add_subdirectory(capture)
 add_subdirectory(compute)
+add_subdirectory(enumerate_adapters)
 add_subdirectory(triangle)
 
 set(GLFW_USE_WAYLAND 1)

--- a/examples/capture/CMakeLists.txt
+++ b/examples/capture/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories(${CMAKE_SOURCE_DIR}/../ffi)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll)
 elseif(UNIX AND NOT APPLE)
     set(OS_LIBRARIES "-lm -ldl")
 elseif(APPLE)

--- a/examples/compute/CMakeLists.txt
+++ b/examples/compute/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(${CMAKE_SOURCE_DIR}/../ffi)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll)
 elseif(UNIX AND NOT APPLE)
     set(OS_LIBRARIES "-lm -ldl")
 elseif(APPLE)

--- a/examples/enumerate_adapters/CMakeLists.txt
+++ b/examples/enumerate_adapters/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.20)
+project(enumerate_adapters LANGUAGES C)
+
+add_executable(enumerate_adapters main.c)
+
+if (MSVC)
+    add_compile_options(/W4)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+include_directories(${CMAKE_SOURCE_DIR}/../ffi)
+include_directories(${CMAKE_SOURCE_DIR}/framework)
+
+if (WIN32)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt)
+elseif(UNIX AND NOT APPLE)
+    set(OS_LIBRARIES "-lm -ldl")
+elseif(APPLE)
+    set(OS_LIBRARIES "-framework CoreFoundation -framework QuartzCore -framework Metal")
+endif()
+
+target_link_libraries(enumerate_adapters framework ${WGPU_LIBRARY} ${OS_LIBRARIES})

--- a/examples/enumerate_adapters/CMakeLists.txt
+++ b/examples/enumerate_adapters/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(${CMAKE_SOURCE_DIR}/../ffi)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll)
 elseif(UNIX AND NOT APPLE)
     set(OS_LIBRARIES "-lm -ldl")
 elseif(APPLE)

--- a/examples/enumerate_adapters/main.c
+++ b/examples/enumerate_adapters/main.c
@@ -1,0 +1,48 @@
+#include "framework.h"
+#include "webgpu-headers/webgpu.h"
+#include "wgpu.h"
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+  frmwrk_setup_logging(WGPULogLevel_Warn);
+
+  WGPUInstance instance =
+      wgpuCreateInstance(&(const WGPUInstanceDescriptor){0});
+  assert(instance);
+
+  const size_t adapter_count =
+      wgpuInstanceEnumerateAdapters(instance, NULL, NULL);
+  WGPUAdapter *adapters = malloc(sizeof(WGPUAdapter) * adapter_count);
+  assert(adapters);
+  wgpuInstanceEnumerateAdapters(instance, NULL, adapters);
+
+  for (int i = 0; i < adapter_count; i++) {
+    WGPUAdapter adapter = adapters[i];
+    assert(adapter);
+
+    WGPUAdapterProperties props;
+    wgpuAdapterGetProperties(adapter, &props);
+    printf("WGPUAdapter: %d\n", i);
+    printf("WGPUAdapterProperties {\n"
+           "\tvendorID: %" PRIu32 "\n"
+           "\tvendorName: %s\n"
+           "\tarchitecture: %s\n"
+           "\tdeviceID: %" PRIu32 "\n"
+           "\tname: %s\n"
+           "\tdriverDescription: %s\n"
+           "\tadapterType: %#.8x\n"
+           "\tbackendType: %#.8x\n"
+           "}\n",
+           props.vendorID, props.vendorName, props.architecture, props.deviceID,
+           props.name, props.driverDescription, props.adapterType,
+           props.backendType);
+
+    wgpuAdapterDrop(adapter);
+  }
+
+  free(adapters);
+  wgpuInstanceDrop(instance);
+}

--- a/examples/framework/CMakeLists.txt
+++ b/examples/framework/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 include_directories(${CMAKE_SOURCE_DIR}/../ffi)
 
 if (WIN32)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll)
 elseif(UNIX AND NOT APPLE)
     set(OS_LIBRARIES "-lm -ldl")
 elseif(APPLE)

--- a/examples/triangle/CMakeLists.txt
+++ b/examples/triangle/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories(${DEP_GLFW_DIR}/include)
 
 if (WIN32)
     add_definitions(-DWGPU_TARGET_WINDOWS)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll)
 elseif(UNIX AND NOT APPLE)
     add_definitions(-DWGPU_TARGET_LINUX_X11)
     set(OS_LIBRARIES "-lm -ldl")

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -178,6 +178,11 @@ typedef struct WGPUSwapChainDescriptorExtras {
     WGPUTextureFormat const * viewFormats;
 } WGPUSwapChainDescriptorExtras;
 
+typedef struct WGPUInstanceEnumerateAdapterOptions {
+    WGPUChainedStruct chain;
+    WGPUInstanceBackendFlags backends;
+} WGPUInstanceEnumerateAdapterOptions;
+
 typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void * userdata);
 
 #ifdef __cplusplus
@@ -185,7 +190,7 @@ extern "C" {
 #endif
 
 void wgpuGenerateReport(WGPUInstance instance, WGPUGlobalReport * report);
-size_t wgpuInstanceEnumerateAdapters(WGPUInstance instance, WGPUAdapter * adapters);
+size_t wgpuInstanceEnumerateAdapters(WGPUInstance instance, WGPUInstanceEnumerateAdapterOptions const * options, WGPUAdapter * adapters);
 
 WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, uint32_t commandCount, WGPUCommandBuffer const * commands);
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -184,7 +184,8 @@ typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void *
 extern "C" {
 #endif
 
-void wgpuGenerateReport(WGPUInstance instance, WGPUGlobalReport* report);
+void wgpuGenerateReport(WGPUInstance instance, WGPUGlobalReport * report);
+size_t wgpuInstanceEnumerateAdapters(WGPUInstance instance, WGPUAdapter * adapters);
 
 WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, uint32_t commandCount, WGPUCommandBuffer const * commands);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use conv::{
-    map_adapter_options, map_device_descriptor, map_instance_descriptor,
-    map_pipeline_layout_descriptor, map_shader_module, map_surface, map_swapchain_descriptor,
-    write_limits_struct, CreateSurfaceParams,
+    map_adapter_options, map_device_descriptor, map_instance_backend_flags,
+    map_instance_descriptor, map_pipeline_layout_descriptor, map_shader_module, map_surface,
+    map_swapchain_descriptor, write_limits_struct, CreateSurfaceParams,
 };
 use std::{
     borrow::Cow,
@@ -2395,32 +2395,47 @@ pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuInstanceEnumerateAdapters(
     instance: native::WGPUInstance,
-    output: *mut native::WGPUAdapter,
+    options: Option<&native::WGPUInstanceEnumerateAdapterOptions>,
+    adapters: *mut native::WGPUAdapter,
 ) -> usize {
     let instance = instance.as_ref().expect("invalid instance");
     let context = &instance.context;
 
-    let mut adapters = context.enumerate_adapters(wgc::instance::AdapterInputs::Mask(
-        wgt::Backends::all(),
-        |_| (),
-    ));
-    if !output.is_null() {
-        let mut i = 0;
-        for adapter in adapters.drain(..) {
-            *output.add(i) = Box::into_raw(Box::new(WGPUAdapterImpl {
+    let inputs = match options {
+        Some(options) => {
+            wgc::instance::AdapterInputs::Mask(map_instance_backend_flags(options.backends), |_| ())
+        }
+        None => wgc::instance::AdapterInputs::Mask(wgt::Backends::all(), |_| ()),
+    };
+
+    let result = context.enumerate_adapters(inputs);
+    let count = result.len();
+
+    if !adapters.is_null() {
+        let temp = std::slice::from_raw_parts_mut(adapters, count);
+
+        result.iter().enumerate().for_each(|(i, id)| {
+            // It's users responsibility to drop the adapters they
+            // don't need.
+
+            temp[i] = Box::into_raw(Box::new(WGPUAdapterImpl {
                 context: context.clone(),
-                id: adapter,
+                id: *id,
                 name: CString::default(),
                 vendor_name: CString::default(),
                 architecture_name: CString::default(),
                 driver_desc: CString::default(),
             }));
-            i += 1;
-        }
-        i
+        });
     } else {
-        adapters.len()
+        // Drop all the adapters when only counting length.
+
+        result
+            .iter()
+            .for_each(|id| gfx_select!(id => context.adapter_drop(*id)));
     }
+
+    count
 }
 
 // QuerySet methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2403,7 +2403,7 @@ pub unsafe extern "C" fn wgpuInstanceEnumerateAdapters(
 
     let inputs = match options {
         Some(options) => {
-            wgc::instance::AdapterInputs::Mask(map_instance_backend_flags(options.backends), |_| ())
+            wgc::instance::AdapterInputs::Mask(map_instance_backend_flags(options.backends as native::WGPUInstanceBackend), |_| ())
         }
         None => wgc::instance::AdapterInputs::Mask(wgt::Backends::all(), |_| ()),
     };


### PR DESCRIPTION
I would love some advice on how to proceed with this.

I am interested in potentially using wgpu-native as a cross-platform graphics api.  For my application, a volume rendering tool for scientific data (https://www.allencell.org/pathtrace-rendering.html), it makes sense to be able to support multi-gpu systems and potentially allow gpu selection by very custom means.  

So I have done a very basic first pass at exposing enumerate_adapters but the enumeration I get spans all possible backends.  Apart from checking against a previously created "compatible surface", is there some way to detect a current backend at run time?  Or is it reasonable to return adapters from all supported back ends?

Also api advice welcomed: for example, should there be a callback passed in to wgpuInstanceEnumerateAdapters?

