### PR TITLE
add stubs for unimplemented fns & implement some fns

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,6 @@ fn main() {
         .header("ffi/webgpu-headers/webgpu.h")
         .header("ffi/wgpu.h")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .blocklist_type("(^WGPUProc).*")
         .blocklist_function("wgpuGetProcAddress")
         .prepend_enum_name(false)
         .size_t_is_usize(true)

--- a/src/command.rs
+++ b/src/command.rs
@@ -281,6 +281,45 @@ pub unsafe extern "C" fn wgpuCommandEncoderPushDebugGroup(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wgpuCommandEncoderResolveQuerySet(
+    encoder: native::WGPUCommandEncoder,
+    query_set: native::WGPUQuerySet,
+    first_query: u32,
+    query_count: u32,
+    destination: native::WGPUBuffer,
+    destination_offset: u64,
+) {
+    let (encoder, context) = encoder.unwrap_handle();
+    let (query_set, _) = query_set.unwrap_handle();
+    let (destination, _) = destination.unwrap_handle();
+
+    gfx_select!(encoder => context.command_encoder_resolve_query_set(
+        encoder,
+        query_set,
+        first_query,
+        query_count,
+        destination,
+        destination_offset))
+    .expect("Unable to resolve query set");
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuCommandEncoderWriteTimestamp(
+    encoder: native::WGPUCommandEncoder,
+    query_set: native::WGPUQuerySet,
+    query_index: u32,
+) {
+    let (encoder, context) = encoder.unwrap_handle();
+    let (query_set, _) = query_set.unwrap_handle();
+
+    gfx_select!(encoder => context.command_encoder_write_timestamp(
+        encoder,
+        query_set,
+        query_index))
+    .expect("Unable to write timestamp");
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wgpuComputePassEncoderEnd(pass_handle: native::WGPUComputePassEncoder) {
     let (pass, context) = unwrap_compute_pass_encoder(pass_handle);
     let encoder_id = pass.parent_id();
@@ -417,6 +456,25 @@ pub unsafe extern "C" fn wgpuComputePassEncoderPushDebugGroup(
 ) {
     let (pass, _) = unwrap_compute_pass_encoder(pass);
     compute_ffi::wgpu_compute_pass_push_debug_group(pass, group_label, 0);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePassEncoderBeginPipelineStatisticsQuery(
+    pass: native::WGPUComputePassEncoder,
+    query_set: native::WGPUQuerySet,
+    query_index: u32,
+) {
+    let (pass, _) = unwrap_compute_pass_encoder(pass);
+    let (query_set, _) = query_set.unwrap_handle();
+    compute_ffi::wgpu_compute_pass_begin_pipeline_statistics_query(pass, query_set, query_index);
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuComputePassEncoderEndPipelineStatisticsQuery(
+    pass: native::WGPUComputePassEncoder,
+) {
+    let (pass, _) = unwrap_compute_pass_encoder(pass);
+    compute_ffi::wgpu_compute_pass_end_pipeline_statistics_query(pass);
 }
 
 #[no_mangle]
@@ -702,6 +760,30 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderExecuteBundles(
         bundles,
         bundles_count as usize,
     );
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPassEncoderBeginPipelineStatisticsQuery(
+    render_pass_encoder: native::WGPURenderPassEncoder,
+    query_set: native::WGPUQuerySet,
+    query_index: u32,
+) {
+    let (render_pass_encoder, _) = unwrap_render_pass_encoder(render_pass_encoder);
+    let (query_set, _) = query_set.unwrap_handle();
+
+    render_ffi::wgpu_render_pass_begin_pipeline_statistics_query(
+        render_pass_encoder,
+        query_set,
+        query_index,
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuRenderPassEncoderEndPipelineStatisticsQuery(
+    render_pass_encoder: native::WGPURenderPassEncoder,
+) {
+    let (render_pass_encoder, _) = unwrap_render_pass_encoder(render_pass_encoder);
+    render_ffi::wgpu_render_pass_end_pipeline_statistics_query(render_pass_encoder);
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod command;
 pub mod conv;
 pub mod device;
 pub mod logging;
+pub mod unimplemented;
 
 pub type Context = wgc::hub::Global<wgc::hub::IdentityManagerFactory>;
 

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -1,0 +1,365 @@
+use crate::native;
+
+#[no_mangle]
+pub extern "C" fn wgpuGetProcAddress(
+    _device: native::WGPUDevice,
+    _proc_name: *const ::std::os::raw::c_char,
+) -> native::WGPUProc {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuBindGroupSetLabel(
+    _bind_group: native::WGPUBindGroup,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuBindGroupLayoutSetLabel(
+    _bind_group_layout: native::WGPUBindGroupLayout,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuBufferGetConstMappedRange(
+    _buffer: native::WGPUBuffer,
+    _offset: usize,
+    _size: usize,
+) -> *const ::std::os::raw::c_void {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuBufferGetSize(_buffer: native::WGPUBuffer) -> u64 {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuBufferGetUsage(_buffer: native::WGPUBuffer) -> native::WGPUBufferUsage {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuBufferSetLabel(
+    _buffer: native::WGPUBuffer,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuCommandBufferSetLabel(
+    _command_buffer: native::WGPUCommandBuffer,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuCommandEncoderResolveQuerySet(
+    _command_encoder: native::WGPUCommandEncoder,
+    _query_set: native::WGPUQuerySet,
+    _first_query: u32,
+    _query_count: u32,
+    _destination: native::WGPUBuffer,
+    _destination_offset: u64,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuCommandEncoderSetLabel(
+    _command_encoder: native::WGPUCommandEncoder,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuCommandEncoderWriteTimestamp(
+    _command_encoder: native::WGPUCommandEncoder,
+    _query_set: native::WGPUQuerySet,
+    _query_index: u32,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuComputePassEncoderBeginPipelineStatisticsQuery(
+    _compute_pass_encoder: native::WGPUComputePassEncoder,
+    _query_set: native::WGPUQuerySet,
+    _query_index: u32,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuComputePassEncoderEndPipelineStatisticsQuery(
+    _compute_pass_encoder: native::WGPUComputePassEncoder,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuComputePassEncoderSetLabel(
+    _compute_pass_encoder: native::WGPUComputePassEncoder,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuComputePipelineSetLabel(
+    _compute_pipeline: native::WGPUComputePipeline,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuDeviceCreateComputePipelineAsync(
+    _device: native::WGPUDevice,
+    _descriptor: *const native::WGPUComputePipelineDescriptor,
+    _callback: native::WGPUCreateComputePipelineAsyncCallback,
+    _userdata: *mut ::std::os::raw::c_void,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuDeviceCreateQuerySet(
+    _device: native::WGPUDevice,
+    _descriptor: *const native::WGPUQuerySetDescriptor,
+) -> native::WGPUQuerySet {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuDeviceCreateRenderPipelineAsync(
+    _device: native::WGPUDevice,
+    _descriptor: *const native::WGPURenderPipelineDescriptor,
+    _callback: native::WGPUCreateRenderPipelineAsyncCallback,
+    _userdata: *mut ::std::os::raw::c_void,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuDevicePopErrorScope(
+    _device: native::WGPUDevice,
+    _callback: native::WGPUErrorCallback,
+    _userdata: *mut ::std::os::raw::c_void,
+) -> bool {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuDevicePushErrorScope(
+    _device: native::WGPUDevice,
+    _filter: native::WGPUErrorFilter,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuDeviceSetLabel(
+    _device: native::WGPUDevice,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuInstanceProcessEvents(_instance: native::WGPUInstance) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuPipelineLayoutSetLabel(
+    _pipeline_layout: native::WGPUPipelineLayout,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuQuerySetDestroy(_query_set: native::WGPUQuerySet) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuQuerySetGetCount(_query_set: native::WGPUQuerySet) -> u32 {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuQuerySetGetType(_query_set: native::WGPUQuerySet) -> native::WGPUQueryType {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuQuerySetSetLabel(
+    _query_set: native::WGPUQuerySet,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuQueueOnSubmittedWorkDone(
+    _queue: native::WGPUQueue,
+    _callback: native::WGPUQueueWorkDoneCallback,
+    _userdata: *mut ::std::os::raw::c_void,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuQueueSetLabel(
+    _queue: native::WGPUQueue,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuRenderBundleEncoderSetLabel(
+    _render_bundle_encoder: native::WGPURenderBundleEncoder,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuRenderPassEncoderBeginOcclusionQuery(
+    _render_pass_encoder: native::WGPURenderPassEncoder,
+    _query_index: u32,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuRenderPassEncoderBeginPipelineStatisticsQuery(
+    _render_pass_encoder: native::WGPURenderPassEncoder,
+    _query_set: native::WGPUQuerySet,
+    _query_index: u32,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuRenderPassEncoderEndOcclusionQuery(
+    _render_pass_encoder: native::WGPURenderPassEncoder,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuRenderPassEncoderEndPipelineStatisticsQuery(
+    _render_pass_encoder: native::WGPURenderPassEncoder,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuRenderPassEncoderSetLabel(
+    _render_pass_encoder: native::WGPURenderPassEncoder,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuRenderPipelineSetLabel(
+    _render_pipeline: native::WGPURenderPipeline,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuSamplerSetLabel(
+    _sampler: native::WGPUSampler,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuShaderModuleGetCompilationInfo(
+    _shader_module: native::WGPUShaderModule,
+    _callback: native::WGPUCompilationInfoCallback,
+    _userdata: *mut ::std::os::raw::c_void,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuShaderModuleSetLabel(
+    _shader_module: native::WGPUShaderModule,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuTextureGetDepthOrArrayLayers(_texture: native::WGPUTexture) -> u32 {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuTextureGetDimension(
+    _texture: native::WGPUTexture,
+) -> native::WGPUTextureDimension {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuTextureGetFormat(_texture: native::WGPUTexture) -> native::WGPUTextureFormat {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuTextureGetHeight(_texture: native::WGPUTexture) -> u32 {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuTextureGetMipLevelCount(_texture: native::WGPUTexture) -> u32 {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuTextureGetSampleCount(_texture: native::WGPUTexture) -> u32 {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuTextureGetUsage(_texture: native::WGPUTexture) -> native::WGPUTextureUsage {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureGetWidth(_texture: native::WGPUTexture) -> u32 {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuTextureSetLabel(
+    _texture: native::WGPUTexture,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuTextureViewSetLabel(
+    _texture_view: native::WGPUTextureView,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -25,15 +25,6 @@ pub extern "C" fn wgpuBindGroupLayoutSetLabel(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuBufferGetConstMappedRange(
-    _buffer: native::WGPUBuffer,
-    _offset: usize,
-    _size: usize,
-) -> *const ::std::os::raw::c_void {
-    unimplemented!();
-}
-
-#[no_mangle]
 pub extern "C" fn wgpuBufferGetSize(_buffer: native::WGPUBuffer) -> u64 {
     unimplemented!();
 }
@@ -60,46 +51,9 @@ pub extern "C" fn wgpuCommandBufferSetLabel(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuCommandEncoderResolveQuerySet(
-    _command_encoder: native::WGPUCommandEncoder,
-    _query_set: native::WGPUQuerySet,
-    _first_query: u32,
-    _query_count: u32,
-    _destination: native::WGPUBuffer,
-    _destination_offset: u64,
-) {
-    unimplemented!();
-}
-
-#[no_mangle]
 pub extern "C" fn wgpuCommandEncoderSetLabel(
     _command_encoder: native::WGPUCommandEncoder,
     _label: *const ::std::os::raw::c_char,
-) {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuCommandEncoderWriteTimestamp(
-    _command_encoder: native::WGPUCommandEncoder,
-    _query_set: native::WGPUQuerySet,
-    _query_index: u32,
-) {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuComputePassEncoderBeginPipelineStatisticsQuery(
-    _compute_pass_encoder: native::WGPUComputePassEncoder,
-    _query_set: native::WGPUQuerySet,
-    _query_index: u32,
-) {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuComputePassEncoderEndPipelineStatisticsQuery(
-    _compute_pass_encoder: native::WGPUComputePassEncoder,
 ) {
     unimplemented!();
 }
@@ -127,14 +81,6 @@ pub extern "C" fn wgpuDeviceCreateComputePipelineAsync(
     _callback: native::WGPUCreateComputePipelineAsyncCallback,
     _userdata: *mut ::std::os::raw::c_void,
 ) {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuDeviceCreateQuerySet(
-    _device: native::WGPUDevice,
-    _descriptor: *const native::WGPUQuerySetDescriptor,
-) -> native::WGPUQuerySet {
     unimplemented!();
 }
 
@@ -243,23 +189,7 @@ pub extern "C" fn wgpuRenderPassEncoderBeginOcclusionQuery(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuRenderPassEncoderBeginPipelineStatisticsQuery(
-    _render_pass_encoder: native::WGPURenderPassEncoder,
-    _query_set: native::WGPUQuerySet,
-    _query_index: u32,
-) {
-    unimplemented!();
-}
-
-#[no_mangle]
 pub extern "C" fn wgpuRenderPassEncoderEndOcclusionQuery(
-    _render_pass_encoder: native::WGPURenderPassEncoder,
-) {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuRenderPassEncoderEndPipelineStatisticsQuery(
     _render_pass_encoder: native::WGPURenderPassEncoder,
 ) {
     unimplemented!();


### PR DESCRIPTION
export all the fns present in the headers. this makes some binding generators that check `.so`/`.a` happy; no more complains for missing fn signatures.

also it's probably makes it better for us to track which functions are unimplemented.

new fns implemented are:
- `wgpuCommandEncoderResolveQuerySet`
- `wgpuCommandEncoderWriteTimestamp`
- `wgpuComputePassEncoderBeginPipelineStatisticsQuery`
- `wgpuComputePassEncoderEndPipelineStatisticsQuery`
- `wgpuDeviceCreateQuerySet`
- `wgpuRenderPassEncoderBeginPipelineStatisticsQuery`
- `wgpuRenderPassEncoderEndPipelineStatisticsQuery`
- `wgpuBufferGetConstMappedRange`