### PR TITLE
add `wgpuSurfaceGetCapabilities` & `WGPUSwapChainDescriptorExtras`

### DIFF
--- a/examples/framework.c
+++ b/examples/framework.c
@@ -138,69 +138,50 @@ void printAdapterFeatures(WGPUAdapter adapter) {
       (WGPUFeatureName *)malloc(count * sizeof(WGPUFeatureName));
   wgpuAdapterEnumerateFeatures(adapter, features);
 
-  printf("[]WGPUFeatureName {\n");
-
+  printf("adapterFeatures = [ ");
   for (size_t i = 0; i < count; i++) {
-    uint32_t feature = features[i];
-    switch (feature) {
-    case WGPUFeatureName_DepthClipControl:
-      printf("\tDepthClipControl\n");
-      break;
-
-    case WGPUFeatureName_Depth32FloatStencil8:
-      printf("\tDepth32FloatStencil8\n");
-      break;
-
-    case WGPUFeatureName_TimestampQuery:
-      printf("\tTimestampQuery\n");
-      break;
-
-    case WGPUFeatureName_PipelineStatisticsQuery:
-      printf("\tPipelineStatisticsQuery\n");
-      break;
-
-    case WGPUFeatureName_TextureCompressionBC:
-      printf("\tTextureCompressionBC\n");
-      break;
-
-    case WGPUFeatureName_TextureCompressionETC2:
-      printf("\tTextureCompressionETC2\n");
-      break;
-
-    case WGPUFeatureName_TextureCompressionASTC:
-      printf("\tTextureCompressionASTC\n");
-      break;
-
-    case WGPUFeatureName_IndirectFirstInstance:
-      printf("\tIndirectFirstInstance\n");
-      break;
-
-    case WGPUNativeFeature_PUSH_CONSTANTS:
-      printf("\tWGPUNativeFeature_PUSH_CONSTANTS\n");
-      break;
-
-    case WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES:
-      printf("\tWGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES\n");
-      break;
-
-    case WGPUNativeFeature_MULTI_DRAW_INDIRECT:
-      printf("\tWGPUNativeFeature_MULTI_DRAW_INDIRECT\n");
-      break;
-
-    case WGPUNativeFeature_MULTI_DRAW_INDIRECT_COUNT:
-      printf("\tWGPUNativeFeature_MULTI_DRAW_INDIRECT_COUNT\n");
-      break;
-
-    case WGPUNativeFeature_VERTEX_WRITABLE_STORAGE:
-      printf("\tWGPUNativeFeature_VERTEX_WRITABLE_STORAGE\n");
-      break;
-
-    default:
-      printf("\tUnknown=%d\n", feature);
-    }
+    printf("%#.8x ", features[i]);
   }
+  printf("]\n");
+
+  free(features);
+}
+
+void printSurfaceCapabilities(WGPUSurface surface, WGPUAdapter adapter) {
+  WGPUSurfaceCapabilities caps = {0};
+
+  wgpuSurfaceGetCapabilities(surface, adapter, &caps);
+
+  caps.formats = malloc(caps.formatCount * sizeof(WGPUTextureFormat));
+  caps.presentModes = malloc(caps.presentModeCount * sizeof(WGPUPresentMode));
+  caps.alphaModes =
+      malloc(caps.alphaModeCount * sizeof(WGPUCompositeAlphaMode));
+
+  wgpuSurfaceGetCapabilities(surface, adapter, &caps);
+
+  printf("WGPUSurfaceCapabilities {\n");
+
+  printf("\t.formats = [ ");
+  for (size_t i = 0; i < caps.formatCount; i++) {
+    printf("%#.8X ", caps.formats[i]);
+  }
+  printf("]\n");
+
+  printf("\t.presentModes = [ ");
+  for (size_t i = 0; i < caps.presentModeCount; i++) {
+    printf("%#.8X ", caps.presentModes[i]);
+  }
+  printf("]\n");
+
+  printf("\t.alphaModes = [ ");
+  for (size_t i = 0; i < caps.alphaModeCount; i++) {
+    printf("%#.8X ", caps.alphaModes[i]);
+  }
+  printf("]\n");
 
   printf("}\n");
 
-  free(features);
+  free(caps.formats);
+  free(caps.presentModes);
+  free(caps.alphaModes);
 }

--- a/examples/framework.h
+++ b/examples/framework.h
@@ -16,3 +16,4 @@ void initializeLog(void);
 
 void printGlobalReport(WGPUGlobalReport report);
 void printAdapterFeatures(WGPUAdapter adapter);
+void printSurfaceCapabilities(WGPUSurface surface, WGPUAdapter adapter);

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -175,6 +175,7 @@ int main(int argc, char *argv[]) {
                              (void *)&adapter);
 
   printAdapterFeatures(adapter);
