### PR TITLE
Fix packaging

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -289,6 +289,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: dist
+        path: dist
     - name: Create commit-sha file
       env:
         GITHUB_SHA: ${{ github.sha }}


### PR DESCRIPTION
The `download-artifact`  action was bumped to v3 recently, but it behaves a bit differently - we now also must set the path. Tested on my fork.