### PR TITLE
refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,6 @@ name = "wgpu-native"
 version = "0.0.0"
 dependencies = [
  "bindgen",
- "lazy_static",
  "log",
  "naga",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ rev = "b99d58ea435090e561377949f428bce2c18451bb"
 version = "0.12.0"
 
 [dependencies]
-lazy_static = "1.4"
 raw-window-handle = "0.5"
 paste = "1.0"
 log = "0.4"

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,55 +1,23 @@
-use crate::native::{Handle, IntoHandle, IntoHandleWithContext, UnwrapId};
-use crate::{conv, handle_device_error, make_slice, native, Context, OwnedLabel};
+use crate::{conv, handle_device_error, make_slice, native, OwnedLabel};
 use std::ffi::CStr;
 use std::os::raw::c_char;
-use std::sync::Arc;
 use std::{borrow::Cow, num::NonZeroU64};
-use wgc::command::{ComputePass, RenderBundleEncoder, RenderPass};
 use wgc::{
     command::{bundle_ffi, compute_ffi, render_ffi},
     gfx_select,
 };
-
-fn unwrap_render_bundle_encoder<'a>(
-    handle: *mut native::WGPURenderBundleEncoderImpl,
-) -> (&'a mut RenderBundleEncoder, &'a Arc<Context>) {
-    unsafe {
-        let v = handle.as_mut().expect("invalid render bundle encoder");
-        (&mut v.encoder, &v.context)
-    }
-}
-
-fn unwrap_compute_pass_encoder<'a>(
-    handle: *mut native::WGPUComputePassEncoderImpl,
-) -> (&'a mut ComputePass, &'a Arc<Context>) {
-    unsafe {
-        let v = handle.as_mut().expect("invalid compute pass encoder");
-        (&mut v.encoder, &v.context)
-    }
-}
-
-fn unwrap_render_pass_encoder<'a>(
-    handle: *mut native::WGPURenderPassEncoderImpl,
-) -> (&'a mut RenderPass, &'a Arc<Context>) {
-    unsafe {
-        let v = handle.as_mut().expect("invalid render pass encoder");
-        (&mut v.encoder, &v.context)
-    }
-}
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuCommandEncoderFinish(
     command_encoder: native::WGPUCommandEncoder,
     descriptor: Option<&native::WGPUCommandBufferDescriptor>,
 ) -> native::WGPUCommandBuffer {
+    assert!(!command_encoder.is_null(), "invalid command encoder");
+
     // NOTE: Automatically drop the encoder
-    let (command_encoder, context) = {
-        if command_encoder.is_null() {
-            panic!("invalid render command encoder");
-        }
-        let v = Box::from_raw(command_encoder);
-        (v.id, v.context)
-    };
+    let command_encoder = Box::from_raw(command_encoder);
+    let context = &command_encoder.context;
+    let command_encoder_id = command_encoder.id;
 
     let desc = match descriptor {
         Some(descriptor) => wgt::CommandBufferDescriptor {
@@ -58,15 +26,17 @@ pub unsafe extern "C" fn wgpuCommandEncoderFinish(
         None => wgt::CommandBufferDescriptor::default(),
     };
 
-    let (id, error) =
-        gfx_select!(command_encoder => context.command_encoder_finish(command_encoder, &desc));
+    let (command_buffer_id, error) = gfx_select!(command_encoder_id => context.command_encoder_finish(command_encoder_id, &desc));
     if let Some(error) = error {
         // TODO figure out what device the encoder belongs to and call
         // handle_device_error()
         log::error!("command_encoder_finish() failed: {:?}", error);
         std::ptr::null_mut()
     } else {
-        id.into_handle_with_context(&context)
+        Box::into_raw(Box::new(native::WGPUCommandBufferImpl {
+            context: context.clone(),
+            id: command_buffer_id,
+        }))
     }
 }
 
@@ -77,12 +47,15 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearBuffer(
     offset: u64,
     size: u64,
 ) {
-    let (command_encoder, _) = command_encoder.unwrap_handle();
-    let (buffer, context) = buffer.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
-    gfx_select!(command_encoder => context.command_encoder_clear_buffer(
-        command_encoder,
-        buffer,
+    gfx_select!(command_encoder_id => context.command_encoder_clear_buffer(
+        command_encoder_id,
+        buffer_id,
         offset,
         match size {
             0 => panic!("invalid size"),
@@ -102,15 +75,18 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyBufferToBuffer(
     destination_offset: u64,
     size: u64,
 ) {
-    let (command_encoder, _) = command_encoder.unwrap_handle();
-    let (source, _) = source.unwrap_handle();
-    let (destination, context) = destination.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
+    let source_buffer_id = source.as_ref().expect("invalid source").id;
+    let destination_buffer_id = destination.as_ref().expect("invalid destination").id;
 
-    gfx_select!(command_encoder => context.command_encoder_copy_buffer_to_buffer(
-        command_encoder,
-        source,
+    gfx_select!(command_encoder_id => context.command_encoder_copy_buffer_to_buffer(
+        command_encoder_id,
+        source_buffer_id,
         source_offset,
-        destination,
+        destination_buffer_id,
         destination_offset,
         size))
     .expect("Unable to copy buffer to buffer")
@@ -123,10 +99,13 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyTextureToTexture(
     destination: Option<&native::WGPUImageCopyTexture>,
     copy_size: Option<&native::WGPUExtent3D>,
 ) {
-    let (command_encoder, context) = command_encoder.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
 
-    gfx_select!(command_encoder => context.command_encoder_copy_texture_to_texture(
-        command_encoder,
+    gfx_select!(command_encoder_id => context.command_encoder_copy_texture_to_texture(
+        command_encoder_id,
         &conv::map_image_copy_texture(source.expect("invalid source")),
         &conv::map_image_copy_texture(destination.expect("invalid destination")),
         &conv::map_extent3d(copy_size.expect("invalid copy size"))))
@@ -140,10 +119,13 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyTextureToBuffer(
     destination: Option<&native::WGPUImageCopyBuffer>,
     copy_size: Option<&native::WGPUExtent3D>,
 ) {
-    let (command_encoder, context) = command_encoder.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
 
-    gfx_select!(command_encoder => context.command_encoder_copy_texture_to_buffer(
-        command_encoder,
+    gfx_select!(command_encoder_id => context.command_encoder_copy_texture_to_buffer(
+        command_encoder_id,
         &conv::map_image_copy_texture(source.expect("invalid source")),
         &conv::map_image_copy_buffer(destination.expect("invalid destination")),
         &conv::map_extent3d(copy_size.expect("invalid copy size"))))
@@ -157,10 +139,13 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyBufferToTexture(
     destination: Option<&native::WGPUImageCopyTexture>,
     copy_size: Option<&native::WGPUExtent3D>,
 ) {
-    let (command_encoder, context) = command_encoder.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
 
-    gfx_select!(command_encoder => context.command_encoder_copy_buffer_to_texture(
-        command_encoder,
+    gfx_select!(command_encoder_id => context.command_encoder_copy_buffer_to_texture(
+        command_encoder_id,
         &conv::map_image_copy_buffer(source.expect("invalid source")),
         &conv::map_image_copy_texture(destination.expect("invalid destination")),
         &conv::map_extent3d(copy_size.expect("invalid copy size"))))
@@ -172,7 +157,10 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginComputePass(
     command_encoder: native::WGPUCommandEncoder,
     descriptor: Option<&native::WGPUComputePassDescriptor>,
 ) -> native::WGPUComputePassEncoder {
-    let (command_encoder, context) = command_encoder.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
 
     let desc = match descriptor {
         Some(descriptor) => wgc::command::ComputePassDescriptor {
@@ -180,28 +168,31 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginComputePass(
         },
         None => wgc::command::ComputePassDescriptor::default(),
     };
-    let pass = wgc::command::ComputePass::new(command_encoder, &desc);
-    native::WGPUComputePassEncoderImpl {
+
+    Box::into_raw(Box::new(native::WGPUComputePassEncoderImpl {
         context: context.clone(),
-        encoder: pass,
-    }
-    .into_handle()
+        encoder: wgc::command::ComputePass::new(command_encoder_id, &desc),
+    }))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
-    encoder: native::WGPUCommandEncoder,
+    command_encoder: native::WGPUCommandEncoder,
     descriptor: Option<&native::WGPURenderPassDescriptor>,
 ) -> native::WGPURenderPassEncoder {
-    let (encoder, context) = encoder.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
     let descriptor = descriptor.expect("invalid descriptor");
 
     let depth_stencil_attachment = descriptor.depthStencilAttachment.as_ref().map(|desc| {
         wgc::command::RenderPassDepthStencilAttachment {
             view: desc
                 .view
-                .as_option()
-                .expect("invalid texture view for depth stencil attachment"),
+                .as_ref()
+                .expect("invalid texture view for depth stencil attachment")
+                .id,
             depth: wgc::command::PassChannel {
                 load_op: conv::map_load_op(desc.depthLoadOp),
                 store_op: conv::map_store_op(desc.depthStoreOp),
@@ -225,158 +216,186 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
             )
             .iter()
             .map(|color_attachment| {
-                color_attachment.view.as_option().map(|view| {
-                    wgc::command::RenderPassColorAttachment {
-                        view,
-                        resolve_target: color_attachment.resolveTarget.as_option(),
+                color_attachment
+                    .view
+                    .as_ref()
+                    .map(|view| wgc::command::RenderPassColorAttachment {
+                        view: view.id,
+                        resolve_target: color_attachment.resolveTarget.as_ref().map(|v| v.id),
                         channel: wgc::command::PassChannel {
                             load_op: conv::map_load_op(color_attachment.loadOp),
                             store_op: conv::map_store_op(color_attachment.storeOp),
                             clear_value: conv::map_color(&color_attachment.clearValue),
                             read_only: false,
                         },
-                    }
-                })
+                    })
             })
             .collect(),
         ),
         depth_stencil_attachment: depth_stencil_attachment.as_ref(),
     };
-    let pass = wgc::command::RenderPass::new(encoder, &desc);
-    native::WGPURenderPassEncoderImpl {
+
+    Box::into_raw(Box::new(native::WGPURenderPassEncoderImpl {
         context: context.clone(),
-        encoder: pass,
-    }
-    .into_handle()
+        encoder: wgc::command::RenderPass::new(command_encoder_id, &desc),
+    }))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuCommandEncoderInsertDebugMarker(
-    encoder: native::WGPUCommandEncoder,
+    command_encoder: native::WGPUCommandEncoder,
     marker_label: *const c_char,
 ) {
-    let (encoder, context) = encoder.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
 
-    gfx_select!(encoder => context.command_encoder_insert_debug_marker(encoder, CStr::from_ptr(marker_label).to_str().unwrap()))
+    gfx_select!(command_encoder_id => context.command_encoder_insert_debug_marker(command_encoder_id, CStr::from_ptr(marker_label).to_str().unwrap()))
         .expect("Unable to insert debug marker");
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuCommandEncoderPopDebugGroup(encoder: native::WGPUCommandEncoder) {
-    let (encoder, context) = encoder.unwrap_handle();
+pub unsafe extern "C" fn wgpuCommandEncoderPopDebugGroup(
+    command_encoder: native::WGPUCommandEncoder,
+) {
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
 
-    gfx_select!(encoder => context.command_encoder_pop_debug_group(encoder))
+    gfx_select!(command_encoder_id => context.command_encoder_pop_debug_group(command_encoder_id))
         .expect("Unable to pop debug group");
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuCommandEncoderPushDebugGroup(
-    encoder: native::WGPUCommandEncoder,
+    command_encoder: native::WGPUCommandEncoder,
     group_label: *const c_char,
 ) {
-    let (encoder, context) = encoder.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
 
-    gfx_select!(encoder => context.command_encoder_push_debug_group(encoder, CStr::from_ptr(group_label).to_str().unwrap()))
+    gfx_select!(command_encoder_id => context.command_encoder_push_debug_group(command_encoder_id, CStr::from_ptr(group_label).to_str().unwrap()))
         .expect("Unable to push debug group");
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuCommandEncoderResolveQuerySet(
-    encoder: native::WGPUCommandEncoder,
+    command_encoder: native::WGPUCommandEncoder,
     query_set: native::WGPUQuerySet,
     first_query: u32,
     query_count: u32,
     destination: native::WGPUBuffer,
     destination_offset: u64,
 ) {
-    let (encoder, context) = encoder.unwrap_handle();
-    let (query_set, _) = query_set.unwrap_handle();
-    let (destination, _) = destination.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
+    let query_set_id = query_set.as_ref().expect("invalid query set").id;
+    let destination_buffer_id = destination.as_ref().expect("invalid destination").id;
 
-    gfx_select!(encoder => context.command_encoder_resolve_query_set(
-        encoder,
-        query_set,
+    gfx_select!(command_encoder_id => context.command_encoder_resolve_query_set(
+        command_encoder_id,
+        query_set_id,
         first_query,
         query_count,
-        destination,
+        destination_buffer_id,
         destination_offset))
     .expect("Unable to resolve query set");
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuCommandEncoderWriteTimestamp(
-    encoder: native::WGPUCommandEncoder,
+    command_encoder: native::WGPUCommandEncoder,
     query_set: native::WGPUQuerySet,
     query_index: u32,
 ) {
-    let (encoder, context) = encoder.unwrap_handle();
-    let (query_set, _) = query_set.unwrap_handle();
+    let (command_encoder_id, context) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (command_encoder.id, &command_encoder.context)
+    };
+    let query_set_id = query_set.as_ref().expect("invalid query set").id;
 
-    gfx_select!(encoder => context.command_encoder_write_timestamp(
-        encoder,
-        query_set,
+    gfx_select!(command_encoder_id => context.command_encoder_write_timestamp(
+        command_encoder_id,
+        query_set_id,
         query_index))
     .expect("Unable to write timestamp");
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuComputePassEncoderEnd(pass_handle: native::WGPUComputePassEncoder) {
-    let (pass, context) = unwrap_compute_pass_encoder(pass_handle);
-    let encoder_id = pass.parent_id();
-    gfx_select!(encoder_id => context.command_encoder_run_compute_pass(encoder_id, pass))
-        .expect("Unable to end compute pass");
+pub unsafe extern "C" fn wgpuComputePassEncoderEnd(pass: native::WGPUComputePassEncoder) {
+    assert!(!pass.is_null(), "invalid compute pass");
 
-    // NOTE: Automatically drops the encoder
-    pass_handle.drop();
+    // NOTE: Automatically drops the compute pass
+    let pass = Box::from_raw(pass);
+    let context = &pass.context;
+    let command_encoder_id = pass.encoder.parent_id();
+
+    gfx_select!(command_encoder_id => context.command_encoder_run_compute_pass(command_encoder_id, &pass.encoder))
+        .expect("Unable to end compute pass");
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuRenderPassEncoderEnd(pass_handle: native::WGPURenderPassEncoder) {
-    let (pass, context) = unwrap_render_pass_encoder(pass_handle);
-    let encoder_id = pass.parent_id();
-    gfx_select!(encoder_id => context.command_encoder_run_render_pass(encoder_id, pass))
-        .expect("Unable to end render pass");
+pub unsafe extern "C" fn wgpuRenderPassEncoderEnd(pass: native::WGPURenderPassEncoder) {
+    assert!(!pass.is_null(), "invalid render pass");
 
-    // NOTE: Automatically drops the encoder
-    pass_handle.drop();
+    // NOTE: Automatically drops the render pass
+    let pass = Box::from_raw(pass);
+    let context = &pass.context;
+    let command_encoder_id = pass.encoder.parent_id();
+
+    gfx_select!(command_encoder_id => context.command_encoder_run_render_pass(command_encoder_id, &pass.encoder))
+        .expect("Unable to end render pass");
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuComputePassEncoderSetPipeline(
     pass: native::WGPUComputePassEncoder,
-    pipeline_id: native::WGPUComputePipeline,
+    compute_pipeline: native::WGPUComputePipeline,
 ) {
-    let (pass, _) = unwrap_compute_pass_encoder(pass);
-    let (pipeline_id, _) = pipeline_id.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid compute pass").encoder;
+    let compute_pipeline_id = compute_pipeline
+        .as_ref()
+        .expect("invalid compute pipeline")
+        .id;
 
-    compute_ffi::wgpu_compute_pass_set_pipeline(pass, pipeline_id);
+    compute_ffi::wgpu_compute_pass_set_pipeline(pass, compute_pipeline_id);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderPassEncoderSetPipeline(
     pass: native::WGPURenderPassEncoder,
-    pipeline_id: native::WGPURenderPipeline,
+    render_pipeline: native::WGPURenderPipeline,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
-    let (pipeline_id, _) = pipeline_id.unwrap_handle();
-    render_ffi::wgpu_render_pass_set_pipeline(pass, pipeline_id);
+    let render_pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let render_pipeline_id = render_pipeline
+        .as_ref()
+        .expect("invalid render pipeline")
+        .id;
+
+    render_ffi::wgpu_render_pass_set_pipeline(render_pass, render_pipeline_id);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuComputePassEncoderSetBindGroup(
     pass: native::WGPUComputePassEncoder,
     group_index: u32,
-    group: native::WGPUBindGroup,
+    bind_group: native::WGPUBindGroup,
     dynamic_offset_count: u32,
     dynamic_offsets: *const u32,
 ) {
-    let (pass, _) = unwrap_compute_pass_encoder(pass);
-    let (group, _) = group.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid compute pass").encoder;
+    let bind_group_id = bind_group.as_ref().expect("invalid bind group").id;
 
     compute_ffi::wgpu_compute_pass_set_bind_group(
         pass,
         group_index,
-        group,
+        bind_group_id,
         dynamic_offsets,
         dynamic_offset_count as usize,
     );
@@ -386,17 +405,17 @@ pub unsafe extern "C" fn wgpuComputePassEncoderSetBindGroup(
 pub unsafe extern "C" fn wgpuRenderPassEncoderSetBindGroup(
     pass: native::WGPURenderPassEncoder,
     group_index: u32,
-    group: native::WGPUBindGroup,
+    bind_group: native::WGPUBindGroup,
     dynamic_offset_count: u32,
     dynamic_offsets: *const u32,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
-    let (group, _) = group.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let bind_group_id = bind_group.as_ref().expect("invalid bind group").id;
 
     render_ffi::wgpu_render_pass_set_bind_group(
         pass,
         group_index,
-        group,
+        bind_group_id,
         dynamic_offsets,
         dynamic_offset_count as usize,
     );
@@ -409,7 +428,8 @@ pub unsafe extern "C" fn wgpuComputePassEncoderDispatchWorkgroups(
     workgroup_count_y: u32,
     workgroup_count_z: u32,
 ) {
-    let (pass, _) = unwrap_compute_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid compute pass").encoder;
+
     compute_ffi::wgpu_compute_pass_dispatch_workgroups(
         pass,
         workgroup_count_x,
@@ -424,12 +444,15 @@ pub unsafe extern "C" fn wgpuComputePassEncoderDispatchWorkgroupsIndirect(
     indirect_buffer: native::WGPUBuffer,
     indirect_offset: u64,
 ) {
-    let (pass, _) = unwrap_compute_pass_encoder(pass);
-    let (indirect_buffer, _) = indirect_buffer.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid compute pass").encoder;
+    let indirect_buffer_id = indirect_buffer
+        .as_mut()
+        .expect("invalid indirect buffer")
+        .id;
 
     compute_ffi::wgpu_compute_pass_dispatch_workgroups_indirect(
         pass,
-        indirect_buffer,
+        indirect_buffer_id,
         indirect_offset,
     );
 }
@@ -439,13 +462,13 @@ pub unsafe extern "C" fn wgpuComputePassEncoderInsertDebugMarker(
     pass: native::WGPUComputePassEncoder,
     marker_label: *const c_char,
 ) {
-    let (pass, _) = unwrap_compute_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid compute pass").encoder;
     compute_ffi::wgpu_compute_pass_insert_debug_marker(pass, marker_label, 0);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuComputePassEncoderPopDebugGroup(pass: native::WGPUComputePassEncoder) {
-    let (pass, _) = unwrap_compute_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid compute pass").encoder;
     compute_ffi::wgpu_compute_pass_pop_debug_group(pass);
 }
 
@@ -454,7 +477,7 @@ pub unsafe extern "C" fn wgpuComputePassEncoderPushDebugGroup(
     pass: native::WGPUComputePassEncoder,
     group_label: *const c_char,
 ) {
-    let (pass, _) = unwrap_compute_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid compute pass").encoder;
     compute_ffi::wgpu_compute_pass_push_debug_group(pass, group_label, 0);
 }
 
@@ -464,16 +487,17 @@ pub unsafe extern "C" fn wgpuComputePassEncoderBeginPipelineStatisticsQuery(
     query_set: native::WGPUQuerySet,
     query_index: u32,
 ) {
-    let (pass, _) = unwrap_compute_pass_encoder(pass);
-    let (query_set, _) = query_set.unwrap_handle();
-    compute_ffi::wgpu_compute_pass_begin_pipeline_statistics_query(pass, query_set, query_index);
+    let pass = &mut pass.as_mut().expect("invalid compute pass").encoder;
+    let query_set_id = query_set.as_ref().expect("invalid query set").id;
+
+    compute_ffi::wgpu_compute_pass_begin_pipeline_statistics_query(pass, query_set_id, query_index);
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuComputePassEncoderEndPipelineStatisticsQuery(
+pub unsafe extern "C" fn wgpuComputePassEncoderEndPipelineStatisticsQuery(
     pass: native::WGPUComputePassEncoder,
 ) {
-    let (pass, _) = unwrap_compute_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid compute pass").encoder;
     compute_ffi::wgpu_compute_pass_end_pipeline_statistics_query(pass);
 }
 
@@ -485,7 +509,7 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDraw(
     first_vertex: u32,
     first_instance: u32,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
     render_ffi::wgpu_render_pass_draw(
         pass,
         vertex_count,
@@ -504,7 +528,7 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDrawIndexed(
     base_vertex: u32,
     first_instance: u32,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
     render_ffi::wgpu_render_pass_draw_indexed(
         pass,
         index_count,
@@ -521,10 +545,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDrawIndirect(
     buffer: native::WGPUBuffer,
     indirect_offset: u64,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
-    let (buffer, _) = buffer.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
-    render_ffi::wgpu_render_pass_draw_indirect(pass, buffer, indirect_offset);
+    render_ffi::wgpu_render_pass_draw_indirect(pass, buffer_id, indirect_offset);
 }
 
 #[no_mangle]
@@ -533,10 +557,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDrawIndexedIndirect(
     buffer: native::WGPUBuffer,
     indirect_offset: u64,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
-    let (buffer, _) = buffer.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
-    render_ffi::wgpu_render_pass_draw_indexed_indirect(pass, buffer, indirect_offset);
+    render_ffi::wgpu_render_pass_draw_indexed_indirect(pass, buffer_id, indirect_offset);
 }
 
 #[no_mangle]
@@ -546,10 +570,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndirect(
     offset: u64,
     count: u32,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
-    let (buffer, _) = buffer.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
-    render_ffi::wgpu_render_pass_multi_draw_indirect(pass, buffer, offset, count);
+    render_ffi::wgpu_render_pass_multi_draw_indirect(pass, buffer_id, offset, count);
 }
 
 #[no_mangle]
@@ -559,10 +583,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndexedIndirect(
     offset: u64,
     count: u32,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
-    let (buffer, _) = buffer.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
-    render_ffi::wgpu_render_pass_multi_draw_indexed_indirect(pass, buffer, offset, count);
+    render_ffi::wgpu_render_pass_multi_draw_indexed_indirect(pass, buffer_id, offset, count);
 }
 
 #[no_mangle]
@@ -574,15 +598,15 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndirectCount(
     count_buffer_offset: u64,
     max_count: u32,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
-    let (buffer, _) = buffer.unwrap_handle();
-    let (count_buffer, _) = count_buffer.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
+    let count_buffer_id = count_buffer.as_ref().expect("invalid count buffer").id;
 
     render_ffi::wgpu_render_pass_multi_draw_indirect_count(
         pass,
-        buffer,
+        buffer_id,
         offset,
-        count_buffer,
+        count_buffer_id,
         count_buffer_offset,
         max_count,
     );
@@ -597,15 +621,15 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndexedIndirectCount(
     count_buffer_offset: u64,
     max_count: u32,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
-    let (buffer, _) = buffer.unwrap_handle();
-    let (count_buffer, _) = count_buffer.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
+    let count_buffer_id = count_buffer.as_ref().expect("invalid count buffer").id;
 
     render_ffi::wgpu_render_pass_multi_draw_indexed_indirect_count(
         pass,
-        buffer,
+        buffer_id,
         offset,
-        count_buffer,
+        count_buffer_id,
         count_buffer_offset,
         max_count,
     );
@@ -619,11 +643,11 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetIndexBuffer(
     offset: u64,
     size: u64,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
-    let (buffer, _) = buffer.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
     pass.set_index_buffer(
-        buffer,
+        buffer_id,
         conv::map_index_format(index_format).expect("Index format cannot be undefined"),
         offset,
         match size {
@@ -642,13 +666,13 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetVertexBuffer(
     offset: u64,
     size: u64,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
-    let (buffer, _) = buffer.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
     render_ffi::wgpu_render_pass_set_vertex_buffer(
         pass,
         slot,
-        buffer,
+        buffer_id,
         offset,
         match size {
             0 => panic!("invalid size"),
@@ -666,10 +690,11 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetPushConstants(
     size_bytes: u32,
     size: *const u8,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+
     render_ffi::wgpu_render_pass_set_push_constants(
         pass,
-        wgt::ShaderStages::from_bits(stages).expect("Invalid shader stage"),
+        wgt::ShaderStages::from_bits(stages).expect("invalid shader stage"),
         offset,
         size_bytes,
         size,
@@ -681,7 +706,8 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetBlendConstant(
     pass: native::WGPURenderPassEncoder,
     color: Option<&native::WGPUColor>,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+
     render_ffi::wgpu_render_pass_set_blend_constant(
         pass,
         &conv::map_color(color.expect("invalid color")),
@@ -693,7 +719,8 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetStencilReference(
     pass: native::WGPURenderPassEncoder,
     reference: u32,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+
     render_ffi::wgpu_render_pass_set_stencil_reference(pass, reference);
 }
 
@@ -707,7 +734,8 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetViewport(
     depth_min: f32,
     depth_max: f32,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+
     render_ffi::wgpu_render_pass_set_viewport(pass, x, y, w, h, depth_min, depth_max);
 }
 
@@ -719,7 +747,8 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetScissorRect(
     w: u32,
     h: u32,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+
     render_ffi::wgpu_render_pass_set_scissor_rect(pass, x, y, w, h);
 }
 
@@ -728,13 +757,15 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderInsertDebugMarker(
     pass: native::WGPURenderPassEncoder,
     marker_label: *const c_char,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+
     render_ffi::wgpu_render_pass_insert_debug_marker(pass, marker_label, 0);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderPassEncoderPopDebugGroup(pass: native::WGPURenderPassEncoder) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+
     render_ffi::wgpu_render_pass_pop_debug_group(pass);
 }
 
@@ -743,60 +774,59 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderPushDebugGroup(
     pass: native::WGPURenderPassEncoder,
     group_label: *const c_char,
 ) {
-    let (pass, _) = unwrap_render_pass_encoder(pass);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+
     render_ffi::wgpu_render_pass_push_debug_group(pass, group_label, 0);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderPassEncoderExecuteBundles(
-    render_pass_encoder: native::WGPURenderPassEncoder,
+    pass: native::WGPURenderPassEncoder,
     bundle_count: u32,
-    bundles: *const wgc::id::RenderBundleId,
+    bundles: *const native::WGPURenderBundle,
 ) {
-    let (render_pass_encoder, _) = unwrap_render_pass_encoder(render_pass_encoder);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
 
-    render_ffi::wgpu_render_pass_execute_bundles(
-        render_pass_encoder,
-        bundles,
-        bundle_count as usize,
-    );
+    let bundle_ids = make_slice(bundles, bundle_count as usize)
+        .iter()
+        .map(|v| v.as_ref().expect("invalid render bundle").id)
+        .collect::<Vec<wgc::id::RenderBundleId>>();
+
+    render_ffi::wgpu_render_pass_execute_bundles(pass, bundle_ids.as_ptr(), bundle_ids.len());
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderPassEncoderBeginPipelineStatisticsQuery(
-    render_pass_encoder: native::WGPURenderPassEncoder,
+    pass: native::WGPURenderPassEncoder,
     query_set: native::WGPUQuerySet,
     query_index: u32,
 ) {
-    let (render_pass_encoder, _) = unwrap_render_pass_encoder(render_pass_encoder);
-    let (query_set, _) = query_set.unwrap_handle();
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    let query_set_id = query_set.as_ref().expect("invalid query set").id;
 
-    render_ffi::wgpu_render_pass_begin_pipeline_statistics_query(
-        render_pass_encoder,
-        query_set,
-        query_index,
-    );
+    render_ffi::wgpu_render_pass_begin_pipeline_statistics_query(pass, query_set_id, query_index);
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuRenderPassEncoderEndPipelineStatisticsQuery(
-    render_pass_encoder: native::WGPURenderPassEncoder,
+pub unsafe extern "C" fn wgpuRenderPassEncoderEndPipelineStatisticsQuery(
+    pass: native::WGPURenderPassEncoder,
 ) {
-    let (render_pass_encoder, _) = unwrap_render_pass_encoder(render_pass_encoder);
-    render_ffi::wgpu_render_pass_end_pipeline_statistics_query(render_pass_encoder);
+    let pass = &mut pass.as_mut().expect("invalid render pass").encoder;
+    render_ffi::wgpu_render_pass_end_pipeline_statistics_query(pass);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderDraw(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     vertex_count: u32,
     instance_count: u32,
     first_vertex: u32,
     first_instance: u32,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+
     bundle_ffi::wgpu_render_bundle_draw(
-        render_bundle_encoder,
+        bundle,
         vertex_count,
         instance_count,
         first_vertex,
@@ -806,16 +836,17 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderDraw(
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderDrawIndexed(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     index_count: u32,
     instance_count: u32,
     first_index: u32,
     base_vertex: i32,
     first_instance: u32,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+
     bundle_ffi::wgpu_render_bundle_draw_indexed(
-        render_bundle_encoder,
+        bundle,
         index_count,
         instance_count,
         first_index,
@@ -826,49 +857,50 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderDrawIndexed(
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderDrawIndexedIndirect(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     indirect_buffer: native::WGPUBuffer,
     indirect_offset: u64,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
-    let (indirect_buffer, _) = indirect_buffer.unwrap_handle();
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+    let indirect_buffer_id = indirect_buffer
+        .as_ref()
+        .expect("invalid indirect buffer")
+        .id;
+
     bundle_ffi::wgpu_render_bundle_draw_indexed_indirect(
-        render_bundle_encoder,
-        indirect_buffer,
+        bundle,
+        indirect_buffer_id,
         indirect_offset,
     );
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderDrawIndirect(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     indirect_buffer: native::WGPUBuffer,
     indirect_offset: u64,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
-    let (indirect_buffer, _) = indirect_buffer.unwrap_handle();
-    bundle_ffi::wgpu_render_bundle_draw_indirect(
-        render_bundle_encoder,
-        indirect_buffer,
-        indirect_offset,
-    );
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+    let indirect_buffer_id = indirect_buffer
+        .as_ref()
+        .expect("invalid indirect buffer")
+        .id;
+
+    bundle_ffi::wgpu_render_bundle_draw_indirect(bundle, indirect_buffer_id, indirect_offset);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderFinish(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     descriptor: Option<&native::WGPURenderBundleDescriptor>,
 ) -> native::WGPURenderBundle {
-    // NOTE: Automatically drop the encoder
-    let (render_bundle_encoder, context) = {
-        if render_bundle_encoder.is_null() {
-            panic!("invalid render bundle encoder");
-        }
-        let v = Box::from_raw(render_bundle_encoder);
-        (v.encoder, v.context)
-    };
+    assert!(!bundle.is_null(), "invalid render bundle");
 
-    let device = render_bundle_encoder.parent();
+    // NOTE: Automatically drops the bundle encoder
+    let bundle = Box::from_raw(bundle);
+    let context = &bundle.context;
+    let bundle_encoder = bundle.encoder;
+    let device_id = bundle_encoder.parent();
 
     let desc = match descriptor {
         Some(descriptor) => wgt::RenderBundleDescriptor {
@@ -877,55 +909,59 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderFinish(
         None => wgt::RenderBundleDescriptor::default(),
     };
 
-    let (render_bundle, error) = gfx_select!(device => context.render_bundle_encoder_finish(render_bundle_encoder, &desc, ()));
+    let (render_bundle_id, error) =
+        gfx_select!(device_id => context.render_bundle_encoder_finish(bundle_encoder, &desc, ()));
     if let Some(error) = error {
-        handle_device_error(device, &error);
+        handle_device_error(device_id, &error);
         std::ptr::null_mut()
     } else {
-        render_bundle.into_handle_with_context(&context)
+        Box::into_raw(Box::new(native::WGPURenderBundleImpl {
+            context: context.clone(),
+            id: render_bundle_id,
+        }))
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderInsertDebugMarker(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     marker_label: *const c_char,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
-    bundle_ffi::wgpu_render_bundle_insert_debug_marker(render_bundle_encoder, marker_label);
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+    bundle_ffi::wgpu_render_bundle_insert_debug_marker(bundle, marker_label);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderPopDebugGroup(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
-    bundle_ffi::wgpu_render_bundle_pop_debug_group(render_bundle_encoder);
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+    bundle_ffi::wgpu_render_bundle_pop_debug_group(bundle);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderPushDebugGroup(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     group_label: *const c_char,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
-    bundle_ffi::wgpu_render_bundle_push_debug_group(render_bundle_encoder, group_label);
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+    bundle_ffi::wgpu_render_bundle_push_debug_group(bundle, group_label);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderSetBindGroup(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     group_index: u32,
     group: native::WGPUBindGroup,
     dynamic_offset_count: u32,
     dynamic_offsets: *const u32,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
-    let (group, _) = group.unwrap_handle();
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+    let bind_group_id = group.as_ref().expect("invalid bind group").id;
     bundle_ffi::wgpu_render_bundle_set_bind_group(
-        render_bundle_encoder,
+        bundle,
         group_index,
-        group,
+        bind_group_id,
         dynamic_offsets,
         dynamic_offset_count as usize,
     );
@@ -933,19 +969,19 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetBindGroup(
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderSetIndexBuffer(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     buffer: native::WGPUBuffer,
     format: native::WGPUIndexFormat,
     offset: u64,
     size: u64,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
-    let (buffer, _) = buffer.unwrap_handle();
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
     bundle_ffi::wgpu_render_bundle_set_index_buffer(
-        render_bundle_encoder,
-        buffer,
-        conv::map_index_format(format).unwrap(),
+        bundle,
+        buffer_id,
+        conv::map_index_format(format).expect("invalid index format"),
         offset,
         match size {
             0 => panic!("invalid size"),
@@ -957,30 +993,30 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetIndexBuffer(
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderSetPipeline(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     pipeline: native::WGPURenderPipeline,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
-    let (pipeline, _) = pipeline.unwrap_handle();
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+    let pipeline_id = pipeline.as_ref().expect("invalid render pipeline").id;
 
-    bundle_ffi::wgpu_render_bundle_set_pipeline(render_bundle_encoder, pipeline);
+    bundle_ffi::wgpu_render_bundle_set_pipeline(bundle, pipeline_id);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderBundleEncoderSetVertexBuffer(
-    render_bundle_encoder: native::WGPURenderBundleEncoder,
+    bundle: native::WGPURenderBundleEncoder,
     slot: u32,
     buffer: native::WGPUBuffer,
     offset: u64,
     size: u64,
 ) {
-    let (render_bundle_encoder, _) = unwrap_render_bundle_encoder(render_bundle_encoder);
-    let (buffer, _) = buffer.unwrap_handle();
+    let bundle = &mut bundle.as_mut().expect("invalid render bundle").encoder;
+    let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
     bundle_ffi::wgpu_render_bundle_set_vertex_buffer(
-        render_bundle_encoder,
+        bundle,
         slot,
-        buffer,
+        buffer_id,
         offset,
         match size {
             0 => panic!("invalid size"),

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,4 @@
 use crate::{map_enum, native};
-use lazy_static::lazy_static;
 use log::{Level, LevelFilter, Metadata, Record};
 use std::{ffi::CString, sync::Mutex};
 
@@ -71,13 +70,11 @@ struct LoggerInfo {
 }
 unsafe impl Send for LoggerInfo {}
 
-lazy_static! {
-    static ref LOGGER_INFO: Mutex<LoggerInfo> = Mutex::new(LoggerInfo {
-        initialized: false,
-        callback: None,
-        userdata: std::ptr::null_mut(),
-    });
-}
+static LOGGER_INFO: Mutex<LoggerInfo> = Mutex::new(LoggerInfo {
+    initialized: false,
+    callback: None,
+    userdata: std::ptr::null_mut(),
+});
 
 #[no_mangle]
 pub extern "C" fn wgpuSetLogCallback(


### PR DESCRIPTION
removed some unnecessary meta-programming, this makes some functions little more verbose but improves readability & makes it simpler to understand for new contributors.

some additional changes:
- replace some `unwrap` calls with `expect('msg')`
- replace usages of `slice::from_raw_parts` + `copy_from_slice` with direct call to [`std::ptr::copy_nonoverlapping`](https://doc.rust-lang.org/std/ptr/fn.copy_nonoverlapping.html)
- generate error msg for uncaptured error callback using `err.to_string()` instead of `format!("{err}")`, this makes string human readable.
- remove some redundant `drop` calls
- make some mapping functions `#[inline]`
- remove `lazy_static` dependency

### Testing
tested via running examples on linux