### PR TITLE
Add a link to WebGPU-C++ wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The bindings are based on the WebGPU-native header found at `ffi/webgpu-headers/
 - [dvijaha/WGPUNative.jl](https://github.com/dvijaha/WGPUNative.jl) - stable Julia wrapper
 - [kgpu/wgpuj](https://github.com/kgpu/kgpu/tree/master/wgpuj) - Java/Kotlin wrapper
 - [rajveermalviya/go-webgpu](https://github.com/rajveermalviya/go-webgpu) - Go wrapper
+- [WebGPU-C++](https://github.com/eliemichel/WebGPU-Cpp) - Auto-generated C++ wrapper (developped for the [Learn WebGPU native](https://eliemichel.github.io/LearnWebGPU) course)
 
 Note: the version numbers of `wgpu-native` are not aligned with versions of `wgpu` or other crates!
 


### PR DESCRIPTION
Maybe the course could also be listed in Usage, or in the wiki?