### PR TITLE
update `wgpu-core` to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,15 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,22 +34,11 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.37.0+1.3.209"
+version = "0.37.2+1.3.238"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006ca68e0f2b03f22d6fa9f2860f85aed430d257fec20f8879b2145e7c7ae1a6"
+checksum = "28bf19c1f0a470be5fbf7522a308a05df06610252c5bcf5143e1b23f629a9a03"
 dependencies = [
  "libloading",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -75,15 +55,13 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
- "env_logger",
  "lazy_static",
  "lazycell",
  "log",
@@ -93,6 +71,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
  "which",
 ]
 
@@ -116,16 +95,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags_serde_shim"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25c3d626f0280ec39b33a6fc5c6c1067432b4c41e94aee40ded197a6649bf025"
-dependencies = [
- "bitflags",
- "serde",
-]
 
 [[package]]
 name = "block"
@@ -167,12 +136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
 name = "clang-sys"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,30 +144,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
-dependencies = [
- "atty",
- "bitflags",
- "clap_lex",
- "indexmap",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -262,9 +201,8 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "d3d12"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827914e1f53b1e0e025ecd3d967a7836b7bcb54520f90e21ef8df7b4d88a2759"
+version = "0.6.0"
+source = "git+https://github.com/gfx-rs/d3d12-rs?rev=b940b1d71#b940b1d71ab7083ae80eec697872672dc1f2bd32"
 dependencies = [
  "bitflags",
  "libloading",
@@ -288,23 +226,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "foreign-types"
@@ -338,9 +263,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "glow"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bd5877156a19b8ac83a29b2306fe20537429d318f3ff0a1a2119f8d9c61919"
+checksum = "8edf6019dff2d92ad27c1e3ff82ad50a0aea5b01370353cc928bfdc33e95925c"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -411,25 +336,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
@@ -453,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -563,8 +473,8 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.10.0"
-source = "git+https://github.com/gfx-rs/naga?rev=c52d9102#c52d91023d43092323615fcc746162e478033f26"
+version = "0.11.0"
+source = "git+https://github.com/gfx-rs/naga?rev=f0edae8#f0edae8ce9e55eeef489fc53b10dc95fb79561cc"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -622,10 +532,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.1.0"
+name = "once_cell"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "parking_lot"
@@ -703,11 +613,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -755,8 +665,6 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -765,12 +673,6 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "renderdoc-sys"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
 
 [[package]]
 name = "ron"
@@ -847,20 +749,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -871,12 +767,6 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -899,6 +789,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,9 +814,9 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -928,13 +824,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -943,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -953,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -966,15 +862,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -982,13 +878,12 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.14.2"
-source = "git+https://github.com/gfx-rs/wgpu?rev=628a25e#628a25ef30f3584a3d3e58a203961c9e24850d66"
+version = "0.15.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=659f697#659f6977051345e4e06ab4832c6f7d268f25a1ad"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags",
- "cfg_aliases",
  "codespan-reporting",
  "fxhash",
  "log",
@@ -1007,8 +902,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.14.1"
-source = "git+https://github.com/gfx-rs/wgpu?rev=628a25e#628a25ef30f3584a3d3e58a203961c9e24850d66"
+version = "0.15.1"
+source = "git+https://github.com/gfx-rs/wgpu?rev=659f697#659f6977051345e4e06ab4832c6f7d268f25a1ad"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -1025,6 +920,7 @@ dependencies = [
  "gpu-descriptor",
  "js-sys",
  "khronos-egl",
+ "libc",
  "libloading",
  "log",
  "metal",
@@ -1034,7 +930,6 @@ dependencies = [
  "profiling",
  "range-alloc",
  "raw-window-handle",
- "renderdoc-sys",
  "smallvec",
  "thiserror",
  "wasm-bindgen",
@@ -1048,7 +943,6 @@ name = "wgpu-native"
 version = "0.0.0"
 dependencies = [
  "bindgen",
- "cfg_aliases",
  "lazy_static",
  "log",
  "naga",
@@ -1061,12 +955,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.14.1"
-source = "git+https://github.com/gfx-rs/wgpu?rev=628a25e#628a25ef30f3584a3d3e58a203961c9e24850d66"
+version = "0.15.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=659f697#659f6977051345e4e06ab4832c6f7d268f25a1ad"
 dependencies = [
  "bitflags",
- "bitflags_serde_shim",
+ "js-sys",
  "serde",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,30 +18,52 @@ license = "MIT OR Apache-2.0"
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
-default = []
+default = ["wgsl", "spirv", "glsl"]
+
 angle = ["wgc/angle"]
-vulkan-portability = ["wgc/vulkan-portability"]
+vulkan-portability = ["wgc/vulkan"]
+wgsl = ["wgc/wgsl"]
+spirv = ["naga/spv-in"]
+glsl = ["naga/glsl-in"]
 
 [dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "628a25e"
-# path = "../wgpu/wgpu-core"
-version = "0.14.2"
-features = ["raw-window-handle", "trace"]
+rev = "659f697"
+version = "0.15.0"
+features = ["raw-window-handle", "gles", "trace"]
+
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgc]
+package = "wgpu-core"
+git = "https://github.com/gfx-rs/wgpu"
+rev = "659f697"
+version = "0.15.0"
+features = ["metal"]
+
+[target.'cfg(windows)'.dependencies.wgc]
+package = "wgpu-core"
+git = "https://github.com/gfx-rs/wgpu"
+rev = "659f697"
+version = "0.15.0"
+features = ["dx11", "dx12"]
+
+[target.'cfg(any(windows, all(unix, not(target_arch = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
+package = "wgpu-core"
+git = "https://github.com/gfx-rs/wgpu"
+rev = "659f697"
+version = "0.15.0"
+features = ["vulkan"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "628a25e"
-# path = "../wgpu/wgpu-types"
-version = "0.14"
+rev = "659f697"
+version = "0.15.0"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "c52d9102"
-# version = "0.10"
-features = ["spv-in", "glsl-in"]
+rev = "f0edae8"
+version = "0.11"
 
 [dependencies]
 lazy_static = "1.4"
@@ -51,8 +73,7 @@ log = "0.4"
 thiserror = "1"
 
 [build-dependencies]
-bindgen = "0.60.1"
-cfg_aliases = "0.1"
+bindgen = "0.63"
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,20 +18,21 @@ license = "MIT OR Apache-2.0"
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
-default = ["wgsl", "spirv", "glsl"]
+default = ["wgsl", "spirv", "glsl", "trace"]
 
 angle = ["wgc/angle"]
 vulkan-portability = ["wgc/vulkan"]
 wgsl = ["wgc/wgsl"]
 spirv = ["naga/spv-in"]
 glsl = ["naga/glsl-in"]
+trace = ["wgc/trace"]
 
 [dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
 rev = "659f697"
 version = "0.15.0"
-features = ["raw-window-handle", "gles", "trace"]
+features = ["raw-window-handle", "gles"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgc]
 package = "wgpu-core"

--- a/build.rs
+++ b/build.rs
@@ -43,23 +43,23 @@ fn main() {
         .layout_tests(true);
 
     for (old_name, new_name) in types_to_rename {
-        let line = format!("pub type {} = *mut {};", old_name, new_name);
+        let line = format!("pub type {old_name} = *mut {new_name};");
         builder = builder
             .blocklist_type(old_name)
-            .blocklist_type(format!("{}Impl", old_name))
+            .blocklist_type(format!("{old_name}Impl"))
             .raw_line(line);
     }
 
     // See https://github.com/rust-lang/rust-bindgen/issues/1780
     if let Ok("ios") = env::var("CARGO_CFG_TARGET_OS").as_ref().map(|x| &**x) {
         let output = Command::new("xcrun")
-            .args(&["--sdk", "iphoneos", "--show-sdk-path"])
+            .args(["--sdk", "iphoneos", "--show-sdk-path"])
             .output()
             .expect("xcrun failed")
             .stdout;
         let sdk = std::str::from_utf8(&output).expect("invalid output from `xcrun`");
         builder = builder
-            .clang_arg(format!("-isysroot {}", sdk))
+            .clang_arg(format!("-isysroot {sdk}"))
             .clang_arg("--target=arm64-apple-ios");
     }
 

--- a/build.rs
+++ b/build.rs
@@ -3,27 +3,6 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
-    // Setup cfg aliases
-    cfg_aliases::cfg_aliases! {
-        // Vendors/systems
-        wasm: { target_arch = "wasm32" },
-        apple: { any(target_os = "ios", target_os = "macos") },
-        unix_wo_apple: {all(unix, not(apple))},
-
-        // Backends
-        vulkan: { all(not(wasm), any(windows, unix_wo_apple, feature = "vulkan-portability")) },
-        metal: { all(not(wasm), apple) },
-        dx12: { all(not(wasm), windows) },
-        dx11: { all(not(wasm), windows) },
-        gl: {
-            any(
-                unix_wo_apple,
-                feature = "angle",
-                wasm
-            )
-        },
-    }
-
     println!("cargo:rerun-if-changed=ffi/webgpu-headers/webgpu.h");
     println!("cargo:rerun-if-changed=ffi/wgpu.h");
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -61,9 +61,19 @@ typedef enum WGPUInstanceBackend {
 } WGPUInstanceBackend;
 typedef WGPUFlags WGPUInstanceBackendFlags;
 
+typedef enum WGPUDx12Compiler {
+    WGPUDx12Compiler_Undefined = 0x00000000,
+    WGPUDx12Compiler_Fxc = 0x00000001,
+    WGPUDx12Compiler_Dxc = 0x00000002,
+    WGPUDx12Compiler_Force32 = 0x7FFFFFFF
+} WGPUDx12Compiler;
+
 typedef struct WGPUInstanceExtras {
     WGPUChainedStruct chain;
     WGPUInstanceBackendFlags backends;
+    WGPUDx12Compiler dx12ShaderCompiler;
+    const char* dxilPath;
+    const char* dxcPath;
 } WGPUInstanceExtras;
 
 typedef struct WGPUAdapterExtras {

--- a/src/command.rs
+++ b/src/command.rs
@@ -284,7 +284,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderPushDebugGroup(
 pub unsafe extern "C" fn wgpuComputePassEncoderEnd(pass_handle: native::WGPUComputePassEncoder) {
     let (pass, context) = unwrap_compute_pass_encoder(pass_handle);
     let encoder_id = pass.parent_id();
-    gfx_select!(encoder_id => context.command_encoder_run_compute_pass(encoder_id, &pass))
+    gfx_select!(encoder_id => context.command_encoder_run_compute_pass(encoder_id, pass))
         .expect("Unable to end compute pass");
 
     // NOTE: Automatically drops the encoder
@@ -295,7 +295,7 @@ pub unsafe extern "C" fn wgpuComputePassEncoderEnd(pass_handle: native::WGPUComp
 pub unsafe extern "C" fn wgpuRenderPassEncoderEnd(pass_handle: native::WGPURenderPassEncoder) {
     let (pass, context) = unwrap_render_pass_encoder(pass_handle);
     let encoder_id = pass.parent_id();
-    gfx_select!(encoder_id => context.command_encoder_run_render_pass(encoder_id, &pass))
+    gfx_select!(encoder_id => context.command_encoder_run_render_pass(encoder_id, pass))
         .expect("Unable to end render pass");
 
     // NOTE: Automatically drops the encoder
@@ -611,7 +611,7 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetPushConstants(
     let (pass, _) = unwrap_render_pass_encoder(pass);
     render_ffi::wgpu_render_pass_set_push_constants(
         pass,
-        wgt::ShaderStages::from_bits(stages as u32).expect("Invalid shader stage"),
+        wgt::ShaderStages::from_bits(stages).expect("Invalid shader stage"),
         offset,
         size_bytes,
         size,

--- a/src/command.rs
+++ b/src/command.rs
@@ -603,7 +603,7 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetVertexBuffer(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderPassEncoderSetPushConstants(
     pass: native::WGPURenderPassEncoder,
-    stages: native::WGPUShaderStage,
+    stages: native::WGPUShaderStageFlags,
     offset: u32,
     size_bytes: u32,
     size: *const u8,

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -204,7 +204,7 @@ pub fn map_origin3d(native: &native::WGPUOrigin3D) -> wgt::Origin3d {
     }
 }
 
-pub fn map_instance_backend_flags(flags: u32) -> wgt::Backends {
+pub fn map_instance_backend_flags(flags: native::WGPUInstanceBackend) -> wgt::Backends {
     let mut result: wgt::Backends = wgt::Backends::empty();
     if (flags & native::WGPUInstanceBackend_BrowserWebGPU) != 0 {
         result |= wgt::Backends::BROWSER_WEBGPU;
@@ -246,7 +246,7 @@ pub fn map_instance_descriptor(
         };
 
         wgt::InstanceDescriptor {
-            backends: map_instance_backend_flags(extras.backends),
+            backends: map_instance_backend_flags(extras.backends as native::WGPUInstanceBackend),
             dx12_shader_compiler,
         }
     } else {

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -459,7 +459,7 @@ pub fn map_shader_module<'a>(
         let module = parser.parse().unwrap();
         return wgc::pipeline::ShaderModuleSource::Naga(Cow::Owned(module));
     }
- 
+
     #[cfg(feature = "glsl")]
     if let Some(glsl) = glsl {
         let c_str: &CStr = unsafe { CStr::from_ptr(glsl.code) };

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -172,6 +172,7 @@ map_enum!(
     Sint32x4
 );
 
+#[cfg(feature = "glsl")]
 map_enum!(
     map_shader_stage,
     WGPUShaderStage,

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -205,22 +205,22 @@ pub fn map_origin3d(native: &native::WGPUOrigin3D) -> wgt::Origin3d {
 
 pub fn map_instance_backend_flags(flags: u32) -> wgt::Backends {
     let mut result: wgt::Backends = wgt::Backends::empty();
-    if (flags & native::WGPUInstanceBackend_BrowserWebGPU as u32) != 0 {
+    if (flags & native::WGPUInstanceBackend_BrowserWebGPU) != 0 {
         result |= wgt::Backends::BROWSER_WEBGPU;
     }
-    if (flags & native::WGPUInstanceBackend_Vulkan as u32) != 0 {
+    if (flags & native::WGPUInstanceBackend_Vulkan) != 0 {
         result |= wgt::Backends::VULKAN;
     }
-    if (flags & native::WGPUInstanceBackend_GL as u32) != 0 {
+    if (flags & native::WGPUInstanceBackend_GL) != 0 {
         result |= wgt::Backends::GL;
     }
-    if (flags & native::WGPUInstanceBackend_Metal as u32) != 0 {
+    if (flags & native::WGPUInstanceBackend_Metal) != 0 {
         result |= wgt::Backends::METAL;
     }
-    if (flags & native::WGPUInstanceBackend_DX12 as u32) != 0 {
+    if (flags & native::WGPUInstanceBackend_DX12) != 0 {
         result |= wgt::Backends::DX12;
     }
-    if (flags & native::WGPUInstanceBackend_DX11 as u32) != 0 {
+    if (flags & native::WGPUInstanceBackend_DX11) != 0 {
         result |= wgt::Backends::DX11;
     }
     result
@@ -236,10 +236,10 @@ pub fn map_instance_descriptor(
             native::WGPUDx12Compiler_Dxc => wgt::Dx12Compiler::Dxc {
                 dxil_path: unsafe { extras.dxilPath.as_ref() }
                     .and_then(|v| OwnedLabel::new(v).0)
-                    .and_then(|v| Some(Path::new(&v).to_path_buf())),
+                    .map(|v| Path::new(&v).to_path_buf()),
                 dxc_path: unsafe { extras.dxcPath.as_ref() }
                     .and_then(|v| OwnedLabel::new(v).0)
-                    .and_then(|v| Some(Path::new(&v).to_path_buf())),
+                    .map(|v| Path::new(&v).to_path_buf()),
             },
             _ => wgt::Dx12Compiler::default(),
         };
@@ -567,7 +567,7 @@ pub fn map_texture_dimension(value: native::WGPUTextureDimension) -> wgt::Textur
         native::WGPUTextureDimension_1D => wgt::TextureDimension::D1,
         native::WGPUTextureDimension_2D => wgt::TextureDimension::D2,
         native::WGPUTextureDimension_3D => wgt::TextureDimension::D3,
-        x => panic!("Unknown texture dimension: {}", x),
+        x => panic!("Unknown texture dimension: {x}"),
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -1023,6 +1023,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateSwapChain(
         height: descriptor.height,
         present_mode: conv::map_present_mode(descriptor.presentMode),
         alpha_mode: wgt::CompositeAlphaMode::Auto,
+        view_formats: Vec::new(),
     };
     let error = gfx_select!(device => context.surface_configure(surface, device, &config));
     if let Some(error) = error {
@@ -1149,6 +1150,12 @@ pub unsafe extern "C" fn wgpuDeviceCreateTexture(
             .expect("invalid texture format for texture descriptor"),
         usage: wgt::TextureUsages::from_bits(descriptor.usage)
             .expect("invalid texture usage for texture descriptor"),
+        view_formats: make_slice(descriptor.viewFormats, descriptor.viewFormatCount as usize)
+            .iter()
+            .map(|v| {
+                conv::map_texture_format(*v).expect("invalid view format for texture descriptor")
+            })
+            .collect(),
     };
 
     let (id, error) = gfx_select!(device => context.device_create_texture(device, &desc, ()));

--- a/src/device.rs
+++ b/src/device.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
                         native::WGPUBackendType_D3D12 => wgt::Backends::DX12,
                         native::WGPUBackendType_D3D11 => wgt::Backends::DX11,
                         native::WGPUBackendType_OpenGL => wgt::Backends::GL,
-                        _ => panic!("Invalid backend {}", given_backend),
+                        _ => panic!("Invalid backend {given_backend}"),
                     },
                     |_| (),
                 ),
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
             );
         }
         Err(err) => {
-            let message = CString::new(format!("{:?}", err)).unwrap();
+            let message = CString::new(format!("{err:?}")).unwrap();
 
             (callback.unwrap())(
                 match err {
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn wgpuAdapterRequestDevice(
             );
         }
         Some(err) => {
-            let message = CString::new(format!("{:?}", err)).unwrap();
+            let message = CString::new(format!("{err:?}")).unwrap();
 
             (callback.unwrap())(
                 native::WGPURequestDeviceStatus_Error,
@@ -319,7 +319,7 @@ fn write_limits_struct(
     limits.minUniformBufferOffsetAlignment = wgt_limits.min_uniform_buffer_offset_alignment;
     limits.minStorageBufferOffsetAlignment = wgt_limits.min_storage_buffer_offset_alignment;
     limits.maxVertexBuffers = wgt_limits.max_vertex_buffers;
-    limits.maxBufferSize = wgt_limits.max_buffer_size as u64;
+    limits.maxBufferSize = wgt_limits.max_buffer_size;
     limits.maxVertexAttributes = wgt_limits.max_vertex_attributes;
     limits.maxVertexBufferArrayStride = wgt_limits.max_vertex_buffer_array_stride;
     limits.maxInterStageShaderComponents = wgt_limits.max_inter_stage_shader_components;
@@ -436,7 +436,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
                     native::WGPUTextureSampleType_Depth => wgt::TextureSampleType::Depth,
                     native::WGPUTextureSampleType_Sint => wgt::TextureSampleType::Sint,
                     native::WGPUTextureSampleType_Uint => wgt::TextureSampleType::Uint,
-                    x => panic!("Unknown texture SampleType: {}", x),
+                    x => panic!("Unknown texture SampleType: {x}"),
                 },
                 view_dimension: match entry.texture.viewDimension {
                     native::WGPUTextureViewDimension_1D => wgt::TextureViewDimension::D1,
@@ -447,7 +447,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
                         wgt::TextureViewDimension::CubeArray
                     }
                     native::WGPUTextureViewDimension_3D => wgt::TextureViewDimension::D3,
-                    x => panic!("Unknown texture ViewDimension: {}", x),
+                    x => panic!("Unknown texture ViewDimension: {x}"),
                 },
                 multisampled: entry.texture.multisampled,
             }
@@ -462,7 +462,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
                 native::WGPUSamplerBindingType_Comparison => {
                     wgt::BindingType::Sampler(wgt::SamplerBindingType::Comparison)
                 }
-                x => panic!("Unknown Sampler Type: {}", x),
+                x => panic!("Unknown Sampler Type: {x}"),
             }
         } else if is_storage_texture {
             wgt::BindingType::StorageTexture {
@@ -470,7 +470,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
                     native::WGPUStorageTextureAccess_WriteOnly => {
                         wgt::StorageTextureAccess::WriteOnly
                     }
-                    x => panic!("Unknown StorageTextureAccess: {}", x),
+                    x => panic!("Unknown StorageTextureAccess: {x}"),
                 },
                 format: conv::map_texture_format(entry.storageTexture.format)
                     .expect("StorageTexture format missing"),
@@ -483,7 +483,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
                         wgt::TextureViewDimension::CubeArray
                     }
                     native::WGPUTextureViewDimension_3D => wgt::TextureViewDimension::D3,
-                    x => panic!("Unknown texture ViewDimension: {}", x),
+                    x => panic!("Unknown texture ViewDimension: {x}"),
                 },
             }
         } else if is_buffer {
@@ -496,7 +496,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
                     native::WGPUBufferBindingType_ReadOnlyStorage => {
                         wgt::BufferBindingType::Storage { read_only: true }
                     }
-                    x => panic!("Unknown Buffer Type: {}", x),
+                    x => panic!("Unknown Buffer Type: {x}"),
                 },
                 has_dynamic_offset: entry.buffer.hasDynamicOffset,
                 min_binding_size: match entry.buffer.minBindingSize {
@@ -781,7 +781,7 @@ pub unsafe extern "C" fn wgpuBufferMapAsync(
             native::WGPUMapMode_Write => wgc::device::HostMap::Write,
             native::WGPUMapMode_Read => wgc::device::HostMap::Read,
             native::WGPUMapMode_None => panic!("Buffer map mode None is not supported."),
-            x => panic!("Unknown map mode: {}", x),
+            x => panic!("Unknown map mode: {x}"),
         },
         callback: wgc::resource::BufferMapCallback::from_c(wgc::resource::BufferMapCallbackC {
             callback: std::mem::transmute(callback.expect("Callback cannot be null")),
@@ -870,7 +870,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
                     step_mode: match buffer.stepMode {
                         native::WGPUVertexStepMode_Vertex => wgt::VertexStepMode::Vertex,
                         native::WGPUVertexStepMode_Instance => wgt::VertexStepMode::Instance,
-                        x => panic!("Unknown step mode {}", x),
+                        x => panic!("Unknown step mode {x}"),
                     },
                     attributes: Cow::Owned(
                         make_slice(buffer.attributes, buffer.attributeCount as usize)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,7 +567,7 @@ pub unsafe extern "C" fn wgpuSurfaceGetPreferredFormat(
                 .expect("Could not get preferred swap chain format"),
         )
         .expect("Could not get preferred swap chain format"),
-        Err(err) => panic!("Could not get preferred swap chain format: {}", err),
+        Err(err) => panic!("Could not get preferred swap chain format: {err:?}"),
     };
 
     preferred_format
@@ -597,7 +597,7 @@ pub unsafe extern "C" fn wgpuSurfaceGetSupportedFormats(
             // so, filter them out.
             .filter_map(|f| conv::to_native_texture_format(*f))
             .collect::<Vec<native::WGPUTextureFormat>>(),
-        Err(err) => panic!("Could not get supported swap chain formats: {}", err),
+        Err(err) => panic!("Could not get supported swap chain formats: {err:?}"),
     };
     native_formats.shrink_to_fit();
 
@@ -634,7 +634,7 @@ pub unsafe extern "C" fn wgpuSurfaceGetSupportedPresentModes(
                 | wgt::PresentMode::FifoRelaxed => None, // needs to be supported in webgpu.h
             })
             .collect::<Vec<native::WGPUPresentMode>>(),
-        Err(err) => panic!("Could not get supported present modes: {}", err),
+        Err(err) => panic!("Could not get supported present modes: {err:?}"),
     };
     modes.shrink_to_fit();
 
@@ -719,10 +719,10 @@ pub fn handle_device_error_raw(device: id::DeviceId, typ: native::WGPUErrorType,
                 let cbs = CALLBACKS.lock().unwrap();
                 let cb = cbs.device_lost.get(&device);
                 if let Some(cb) = cb {
-                    (*cb).callback.unwrap()(
+                    cb.callback.unwrap()(
                         native::WGPUDeviceLostReason_Destroyed,
                         msg_c.as_ptr(),
-                        (*cb).userdata,
+                        cb.userdata,
                     );
                 }
             }
@@ -730,7 +730,7 @@ pub fn handle_device_error_raw(device: id::DeviceId, typ: native::WGPUErrorType,
                 let cbs = CALLBACKS.lock().unwrap();
                 let cb = cbs.uncaptured_errors.get(&device);
                 if let Some(cb) = cb {
-                    (*cb).callback.unwrap()(typ, msg_c.as_ptr(), (*cb).userdata);
+                    cb.callback.unwrap()(typ, msg_c.as_ptr(), cb.userdata);
                 }
             }
         }
@@ -745,7 +745,7 @@ pub fn handle_device_error<E: std::any::Any + std::error::Error>(device: id::Dev
         _ => native::WGPUErrorType_Unknown,
     };
 
-    handle_device_error_raw(device, typ, &format!("{:?}", error));
+    handle_device_error_raw(device, typ, &format!("{error:?}"));
 }
 
 #[no_mangle]


### PR DESCRIPTION
update `wgpu-core`, `wgpu-types` & `naga`.
the target-specific features selection for `wgpu-core` dependency is copied from `wgpu` crate.

some pre-enabled features are now added in `default = []` list, so that users can select only the features they want.
for example by running `cargo build --no-default-features --features wgsl,trace` (`spriv` & `glsl` disabled).