### PR TITLE
[WIP] Implement missing texture property accessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,6 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.16.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=011a4e26d04f388ef40e3baee3f19a255b9b5148#011a4e26d04f388ef40e3baee3f19a255b9b5148"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -869,7 +868,6 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.16.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=011a4e26d04f388ef40e3baee3f19a255b9b5148#011a4e26d04f388ef40e3baee3f19a255b9b5148"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -922,7 +920,6 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.16.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=011a4e26d04f388ef40e3baee3f19a255b9b5148#011a4e26d04f388ef40e3baee3f19a255b9b5148"
 dependencies = [
  "bitflags 2.1.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,3 +79,6 @@ bindgen = "0.65"
 [workspace]
 resolver = "2"
 
+[patch."https://github.com/gfx-rs/wgpu"]
+wgpu-core = { path = "../wgpu/wgpu-core" }
+wgpu-types = { path = "../wgpu/wgpu-types" }

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -583,6 +583,14 @@ pub fn map_texture_dimension(value: native::WGPUTextureDimension) -> wgt::Textur
     }
 }
 
+pub fn to_native_texture_dimension(value: wgt::TextureDimension) -> native::WGPUTextureDimension {
+    match value {
+        wgt::TextureDimension::D1 => native::WGPUTextureDimension_1D,
+        wgt::TextureDimension::D2 => native::WGPUTextureDimension_2D,
+        wgt::TextureDimension::D3 => native::WGPUTextureDimension_3D,
+    }
+}
+
 #[rustfmt::skip]
 pub fn map_texture_format(value: native::WGPUTextureFormat) -> Option<wgt::TextureFormat> {
     use wgt::{AstcBlock, AstcChannel};

--- a/src/device.rs
+++ b/src/device.rs
@@ -1201,6 +1201,12 @@ pub unsafe extern "C" fn wgpuTextureDestroy(texture: native::WGPUTexture) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wgpuTextureGetWidth(texture: native::WGPUTexture) -> u32 {
+    let (id, context) = texture.unwrap_handle();
+    gfx_select!(id => context.texture_get_width(id)).expect("Invalid texture");
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wgpuDeviceCreateSampler(
     device: native::WGPUDevice,
     descriptor: Option<&native::WGPUSamplerDescriptor>,

--- a/src/device.rs
+++ b/src/device.rs
@@ -1201,9 +1201,56 @@ pub unsafe extern "C" fn wgpuTextureDestroy(texture: native::WGPUTexture) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wgpuTextureGetDepthOrArrayLayers(texture: native::WGPUTexture) -> u32 {
+    let (id, context) = texture.unwrap_handle();
+    gfx_select!(id => context.texture_get_depth_or_array_layers(id)).expect("Invalid texture")
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureGetDimension(texture: native::WGPUTexture) -> native::WGPUTextureDimension {
+    let (id, context) = texture.unwrap_handle();
+    conv::to_native_texture_dimension(
+        gfx_select!(id => context.texture_get_dimension(id)).expect("Invalid texture")
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureGetFormat(texture: native::WGPUTexture) -> native::WGPUTextureFormat {
+    let (id, context) = texture.unwrap_handle();
+    conv::to_native_texture_format(
+        gfx_select!(id => context.texture_get_format(id)).expect("Invalid texture")
+    ).expect("Invalid texture format")
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wgpuTextureGetWidth(texture: native::WGPUTexture) -> u32 {
     let (id, context) = texture.unwrap_handle();
-    gfx_select!(id => context.texture_get_width(id)).expect("Invalid texture");
+    gfx_select!(id => context.texture_get_width(id)).expect("Invalid texture")
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureGetHeight(texture: native::WGPUTexture) -> u32 {
+    let (id, context) = texture.unwrap_handle();
+    gfx_select!(id => context.texture_get_height(id)).expect("Invalid texture")
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureGetMipLevelCount(texture: native::WGPUTexture) -> u32 {
+    let (id, context) = texture.unwrap_handle();
+    gfx_select!(id => context.texture_get_mip_level_count(id)).expect("Invalid texture")
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureGetSampleCount(texture: native::WGPUTexture) -> u32 {
+    let (id, context) = texture.unwrap_handle();
+    gfx_select!(id => context.texture_get_sample_count(id)).expect("Invalid texture")
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureGetUsage(texture: native::WGPUTexture) -> native::WGPUTextureUsage {
+    let (id, context) = texture.unwrap_handle();
+    gfx_select!(id => context.texture_get_usage(id)).expect("Invalid texture")
+        .bits().try_into().expect("Invalid texture usage")
 }
 
 #[no_mangle]

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -279,11 +279,6 @@ pub extern "C" fn wgpuTextureGetUsage(_texture: native::WGPUTexture) -> native::
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuTextureGetWidth(_texture: native::WGPUTexture) -> u32 {
-    unimplemented!();
-}
-
-#[no_mangle]
 pub extern "C" fn wgpuTextureSetLabel(
     _texture: native::WGPUTexture,
     _label: *const ::std::os::raw::c_char,

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -242,43 +242,6 @@ pub extern "C" fn wgpuShaderModuleSetLabel(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuTextureGetDepthOrArrayLayers(_texture: native::WGPUTexture) -> u32 {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuTextureGetDimension(
-    _texture: native::WGPUTexture,
-) -> native::WGPUTextureDimension {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuTextureGetFormat(_texture: native::WGPUTexture) -> native::WGPUTextureFormat {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuTextureGetHeight(_texture: native::WGPUTexture) -> u32 {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuTextureGetMipLevelCount(_texture: native::WGPUTexture) -> u32 {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuTextureGetSampleCount(_texture: native::WGPUTexture) -> u32 {
-    unimplemented!();
-}
-
-#[no_mangle]
-pub extern "C" fn wgpuTextureGetUsage(_texture: native::WGPUTexture) -> native::WGPUTextureUsage {
-    unimplemented!();
-}
-
-#[no_mangle]
 pub extern "C" fn wgpuTextureSetLabel(
     _texture: native::WGPUTexture,
     _label: *const ::std::os::raw::c_char,


### PR DESCRIPTION
Add missing standard getters.

**NB:** This PR requires https://github.com/gfx-rs/wgpu/pull/3740 to be merged in `wgpu` first. Once this is done, I will revert the change of `Cargo.toml` and `Cargo.lock`.