### PR TITLE
support nullable args in `requestAdapter` & `requestDevice`

### DIFF
--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -28,33 +28,16 @@ int main(int argc, char *argv[]) {
   int width = 100;
   int height = 200;
 
-  WGPUInstance instance = wgpuCreateInstance(&(WGPUInstanceDescriptor) {.nextInChain = NULL});
+  WGPUInstance instance =
+      wgpuCreateInstance(&(WGPUInstanceDescriptor){.nextInChain = NULL});
 
   WGPUAdapter adapter;
-  wgpuInstanceRequestAdapter(instance,
-                             &(WGPURequestAdapterOptions){
-                                 .nextInChain = NULL,
-                                 .compatibleSurface = NULL,
-                             },
-                             request_adapter_callback, (void *)&adapter);
+  wgpuInstanceRequestAdapter(instance, NULL, request_adapter_callback,
+                             (void *)&adapter);
 
   WGPUDevice device;
-  wgpuAdapterRequestDevice(adapter,
-                           &(WGPUDeviceDescriptor){
-                               .nextInChain = NULL,
-                               .label = "Device",
-                               .requiredLimits =
-                                   &(WGPURequiredLimits){
-                                       .nextInChain = NULL,
-                                       .limits = WGPULimits_DEFAULT,
-                                   },
-                               .defaultQueue =
-                                   (WGPUQueueDescriptor){
-                                       .nextInChain = NULL,
-                                       .label = NULL,
-                                   },
-                           },
-                           request_device_callback, (void *)&device);
+  wgpuAdapterRequestDevice(adapter, NULL, request_device_callback,
+                           (void *)&device);
 
   wgpuDeviceSetUncapturedErrorCallback(device, handle_uncaptured_error, NULL);
   wgpuDeviceSetDeviceLostCallback(device, handle_device_lost, NULL);

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -31,33 +31,16 @@ int main(int argc, char *argv[]) {
 
   initializeLog();
 
-  WGPUInstance instance = wgpuCreateInstance(&(WGPUInstanceDescriptor) {.nextInChain = NULL});
+  WGPUInstance instance =
+      wgpuCreateInstance(&(WGPUInstanceDescriptor){.nextInChain = NULL});
 
   WGPUAdapter adapter;
-  wgpuInstanceRequestAdapter(instance,
-                             &(WGPURequestAdapterOptions){
-                                 .nextInChain = NULL,
-                                 .compatibleSurface = NULL,
-                             },
-                             request_adapter_callback, (void *)&adapter);
+  wgpuInstanceRequestAdapter(instance, NULL, request_adapter_callback,
+                             (void *)&adapter);
 
   WGPUDevice device;
-  wgpuAdapterRequestDevice(adapter,
-                           &(WGPUDeviceDescriptor){
-                               .nextInChain = NULL,
-                               .label = "Device",
-                               .requiredLimits =
-                                   &(WGPURequiredLimits){
-                                       .nextInChain = NULL,
-                                       .limits = WGPULimits_DEFAULT,
-                                   },
-                               .defaultQueue =
-                                   (WGPUQueueDescriptor){
-                                       .nextInChain = NULL,
-                                       .label = NULL,
-                                   },
-                           },
-                           request_device_callback, (void *)&device);
+  wgpuAdapterRequestDevice(adapter, NULL, request_device_callback,
+                           (void *)&device);
 
   wgpuDeviceSetUncapturedErrorCallback(device, handle_uncaptured_error, NULL);
   wgpuDeviceSetDeviceLostCallback(device, handle_device_lost, NULL);

--- a/examples/framework.h
+++ b/examples/framework.h
@@ -1,36 +1,5 @@
 #include "wgpu.h"
 
-#define WGPULimits_DEFAULT                                                     \
-  (WGPULimits) {                                                               \
-    .maxBindGroups = WGPU_LIMIT_U32_UNDEFINED,                                 \
-    .maxTextureDimension1D = WGPU_LIMIT_U32_UNDEFINED,                         \
-    .maxTextureDimension2D = WGPU_LIMIT_U32_UNDEFINED,                         \
-    .maxTextureDimension3D = WGPU_LIMIT_U32_UNDEFINED,                         \
-    .maxTextureArrayLayers = WGPU_LIMIT_U32_UNDEFINED,                         \
-    .maxDynamicUniformBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,     \
-    .maxDynamicStorageBuffersPerPipelineLayout = WGPU_LIMIT_U32_UNDEFINED,     \
-    .maxSampledTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,              \
-    .maxSamplersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,                     \
-    .maxStorageBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,               \
-    .maxStorageTexturesPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,              \
-    .maxUniformBuffersPerShaderStage = WGPU_LIMIT_U32_UNDEFINED,               \
-    .maxUniformBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,                   \
-    .maxStorageBufferBindingSize = WGPU_LIMIT_U64_UNDEFINED,                   \
-    .minUniformBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,               \
-    .minStorageBufferOffsetAlignment = WGPU_LIMIT_U32_UNDEFINED,               \
-    .maxVertexBuffers = WGPU_LIMIT_U32_UNDEFINED,                              \
-    .maxBufferSize = WGPU_LIMIT_U64_UNDEFINED,                                 \
-    .maxVertexAttributes = WGPU_LIMIT_U32_UNDEFINED,                           \
-    .maxVertexBufferArrayStride = WGPU_LIMIT_U32_UNDEFINED,                    \
-    .maxInterStageShaderComponents = WGPU_LIMIT_U32_UNDEFINED,                 \
-    .maxComputeWorkgroupStorageSize = WGPU_LIMIT_U32_UNDEFINED,                \
-    .maxComputeInvocationsPerWorkgroup = WGPU_LIMIT_U32_UNDEFINED,             \
-    .maxComputeWorkgroupSizeX = WGPU_LIMIT_U32_UNDEFINED,                      \
-    .maxComputeWorkgroupSizeY = WGPU_LIMIT_U32_UNDEFINED,                      \
-    .maxComputeWorkgroupSizeZ = WGPU_LIMIT_U32_UNDEFINED,                      \
-    .maxComputeWorkgroupsPerDimension = WGPU_LIMIT_U32_UNDEFINED,              \
-  }
-
 WGPUShaderModuleDescriptor load_wgsl(const char *name);
 
 void request_adapter_callback(WGPURequestAdapterStatus status,

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  instance = wgpuCreateInstance(&(WGPUInstanceDescriptor) {.nextInChain = NULL});
+  instance = wgpuCreateInstance(&(WGPUInstanceDescriptor){.nextInChain = NULL});
 
   WGPUSurface surface;
 
@@ -171,32 +171,14 @@ int main(int argc, char *argv[]) {
 #endif
 
   WGPUAdapter adapter;
-  wgpuInstanceRequestAdapter(instance,
-                             &(WGPURequestAdapterOptions){
-                                 .nextInChain = NULL,
-                                 .compatibleSurface = surface,
-                             },
-                             request_adapter_callback, (void *)&adapter);
+  wgpuInstanceRequestAdapter(instance, NULL, request_adapter_callback,
+                             (void *)&adapter);
 
   printAdapterFeatures(adapter);
 
   WGPUDevice device;
-  wgpuAdapterRequestDevice(adapter,
-                           &(WGPUDeviceDescriptor){
-                               .nextInChain = NULL,
-                               .label = "Device",
-                               .requiredLimits =
-                                   &(WGPURequiredLimits){
-                                       .nextInChain = NULL,
-                                       .limits = WGPULimits_DEFAULT,
-                                   },
-                               .defaultQueue =
-                                   (WGPUQueueDescriptor){
-                                       .nextInChain = NULL,
-                                       .label = NULL,
-                                   },
-                           },
-                           request_device_callback, (void *)&device);
+  wgpuAdapterRequestDevice(adapter, NULL, request_device_callback,
+                           (void *)&device);
 
   wgpuDeviceSetUncapturedErrorCallback(device, handle_uncaptured_error, NULL);
   wgpuDeviceSetDeviceLostCallback(device, handle_device_lost, NULL);


### PR DESCRIPTION
As per the headers:

- [`options` arg is nullable for `wgpuInstanceRequestAdapter`](https://github.com/webgpu-native/webgpu-headers/blob/fa1c6ab4927ef1fa5731907b42b62ea93119866c/webgpu.h#L1497)
- [`descriptor` arg is nullable for `wgpuAdapterRequestDevice`](https://github.com/webgpu-native/webgpu-headers/blob/fa1c6ab4927ef1fa5731907b42b62ea93119866c/webgpu.h#L1413)