### PR TITLE
update webgpu-headers

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -750,7 +750,7 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderPushDebugGroup(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderPassEncoderExecuteBundles(
     render_pass_encoder: native::WGPURenderPassEncoder,
-    bundles_count: u32,
+    bundle_count: u32,
     bundles: *const wgc::id::RenderBundleId,
 ) {
     let (render_pass_encoder, _) = unwrap_render_pass_encoder(render_pass_encoder);
@@ -758,7 +758,7 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderExecuteBundles(
     render_ffi::wgpu_render_pass_execute_bundles(
         render_pass_encoder,
         bundles,
-        bundles_count as usize,
+        bundle_count as usize,
     );
 }
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -924,7 +924,7 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
         temp.push(native::WGPUFeatureName_IndirectFirstInstance);
     }
 
-    // native only features
+    // wgpu-rs only features
     if features.contains(wgt::Features::PUSH_CONSTANTS) {
         temp.push(native::WGPUNativeFeature_PUSH_CONSTANTS);
     }
@@ -957,14 +957,18 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUFeatureName_TextureCompressionETC2 => Some(Features::TEXTURE_COMPRESSION_ETC2),
         native::WGPUFeatureName_TextureCompressionASTC => Some(Features::TEXTURE_COMPRESSION_ASTC_LDR),
         native::WGPUFeatureName_IndirectFirstInstance => Some(Features::INDIRECT_FIRST_INSTANCE),
+        native::WGPUFeatureName_ShaderF16 => Some(Features::SHADER_FLOAT16),
 
-        // native only features
+        // wgpu-rs only features
         native::WGPUNativeFeature_PUSH_CONSTANTS => Some(Features::PUSH_CONSTANTS),
         native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES => Some(Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES),
         native::WGPUNativeFeature_MULTI_DRAW_INDIRECT => Some(Features::MULTI_DRAW_INDIRECT),
         native::WGPUNativeFeature_MULTI_DRAW_INDIRECT_COUNT => Some(Features::MULTI_DRAW_INDIRECT_COUNT),
         native::WGPUNativeFeature_VERTEX_WRITABLE_STORAGE => Some(Features::VERTEX_WRITABLE_STORAGE),
 
+        // not available in wgpu-core
+        native::WGPUFeatureName_RG11B10UfloatRenderable => None,
+        native::WGPUFeatureName_BGRA8UnormStorage => None,
         _ => None,
     }
 }

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -25,6 +25,11 @@ pub extern "C" fn wgpuBindGroupLayoutSetLabel(
 }
 
 #[no_mangle]
+pub extern "C" fn wgpuBufferGetMapState(_buffer: native::WGPUBuffer) -> native::WGPUBufferMapState {
+    unimplemented!();
+}
+
+#[no_mangle]
 pub extern "C" fn wgpuBufferGetSize(_buffer: native::WGPUBuffer) -> u64 {
     unimplemented!();
 }


### PR DESCRIPTION
diff: https://github.com/webgpu-native/webgpu-headers/compare/fa1c6ab4927ef1fa5731907b42b62ea93119866c...048341380f41c0d67e66998b3def7b5868380080#diff-074fca0467717d8d789bdfb86bf9e2d4afec03055a2787e0b604fda4254d4ed9