### PR TITLE
Update webgpu header

### DIFF
--- a/examples/framework.c
+++ b/examples/framework.c
@@ -147,10 +147,6 @@ void printAdapterFeatures(WGPUAdapter adapter) {
       printf("\tDepthClipControl\n");
       break;
 
-    case WGPUFeatureName_Depth24UnormStencil8:
-      printf("\tDepth24UnormStencil8\n");
-      break;
-
     case WGPUFeatureName_Depth32FloatStencil8:
       printf("\tDepth32FloatStencil8\n");
       break;

--- a/examples/framework.h
+++ b/examples/framework.h
@@ -19,6 +19,7 @@
     .minUniformBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,               \
     .minStorageBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,               \
     .maxVertexBuffers = WGPU_LIMIT_U32_UNDEFINED,                              \
+    .maxBufferSize = WGPU_LIMIT_U64_UNDEFINED,                                 \
     .maxVertexAttributes = WGPU_LIMIT_U32_UNDEFINED,                           \
     .maxVertexBufferArrayStride = WGPU_LIMIT_U32_UNDEFINED,                    \
     .maxInterStageShaderComponents = WGPU_LIMIT_U32_UNDEFINED,                 \

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -79,13 +79,11 @@ typedef struct WGPUDeviceExtras {
 typedef struct WGPURequiredLimitsExtras {
     WGPUChainedStruct chain;
     uint32_t maxPushConstantSize;
-    uint64_t maxBufferSize;
 } WGPURequiredLimitsExtras;
 
 typedef struct WGPUSupportedLimitsExtras {
     WGPUChainedStructOut chain;
     uint32_t maxPushConstantSize;
-    uint64_t maxBufferSize;
 } WGPUSupportedLimitsExtras;
 
 typedef struct WGPUPushConstantRange {

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -331,6 +331,9 @@ pub fn map_required_limits(
     if limits.maxBindGroups != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_bind_groups = limits.maxBindGroups;
     }
+    //if limits.maxBindingsPerBindGroup != native::WGPU_LIMIT_U32_UNDEFINED {
+    //    wgt_limits.max_bindings_per_bind_group = limits.maxBindingsPerBindGroup;
+    //}  not yet supportted in wgt
     if limits.maxDynamicUniformBuffersPerPipelineLayout != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_dynamic_uniform_buffers_per_pipeline_layout =
             limits.maxDynamicUniformBuffersPerPipelineLayout;
@@ -369,6 +372,9 @@ pub fn map_required_limits(
     if limits.maxVertexBuffers != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_vertex_buffers = limits.maxVertexBuffers;
     }
+    if limits.maxBufferSize != native::WGPU_LIMIT_U64_UNDEFINED as u64 {
+        wgt_limits.max_buffer_size = limits.maxBufferSize;
+    }
     if limits.maxVertexAttributes != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_vertex_attributes = limits.maxVertexAttributes;
     }
@@ -378,6 +384,12 @@ pub fn map_required_limits(
     if limits.maxInterStageShaderComponents != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_inter_stage_shader_components = limits.maxInterStageShaderComponents;
     }
+    //if limits.maxInterStageShaderVariables != native::WGPU_LIMIT_U32_UNDEFINED {
+    //    wgt_limits.max_inter_stage_shader_variables = limits.maxIntmaxInterStageShaderVariableserStageShaderComponents;
+    //}  not yet in wgt
+    //if limits.maxColorAttachments != native::WGPU_LIMIT_U32_UNDEFINED {
+    //    wgt_limits.max_color_attachments = limits.maxColorAttachments;
+    //}  not yet in wgt
     if limits.maxComputeWorkgroupStorageSize != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroup_storage_size = limits.maxComputeWorkgroupStorageSize;
     }
@@ -399,9 +411,6 @@ pub fn map_required_limits(
     if let Some(extras) = extras {
         if extras.maxPushConstantSize != native::WGPU_LIMIT_U32_UNDEFINED {
             wgt_limits.max_push_constant_size = extras.maxPushConstantSize;
-        }
-        if extras.maxBufferSize != native::WGPU_LIMIT_U64_UNDEFINED as u64 {
-            wgt_limits.max_buffer_size = extras.maxBufferSize;
         }
     }
     wgt_limits
@@ -583,7 +592,6 @@ pub fn map_texture_format(value: native::WGPUTextureFormat) -> Option<wgt::Textu
         native::WGPUTextureFormat_Depth16Unorm => Some(wgt::TextureFormat::Depth16Unorm),
         native::WGPUTextureFormat_Depth24Plus => Some(wgt::TextureFormat::Depth24Plus),
         native::WGPUTextureFormat_Depth24PlusStencil8 => Some(wgt::TextureFormat::Depth24PlusStencil8),
-        native::WGPUTextureFormat_Depth24UnormStencil8 =>  None, // unimplmented in wgpu-core
         native::WGPUTextureFormat_Depth32Float => Some(wgt::TextureFormat::Depth32Float),
         native::WGPUTextureFormat_Depth32FloatStencil8 => Some(wgt::TextureFormat::Depth32FloatStencil8),
         native::WGPUTextureFormat_BC1RGBAUnorm => Some(wgt::TextureFormat::Bc1RgbaUnorm),

--- a/src/device.rs
+++ b/src/device.rs
@@ -323,7 +323,6 @@ fn write_limits_struct(
             (*extras).chain.sType = native::WGPUSType_SupportedLimitsExtras;
 
             (*extras).maxPushConstantSize = wgt_limits.max_push_constant_size;
-            (*extras).maxBufferSize = wgt_limits.max_buffer_size;
         }
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -301,6 +301,7 @@ fn write_limits_struct(
     limits.minUniformBufferOffsetAlignment = wgt_limits.min_uniform_buffer_offset_alignment;
     limits.minStorageBufferOffsetAlignment = wgt_limits.min_storage_buffer_offset_alignment;
     limits.maxVertexBuffers = wgt_limits.max_vertex_buffers;
+    limits.maxBufferSize = wgt_limits.max_buffer_size as u64;
     limits.maxVertexAttributes = wgt_limits.max_vertex_attributes;
     limits.maxVertexBufferArrayStride = wgt_limits.max_vertex_buffer_array_stride;
     limits.maxInterStageShaderComponents = wgt_limits.max_inter_stage_shader_components;


### PR DESCRIPTION
Diff of the header: https://github.com/webgpu-native/webgpu-headers/compare/402ee247cfbd9a65673e0f9141d80ccf38e79959..fa1c6ab4927ef1fa5731907b42b62ea93119866c