### PR TITLE
allow 0 for `BufferBindingLayout.minBindingSize`

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -500,10 +500,14 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
                     x => panic!("Unknown Buffer Type: {x}"),
                 },
                 has_dynamic_offset: entry.buffer.hasDynamicOffset,
-                min_binding_size: match entry.buffer.minBindingSize {
-                    0 => panic!("invalid minBindingSize"),
-                    conv::WGPU_WHOLE_SIZE => None,
-                    _ => Some(NonZeroU64::new_unchecked(entry.buffer.minBindingSize)),
+                min_binding_size: {
+                    assert_ne!(
+                        entry.buffer.minBindingSize,
+                        conv::WGPU_WHOLE_SIZE,
+                        "invalid minBindingSize, use 0 instead"
+                    );
+
+                    NonZeroU64::new(entry.buffer.minBindingSize)
                 },
             }
         } else {


### PR DESCRIPTION
as per the spec, `GPUBufferBindingLayout.minBindingSize` should allow 0 as default value instead of `WGPU_WHOLE_SIZE`. 
See https://gpuweb.github.io/gpuweb/#dom-gpubufferbindinglayout-minbindingsize

(also thanks to @eliemichel for catching this)

(this is breaking change, as current code using `WGPU_WHOLE_SIZE` will result in UB)