### PR TITLE
Remove references to versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-native"
-version = "0.6.0"
+version = "0.0.0"
 dependencies = [
  "bindgen",
  "cfg_aliases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-native"
-version = "0.6.0"
+version = "0.0.0"
 authors = [
 	"Dzmitry Malyshau <kvark@mozilla.com>",
 	"Joshua Groves <josh@joshgroves.com>",

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ The bindings are based on the WebGPU-native header found at `ffi/webgpu-headers/
 - [rajveermalviya/go-webgpu](https://github.com/rajveermalviya/go-webgpu) - Go wrapper
 - [WebGPU-C++](https://github.com/eliemichel/WebGPU-Cpp) - Auto-generated C++ wrapper (developped for the [Learn WebGPU native](https://eliemichel.github.io/LearnWebGPU) course)
 
-Note: the version numbers of `wgpu-native` are not aligned with versions of `wgpu` or other crates!
-
 ## Pre-built binaries
 
 Automated 32 and 64-bit builds for MacOS, Windows and Linux are available as Github [releases](https://github.com/gfx-rs/wgpu-native/releases). Details can be found in the  [Binary Releases](https://github.com/gfx-rs/wgpu-native/wiki/Binary-Releases) page in the wiki.

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 
-project('wgpu-native', 'c', version : '0.6.0', license : 'MIT OR Apache-2.0')
+project('wgpu-native', 'c', version : '0.0.0', license : 'MIT OR Apache-2.0')
 
 inc_dirs = [include_directories('ffi', is_system: true)]
 


### PR DESCRIPTION
* Remove sentence that states that our versioning does not match wgpu-core, because it does now.
* Set the project's version nr in Cargo.toml to 0.0.0 to avoid confusion.
* I'll add a note on https://github.com/gfx-rs/wgpu-native/wiki/Binary-Releases to explain how devs can create a release by creating a tag.