+  printSurfaceCapabilities(surface, adapter);
 
   WGPUDevice device;
   wgpuAdapterRequestDevice(adapter, NULL, request_device_callback,
@@ -234,24 +235,34 @@ int main(int argc, char *argv[]) {
                                           .dstFactor = WGPUBlendFactor_Zero,
                                           .operation = WGPUBlendOperation_Add,
                                       }},
-                          .writeMask = WGPUColorWriteMask_All},
+                          .writeMask = WGPUColorWriteMask_All,
+                      },
               },
           .depthStencil = NULL,
       });
 
-  int prevWidth = 0;
-  int prevHeight = 0;
-  glfwGetWindowSize(window, &prevWidth, &prevHeight);
+  WGPUSwapChainDescriptor config = (WGPUSwapChainDescriptor){
+      .nextInChain =
+          (const WGPUChainedStruct *)&(WGPUSwapChainDescriptorExtras){
+              .chain =
+                  (WGPUChainedStruct){
+                      .next = NULL,
+                      .sType = (WGPUSType)WGPUSType_SwapChainDescriptorExtras,
+                  },
+              .alphaMode = WGPUCompositeAlphaMode_Auto,
+              .viewFormatCount = 0,
+              .viewFormats = NULL,
+          },
+      .usage = WGPUTextureUsage_RenderAttachment,
+      .format = swapChainFormat,
+      .width = 0,
+      .height = 0,
+      .presentMode = WGPUPresentMode_Fifo,
+  };
 
-  WGPUSwapChain swapChain =
-      wgpuDeviceCreateSwapChain(device, surface,
-                                &(WGPUSwapChainDescriptor){
-                                    .usage = WGPUTextureUsage_RenderAttachment,
-                                    .format = swapChainFormat,
-                                    .width = prevWidth,
-                                    .height = prevHeight,
-                                    .presentMode = WGPUPresentMode_Fifo,
-                                });
+  glfwGetWindowSize(window, (int *)&config.width, (int *)&config.height);
+
+  WGPUSwapChain swapChain = wgpuDeviceCreateSwapChain(device, surface, &config);
 
   glfwSetKeyCallback(window, handleGlfwKey);
 
