### PR TITLE
Dont rename libs for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ FFI_DIR:=ffi
 BUILD_DIR:=build
 CREATE_BUILD_DIR:=
 OUTPUT_DIR:=
-FINAL_LIB_NAME:=libwgpu
-
 
 WILDCARD_SOURCE:=$(wildcard src/*.rs)
 
@@ -38,12 +36,10 @@ else
 endif
 
 ifeq ($(OS),Windows_NT)
-	LIB_NAME=libwgpu
 	LIB_EXTENSION=dll
 	OS_NAME=windows
 else
 	UNAME_S:=$(shell uname -s)
-	LIB_NAME=libwgpu
 	ifeq ($(UNAME_S),Linux)
 		LIB_EXTENSION=so
 		OS_NAME=linux
@@ -69,7 +65,7 @@ package: lib-native lib-native-release
 		rm -f dist/$$ARCHIVE; \
 		sed 's/webgpu-headers\///' ffi/wgpu.h > wgpu.h ;\
 		if [ $(OS_NAME) = windows ]; then \
-			7z a -tzip dist/$$ARCHIVE ./$(TARGET_DIR)/$$RELEASE/libwgpu_native.dll ./$(TARGET_DIR)/$$RELEASE/wgpu_native.dll ./$(TARGET_DIR)/$$RELEASE/libwgpu_native.lib ./ffi/webgpu-headers/*.h ./wgpu.h ./dist/commit-sha; \
+			7z a -tzip dist/$$ARCHIVE ./$(TARGET_DIR)/$$RELEASE/wgpu_native.dll ./$(TARGET_DIR)/$$RELEASE/wgpu_native.lib ./ffi/webgpu-headers/*.h ./wgpu.h ./dist/commit-sha; \
 		else \
 			zip -j dist/$$ARCHIVE $(TARGET_DIR)/$$RELEASE/libwgpu_native.$(LIB_EXTENSION) ./ffi/webgpu-headers/*.h ./wgpu.h ./dist/commit-sha; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,9 @@ package: lib-native lib-native-release
 		rm -f dist/$$ARCHIVE; \
 		sed 's/webgpu-headers\///' ffi/wgpu.h > wgpu.h ;\
 		if [ $(OS_NAME) = windows ]; then \
-			mv $(TARGET_DIR)/$$RELEASE/$(LIB_NAME).dll $(TARGET_DIR)/$$RELEASE/$(FINAL_LIB_NAME).dll; \
-			mv $(TARGET_DIR)/$$RELEASE/$(LIB_NAME).dll.lib $(TARGET_DIR)/$$RELEASE/$(FINAL_LIB_NAME).lib; \
-			7z a -tzip dist/$$ARCHIVE ./$(TARGET_DIR)/$$RELEASE/$(FINAL_LIB_NAME).$(LIB_EXTENSION) ./$(TARGET_DIR)/$$RELEASE/$(FINAL_LIB_NAME).lib ./ffi/webgpu-headers/*.h ./wgpu.h ./dist/commit-sha; \
+			7z a -tzip dist/$$ARCHIVE ./$(TARGET_DIR)/$$RELEASE/libwgpu_native.dll ./$(TARGET_DIR)/$$RELEASE/wgpu_native.dll ./$(TARGET_DIR)/$$RELEASE/libwgpu_native.lib ./ffi/webgpu-headers/*.h ./wgpu.h ./dist/commit-sha; \
 		else \
-			mv $(TARGET_DIR)/$$RELEASE/$(LIB_NAME).$(LIB_EXTENSION) $(TARGET_DIR)/$$RELEASE/$(FINAL_LIB_NAME).$(LIB_EXTENSION); \
-			zip -j dist/$$ARCHIVE $(TARGET_DIR)/$$RELEASE/$(FINAL_LIB_NAME).$(LIB_EXTENSION) ./ffi/webgpu-headers/*.h ./wgpu.h ./dist/commit-sha; \
+			zip -j dist/$$ARCHIVE $(TARGET_DIR)/$$RELEASE/libwgpu_native.$(LIB_EXTENSION) ./ffi/webgpu-headers/*.h ./wgpu.h ./dist/commit-sha; \
 		fi; \
 		rm wgpu.h ;\
 	done

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ cargo = find_program('cargo')
 if ['linux','android','darwin','cygwin','freebsd','netbsd','openbsd'].contains(host_machine.system())
     lib_path='target/release/libwgpu_native.a'
 else
-    lib_path='target/release/wgpu_native.lib'
+    lib_path='target/release/libwgpu_native.lib'
 endif
 
 #build by cargo

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ cargo = find_program('cargo')
 if ['linux','android','darwin','cygwin','freebsd','netbsd','openbsd'].contains(host_machine.system())
     lib_path='target/release/libwgpu_native.a'
 else
-    lib_path='target/release/libwgpu_native.lib'
+    lib_path='target/release/wgpu_native.lib'
 endif
 
 #build by cargo


### PR DESCRIPTION
 Closes #231

The binary libs that we package as part of a release were renamed to make the names consistent across OS's. Apparently this had unintended side-effects, see #228. I tried to fix this in #229 but that just broke the packaging instead 😕 . This fixes things again, simply by not renaming the libs.

I tried making the build produce `libwgpu_native.dll` instead of `wgpu_native.dll`, but was not able to make that work. If someone knows an easy way to add the "lib" prefix on Windows, that'd be great, but I have a feeling this might be muddy ... 

Anyway, downstream packages might need to update some paths:
* libwgpu.dll -> wgpu_native.dll
* libwgpu.so -> libwgpu_native.so
* libwgpu.dylib -> libwgpu_native.dylib
* 