### PR TITLE
Add `Force32` guard to `WGPUNativeFeature`

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -22,7 +22,7 @@ typedef enum WGPUNativeFeature {
     WGPUNativeFeature_MULTI_DRAW_INDIRECT = 0x60000003,
     WGPUNativeFeature_MULTI_DRAW_INDIRECT_COUNT = 0x60000004,
     WGPUNativeFeature_VERTEX_WRITABLE_STORAGE = 0x60000005,
-    WGPUNativeSType_Force32 = 0x7FFFFFFF
+    WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 
 typedef enum WGPULogLevel {

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -17,11 +17,11 @@ typedef enum WGPUNativeSType {
 } WGPUNativeSType;
 
 typedef enum WGPUNativeFeature {
-    WGPUNativeFeature_PUSH_CONSTANTS = 0x60000001,
-    WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES = 0x60000002,
-    WGPUNativeFeature_MULTI_DRAW_INDIRECT = 0x60000003,
-    WGPUNativeFeature_MULTI_DRAW_INDIRECT_COUNT = 0x60000004,
-    WGPUNativeFeature_VERTEX_WRITABLE_STORAGE = 0x60000005,
+    WGPUNativeFeature_PushConstants = 0x60000001,
+    WGPUNativeFeature_TextureAdapterSpecificFormatFeatures = 0x60000002,
+    WGPUNativeFeature_MultiDrawIndirect = 0x60000003,
+    WGPUNativeFeature_MultiDrawIndirectCount = 0x60000004,
+    WGPUNativeFeature_VertexWritableStorage = 0x60000005,
     WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -22,6 +22,7 @@ typedef enum WGPUNativeFeature {
     WGPUNativeFeature_MULTI_DRAW_INDIRECT = 0x60000003,
     WGPUNativeFeature_MULTI_DRAW_INDIRECT_COUNT = 0x60000004,
     WGPUNativeFeature_VERTEX_WRITABLE_STORAGE = 0x60000005,
+    WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 
 typedef enum WGPULogLevel {

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -929,19 +929,19 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
 
     // wgpu-rs only features
     if features.contains(wgt::Features::PUSH_CONSTANTS) {
-        temp.push(native::WGPUNativeFeature_PUSH_CONSTANTS);
+        temp.push(native::WGPUNativeFeature_PushConstants);
     }
     if features.contains(wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES) {
-        temp.push(native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES);
+        temp.push(native::WGPUNativeFeature_TextureAdapterSpecificFormatFeatures);
     }
     if features.contains(wgt::Features::MULTI_DRAW_INDIRECT) {
-        temp.push(native::WGPUNativeFeature_MULTI_DRAW_INDIRECT);
+        temp.push(native::WGPUNativeFeature_MultiDrawIndirect);
     }
     if features.contains(wgt::Features::MULTI_DRAW_INDIRECT_COUNT) {
-        temp.push(native::WGPUNativeFeature_MULTI_DRAW_INDIRECT_COUNT);
+        temp.push(native::WGPUNativeFeature_MultiDrawIndirectCount);
     }
     if features.contains(wgt::Features::VERTEX_WRITABLE_STORAGE) {
-        temp.push(native::WGPUNativeFeature_VERTEX_WRITABLE_STORAGE);
+        temp.push(native::WGPUNativeFeature_VertexWritableStorage);
     }
 
     temp
@@ -963,11 +963,11 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUFeatureName_ShaderF16 => Some(Features::SHADER_F16),
 
         // wgpu-rs only features
-        native::WGPUNativeFeature_PUSH_CONSTANTS => Some(Features::PUSH_CONSTANTS),
-        native::WGPUNativeFeature_TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES => Some(Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES),
-        native::WGPUNativeFeature_MULTI_DRAW_INDIRECT => Some(Features::MULTI_DRAW_INDIRECT),
-        native::WGPUNativeFeature_MULTI_DRAW_INDIRECT_COUNT => Some(Features::MULTI_DRAW_INDIRECT_COUNT),
-        native::WGPUNativeFeature_VERTEX_WRITABLE_STORAGE => Some(Features::VERTEX_WRITABLE_STORAGE),
+        native::WGPUNativeFeature_PushConstants => Some(Features::PUSH_CONSTANTS),
+        native::WGPUNativeFeature_TextureAdapterSpecificFormatFeatures => Some(Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES),
+        native::WGPUNativeFeature_MultiDrawIndirect => Some(Features::MULTI_DRAW_INDIRECT),
+        native::WGPUNativeFeature_MultiDrawIndirectCount => Some(Features::MULTI_DRAW_INDIRECT_COUNT),
+        native::WGPUNativeFeature_VertexWritableStorage => Some(Features::VERTEX_WRITABLE_STORAGE),
 
         // not available in wgpu-core
         native::WGPUFeatureName_RG11B10UfloatRenderable => None,


### PR DESCRIPTION
Already present in other structs, it must have been forgotten in `WGPUNativeFeature`.

By the way it would match more closely the standard `webgpu.h` header to call this struct `WGPUNativeFeatureName`, and have the values look more like `WGPUNativeFeaturePushConstants` than `WGPUNativeFeature_PUSH_CONSTANTS`.

Side note: Using the `Native` prefix is not as informative as if it would use a name more specific to this very WebGPU backend (as opposed to "Dawn") but I guess this is a general problem of the name "`wgpu-native`".