@@ -260,33 +271,20 @@ int main(int argc, char *argv[]) {
     WGPUTextureView nextTexture = NULL;
 
     for (int attempt = 0; attempt < 2; attempt++) {
+      uint32_t prevWidth = config.width;
+      uint32_t prevHeight = config.height;
+      glfwGetWindowSize(window, (int *)&config.width, (int *)&config.height);
 
-      int width = 0;
-      int height = 0;
-      glfwGetWindowSize(window, &width, &height);
-
-      if (width != prevWidth || height != prevHeight) {
-        prevWidth = width;
-        prevHeight = height;
-
-        swapChain = wgpuDeviceCreateSwapChain(
-            device, surface,
-            &(WGPUSwapChainDescriptor){
-                .usage = WGPUTextureUsage_RenderAttachment,
-                .format = swapChainFormat,
-                .width = prevWidth,
-                .height = prevHeight,
-                .presentMode = WGPUPresentMode_Fifo,
-            });
+      if (prevWidth != config.width || prevHeight != config.height) {
+        swapChain = wgpuDeviceCreateSwapChain(device, surface, &config);
       }
 
       nextTexture = wgpuSwapChainGetCurrentTextureView(swapChain);
-
       if (attempt == 0 && !nextTexture) {
         printf("wgpuSwapChainGetCurrentTextureView() failed; trying to create "
                "a new swap chain...\n");
-        prevWidth = 0;
-        prevHeight = 0;
+        config.width = 0;
+        config.height = 0;
         continue;
       }
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -3,18 +3,6 @@
 
 #include "webgpu-headers/webgpu.h"
 
-// must be used to free the strings & slices returned by the library,
-// for other wgpu objects use appropriate drop functions.
-//
-// first parameter `type` has to be type of derefrenced value
-// for example ->
-//
-//      size_t count;
-//      const WGPUTextureFormat* formats = wgpuSurfaceGetSupportedFormats(surface, adapter, &count);
-//      WGPU_FREE(WGPUTextureFormat, formats, count); // notice `WGPUTextureFormat` instead of `WGPUTextureFormat *`
-//
-#define WGPU_FREE(type, ptr, len) wgpuFree((void *)ptr, len * sizeof(type), _Alignof(type))
-
 typedef enum WGPUNativeSType {
     // Start at 6 to prevent collisions with webgpu STypes
     WGPUSType_DeviceExtras = 0x60000001,
@@ -24,6 +12,7 @@ typedef enum WGPUNativeSType {
     WGPUSType_ShaderModuleGLSLDescriptor = 0x60000005,
     WGPUSType_SupportedLimitsExtras = 0x60000003,
     WGPUSType_InstanceExtras = 0x60000006,
+    WGPUSType_SwapChainDescriptorExtras = 0x60000007,
     WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeSType;
 
@@ -68,12 +57,21 @@ typedef enum WGPUDx12Compiler {
     WGPUDx12Compiler_Force32 = 0x7FFFFFFF
 } WGPUDx12Compiler;
 
+typedef enum WGPUCompositeAlphaMode {
+    WGPUCompositeAlphaMode_Auto = 0x00000000,
+    WGPUCompositeAlphaMode_Opaque = 0x00000001,
+    WGPUCompositeAlphaMode_PreMultiplied = 0x00000002,
+    WGPUCompositeAlphaMode_PostMultiplied = 0x00000003,
+    WGPUCompositeAlphaMode_Inherit = 0x00000004,
+    WGPUCompositeAlphaMode_Force32 = 0x7FFFFFFF
+} WGPUCompositeAlphaMode;
+
 typedef struct WGPUInstanceExtras {
     WGPUChainedStruct chain;
     WGPUInstanceBackendFlags backends;
     WGPUDx12Compiler dx12ShaderCompiler;
-    const char* dxilPath;
-    const char* dxcPath;
+    const char * dxilPath;
+    const char * dxcPath;
 } WGPUInstanceExtras;
 
 typedef struct WGPUAdapterExtras {
@@ -83,7 +81,7 @@ typedef struct WGPUAdapterExtras {
 
 typedef struct WGPUDeviceExtras {
     WGPUChainedStruct chain;
-    const char* tracePath;
+    const char * tracePath;
 } WGPUDeviceExtras;
 
 typedef struct WGPURequiredLimitsExtras {
@@ -125,7 +123,7 @@ typedef struct WGPUShaderModuleGLSLDescriptor {
     WGPUShaderStage stage;
     char const * code;
     uint32_t defineCount;
-    WGPUShaderDefine* defines;
+    WGPUShaderDefine * defines;
 } WGPUShaderModuleGLSLDescriptor;
 
 typedef struct WGPUStorageReport {
@@ -163,6 +161,22 @@ typedef struct WGPUGlobalReport {
     WGPUHubReport gl;
 } WGPUGlobalReport;
 
+typedef struct WGPUSurfaceCapabilities {
+    size_t formatCount;
+    WGPUTextureFormat * formats;
+    size_t presentModeCount;
+    WGPUPresentMode * presentModes;
+    size_t alphaModeCount;
+    WGPUCompositeAlphaMode * alphaModes;
+} WGPUSurfaceCapabilities;
+
+typedef struct WGPUSwapChainDescriptorExtras {
+    WGPUChainedStruct chain;
+    WGPUCompositeAlphaMode alphaMode;
+    size_t viewFormatCount;
+    WGPUTextureFormat const * viewFormats;
+} WGPUSwapChainDescriptorExtras;
+
 typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void * userdata);
 
 #ifdef __cplusplus
@@ -182,13 +196,7 @@ void wgpuSetLogLevel(WGPULogLevel level);
 
 uint32_t wgpuGetVersion(void);
 
-// Returns slice of supported texture formats
-// caller owns the formats slice and must WGPU_FREE() it
-WGPUTextureFormat const * wgpuSurfaceGetSupportedFormats(WGPUSurface surface, WGPUAdapter adapter, size_t * count);
-
-// Returns slice of supported present modes
-// caller owns the present modes slice and must WGPU_FREE() it
-WGPUPresentMode const * wgpuSurfaceGetSupportedPresentModes(WGPUSurface surface, WGPUAdapter adapter, size_t * count);
+void wgpuSurfaceGetCapabilities(WGPUSurface surface, WGPUAdapter adapter, WGPUSurfaceCapabilities * capabilities);
 
 void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void* const data);
 
@@ -220,10 +228,6 @@ void wgpuSurfaceDrop(WGPUSurface surface);
 void wgpuSwapChainDrop(WGPUSwapChain swapChain);
 void wgpuTextureDrop(WGPUTexture texture);
 void wgpuTextureViewDrop(WGPUTextureView textureView);
-
-// must be used to free the strings & slices returned by the library,
-// for other wgpu objects use appropriate drop functions.
-void wgpuFree(void* ptr, size_t size, size_t align);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
- replace `wgpuSurfaceGetSupportedFormats` and `wgpuSurfaceGetSupportedPresentModes` with `wgpuSurfaceGetCapabilities`.
- removed `wgpuFree` since it's not needed anymore, and in future we shouldn't introduce any api that returns memory allocated by the library.
- support for `alphaMode` & `viewFormats` in swapchain creation via `WGPUSwapChainDescriptorExtras`.