### PR TITLE
Fill in more of `WGPUAdapterProperties`

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -67,6 +67,9 @@ pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
                     context: context.clone(),
                     id: adapter,
                     name: CString::default(),
+                    vendor_name: CString::default(),
+                    architecture_name: CString::default(),
+                    driver_desc: CString::default(),
                 }
                 .into_handle(),
                 std::ptr::null(),
@@ -150,10 +153,15 @@ pub unsafe extern "C" fn wgpuAdapterGetProperties(
     let maybe_props = gfx_select!(id => context.adapter_get_info(id));
     if let Ok(props) = maybe_props {
         adapter.name = CString::new((&props.name) as &str).unwrap();
+        let driver_desc = format!("{} {}", props.driver, props.driver_info);
+        adapter.driver_desc = CString::new(driver_desc).unwrap();
 
-        properties.name = adapter.name.as_ptr();
         properties.vendorID = props.vendor as u32;
+        properties.vendorName = adapter.vendor_name.as_ptr();
+        properties.architecture = adapter.architecture_name.as_ptr();
         properties.deviceID = props.device as u32;
+        properties.name = adapter.name.as_ptr();
+        properties.driverDescription = adapter.driver_desc.as_ptr();
         properties.adapterType = match props.device_type {
             wgt::DeviceType::Other => native::WGPUAdapterType_Unknown,
             wgt::DeviceType::IntegratedGpu => native::WGPUAdapterType_IntegratedGPU,

--- a/src/device.rs
+++ b/src/device.rs
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn wgpuAdapterGetProperties(
     if let Ok(props) = maybe_props {
         adapter.name = CString::new((&props.name) as &str).unwrap();
         let driver_desc = format!("{} {}", props.driver, props.driver_info);
-        adapter.driver_desc = CString::new(driver_desc).unwrap();
+        adapter.driver_desc = CString::new(driver_desc.trim()).unwrap();
 
         properties.vendorID = props.vendor as u32;
         properties.vendorName = adapter.vendor_name.as_ptr();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,9 @@ pub mod native {
         pub context: Arc<Context>,
         pub id: AdapterId,
         pub name: std::ffi::CString,
+        pub vendor_name: std::ffi::CString,
+        pub architecture_name: std::ffi::CString,
+        pub driver_desc: std::ffi::CString,
     }
 
     pub struct WGPUSwapChainImpl {


### PR DESCRIPTION
`.driverDescription`: filled in with a combination of the driver name and info, e.g., "NVIDIA  531.41" 
`.vendorName`: empty string (rather than null pointer)
`.architecture`: empty string (rather than null pointer)

Looking at Dawn and Emscripten's implementations, there does not seem to be much consistency in how missing fields are handled: Dawn seems to return empty strings, while Emscripten returns null pointers. My feeling is that empty strings are more in line with the JS WebGPU API which explicitly returns empty strings (and also safer if someone printf's these fields without checking whether they are null).