### PR TITLE
update headers

### DIFF
--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -24,16 +24,6 @@ static void handle_request_device(WGPURequestDeviceStatus status,
   UNUSED(message)
   *(WGPUDevice *)userdata = device;
 }
-static void handle_device_lost(WGPUDeviceLostReason reason, char const *message,
-                               void *userdata) {
-  UNUSED(userdata)
-  printf(LOG_PREFIX " device_lost reason=%#.8x message=%s\n", reason, message);
-}
-static void handle_uncaptured_error(WGPUErrorType type, char const *message,
-                                    void *userdata) {
-  UNUSED(userdata)
-  printf(LOG_PREFIX " uncaptured_error type=%#.8x message=%s\n", type, message);
-}
 static void handle_buffer_map(WGPUBufferMapAsyncStatus status, void *userdata) {
   UNUSED(userdata)
   printf(LOG_PREFIX " buffer_map status=%#.8x\n", status);
@@ -104,9 +94,6 @@ int main(int argc, char *argv[]) {
   ASSERT_CHECK(device);
   queue = wgpuDeviceGetQueue(device);
   ASSERT_CHECK(queue);
-
-  wgpuDeviceSetUncapturedErrorCallback(device, handle_uncaptured_error, NULL);
-  wgpuDeviceSetDeviceLostCallback(device, handle_device_lost, NULL);
 
   BufferDimensions buffer_dimensions = {0};
   buffer_dimensions_init(&buffer_dimensions, width, height);

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -18,16 +18,6 @@ static void handle_request_device(WGPURequestDeviceStatus status,
   UNUSED(message)
   *(WGPUDevice *)userdata = device;
 }
-static void handle_device_lost(WGPUDeviceLostReason reason, char const *message,
-                               void *userdata) {
-  UNUSED(userdata)
-  printf(LOG_PREFIX " device_lost reason=%#.8x message=%s\n", reason, message);
-}
-static void handle_uncaptured_error(WGPUErrorType type, char const *message,
-                                    void *userdata) {
-  UNUSED(userdata)
-  printf(LOG_PREFIX " uncaptured_error type=%#.8x message=%s\n", type, message);
-}
 static void handle_buffer_map(WGPUBufferMapAsyncStatus status, void *userdata) {
   UNUSED(userdata)
   printf(LOG_PREFIX " buffer_map status=%#.8x\n", status);
@@ -77,9 +67,6 @@ int main(int argc, char *argv[]) {
 
   queue = wgpuDeviceGetQueue(device);
   ASSERT_CHECK(queue);
-
-  wgpuDeviceSetUncapturedErrorCallback(device, handle_uncaptured_error, NULL);
-  wgpuDeviceSetDeviceLostCallback(device, handle_device_lost, NULL);
 
   shader_module = frmwrk_load_shader_module(device, "shader.wgsl");
   ASSERT_CHECK(shader_module);

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -55,16 +55,6 @@ static void handle_request_device(WGPURequestDeviceStatus status,
            message);
   }
 }
-static void handle_device_lost(WGPUDeviceLostReason reason, char const *message,
-                               void *userdata) {
-  UNUSED(userdata)
-  printf(LOG_PREFIX " device_lost reason=%#.8x message=%s\n", reason, message);
-}
-static void handle_uncaptured_error(WGPUErrorType type, char const *message,
-                                    void *userdata) {
-  UNUSED(userdata)
-  printf(LOG_PREFIX " uncaptured_error type=%#.8x message=%s\n", type, message);
-}
 static void handle_glfw_key(GLFWwindow *window, int key, int scancode,
                             int action, int mods) {
   UNUSED(scancode)
@@ -243,10 +233,6 @@ int main(int argc, char *argv[]) {
 
   queue = wgpuDeviceGetQueue(demo.device);
   ASSERT_CHECK(queue);
-
-  wgpuDeviceSetUncapturedErrorCallback(demo.device, handle_uncaptured_error,
-                                       NULL);
-  wgpuDeviceSetDeviceLostCallback(demo.device, handle_device_lost, NULL);
 
   shader_module = frmwrk_load_shader_module(demo.device, "shader.wgsl");
   ASSERT_CHECK(shader_module);

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -215,3 +215,230 @@ pub extern "C" fn wgpuTextureViewSetLabel(
 ) {
     unimplemented!();
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuAdapterReference(_adapter: native::WGPUAdapter) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuAdapterRelease(_adapter: native::WGPUAdapter) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuBindGroupReference(_bind_group: native::WGPUBindGroup) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuBindGroupRelease(_bind_group: native::WGPUBindGroup) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuBindGroupLayoutReference(
+    _bind_group_layout: native::WGPUBindGroupLayout,
+) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuBindGroupLayoutRelease(
+    _bind_group_layout: native::WGPUBindGroupLayout,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuBufferReference(_buffer: native::WGPUBuffer) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuBufferRelease(_buffer: native::WGPUBuffer) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuCommandBufferReference(_command_buffer: native::WGPUCommandBuffer) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuCommandBufferRelease(_command_buffer: native::WGPUCommandBuffer) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuCommandEncoderReference(_command_encoder: native::WGPUCommandEncoder) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuCommandEncoderRelease(_command_encoder: native::WGPUCommandEncoder) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePassEncoderReference(
+    _compute_pass_encoder: native::WGPUComputePassEncoder,
+) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePassEncoderRelease(
+    _compute_pass_encoder: native::WGPUComputePassEncoder,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePipelineReference(
+    _compute_pipeline: native::WGPUComputePipeline,
+) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePipelineRelease(
+    _compute_pipeline: native::WGPUComputePipeline,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuDeviceReference(_device: native::WGPUDevice) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuDeviceRelease(_device: native::WGPUDevice) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuInstanceReference(_instance: native::WGPUInstance) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuInstanceRelease(_instance: native::WGPUInstance) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuPipelineLayoutReference(_pipeline_layout: native::WGPUPipelineLayout) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuPipelineLayoutRelease(_pipeline_layout: native::WGPUPipelineLayout) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuQuerySetReference(_query_set: native::WGPUQuerySet) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuQuerySetRelease(_query_set: native::WGPUQuerySet) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuQueueReference(_queue: native::WGPUQueue) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuQueueRelease(_queue: native::WGPUQueue) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderBundleReference(_render_bundle: native::WGPURenderBundle) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderBundleRelease(_render_bundle: native::WGPURenderBundle) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderBundleEncoderReference(
+    _render_bundle_encoder: native::WGPURenderBundleEncoder,
+) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderBundleEncoderRelease(
+    _render_bundle_encoder: native::WGPURenderBundleEncoder,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPassEncoderReference(
+    _render_pass_encoder: native::WGPURenderPassEncoder,
+) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPassEncoderRelease(
+    _render_pass_encoder: native::WGPURenderPassEncoder,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPipelineReference(_render_pipeline: native::WGPURenderPipeline) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPipelineRelease(_render_pipeline: native::WGPURenderPipeline) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuSamplerReference(_sampler: native::WGPUSampler) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuSamplerRelease(_sampler: native::WGPUSampler) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuShaderModuleReference(_shader_module: native::WGPUShaderModule) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuShaderModuleRelease(_shader_module: native::WGPUShaderModule) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuSurfaceReference(_surface: native::WGPUSurface) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuSurfaceRelease(_surface: native::WGPUSurface) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuSwapChainReference(_swap_chain: native::WGPUSwapChain) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuSwapChainRelease(_swap_chain: native::WGPUSwapChain) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureReference(_texture: native::WGPUTexture) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureRelease(_texture: native::WGPUTexture) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureViewReference(_texture_view: native::WGPUTextureView) {
+    unimplemented!();
+}
+#[no_mangle]
+pub unsafe extern "C" fn wgpuTextureViewRelease(_texture_view: native::WGPUTextureView) {
+    unimplemented!();
+}


### PR DESCRIPTION
https://github.com/webgpu-native/webgpu-headers/compare/048341380f41c0d67e66998b3def7b5868380080...245130311ef771c958ba43c322aa7ef1f9edfb8f#diff-074fca0467717d8d789bdfb86bf9e2d4afec03055a2787e0b604fda4254d4ed9

will create a separate PR for migration from `Drop()` -> `Reference/Release()`