### PR TITLE
drop cmdbuffer handles in `wgpuQueueSubmitForIndex`

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1011,7 +1011,7 @@ pub fn map_swapchain_descriptor(
                 native::WGPUCompositeAlphaMode_Inherit => wgt::CompositeAlphaMode::Inherit,
                 _ => panic!("invalid alpha mode for swapchain descriptor"),
             },
-            unsafe { make_slice(extras.viewFormats, extras.viewFormatCount as usize) }
+            unsafe { make_slice(extras.viewFormats, extras.viewFormatCount) }
                 .iter()
                 .map(|f| {
                     map_texture_format(*f).expect("invalid view format for swapchain descriptor")

--- a/src/device.rs
+++ b/src/device.rs
@@ -695,11 +695,11 @@ pub unsafe extern "C" fn wgpuQueueSubmit(
 
     let mut command_buffers = Vec::new();
     for command_buffer in make_slice(commands, command_count as usize) {
-        let ptr = (*command_buffer) as native::WGPUCommandBuffer;
-        // NOTE: Automaticaly drop the command buffer
+        let ptr = *command_buffer;
         if ptr.is_null() {
             panic!("invalid command buffer");
         }
+        // NOTE: Automaticaly drop the command buffer
         let buffer_id = Box::from_raw(ptr).id;
         command_buffers.push(buffer_id)
     }
@@ -718,9 +718,13 @@ pub unsafe extern "C" fn wgpuQueueSubmitForIndex(
 
     let mut command_buffers = Vec::new();
     for command_buffer in make_slice(commands, command_count as usize) {
-        let ptr = (*command_buffer) as native::WGPUCommandBuffer;
-        let (id, _) = ptr.unwrap_handle();
-        command_buffers.push(id)
+        let ptr = *command_buffer;
+        if ptr.is_null() {
+            panic!("invalid command buffer");
+        }
+        // NOTE: Automaticaly drop the command buffer
+        let buffer_id = Box::from_raw(ptr).id;
+        command_buffers.push(buffer_id)
     }
 
     let submission_index = gfx_select!(queue => context.queue_submit(queue, &command_buffers))


### PR DESCRIPTION
currently command buffer handle (boxed struct wrapping actual `CommandBuffer` & `Arc<Context>`) isn't dropped in `wgpuQueueSubmitForIndex`, so basically leaking a ref of `Arc<Context>`. And since `context.queue_submit()` drops the actual `CommandBuffer` internally, calling `wgpuCommandBufferDrop` after `wgpuQueueSubmitForIndex` is useless as it will panic complaining the actual `CommandBuffer` it's already vacant.

so this pr fixes it, completely consuming command buffer on queue submit.

this behavior is already correct in `wgpuQueueSubmit`, just the wgpu extension function `wgpuQueueSubmitForIndex` had this bug.