### PR TITLE
Expose TextureViewArray, SamplerArray and associated extensions to the C API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,7 @@ jobs:
           make example-compute
           make example-triangle
           make example-enumerate_adapters
+          make example-texture_arrays
       - if: ${{ matrix.run_examples }}
         name: Run examples debug
         run: |
@@ -205,10 +206,10 @@ jobs:
           make example-compute-release
           make example-triangle-release
           make example-enumerate_adapters-release
+          make example-texture_arrays-release
       - if: ${{ matrix.run_examples }}
         name: Run examples release
         run: |
           make run-example-capture-release
           make run-example-compute-release
           make run-example-enumerate_adapters-release
-

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build
 dist
 .idea
+examplesbuild

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@
 build
 dist
 .idea
-examplesbuild

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,18 +24,18 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ash"
-version = "0.37.2+1.3.238"
+version = "0.37.3+1.3.251"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28bf19c1f0a470be5fbf7522a308a05df06610252c5bcf5143e1b23f629a9a03"
+checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
 dependencies = [
  "libloading 0.7.4",
 ]
@@ -71,7 +71,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.15",
+ "syn",
  "which",
 ]
 
@@ -98,9 +98,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.1.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
 
 [[package]]
 name = "block"
@@ -110,9 +110,9 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "cc"
@@ -223,9 +223,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -240,9 +240,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "glow"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e007a07a24de5ecae94160f141029e9a347282cfe25d1d58d85d845cf3130f1"
+checksum = "807edf58b70c0b5b2181dd39fe1839dbdb3ba02645630dc5f753e23da307f762"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-alloc"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc59e5f710e310e76e6707f86c561dd646f69a8876da9131703b2f717de818d"
+checksum = "22beaafc29b38204457ea030f6fb7a84c9e4dd1b86e311ba0542533453d87f62"
 dependencies = [
  "bitflags 1.3.2",
  "gpu-alloc-types",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -349,9 +349,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libloading"
@@ -370,14 +370,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -385,12 +385,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "malloc_buf"
@@ -489,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parking_lot"
@@ -505,15 +502,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -540,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "pp-rs"
@@ -555,19 +552,19 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
+checksum = "43ded2b5b204571f065ab8540367d738dfe1b3606ab9eb669dcfb5e7a3a07501"
 dependencies = [
  "proc-macro2",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -580,9 +577,9 @@ checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -601,27 +598,27 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "ron"
@@ -648,22 +645,22 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
@@ -699,20 +696,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -745,14 +731,14 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-width"
@@ -780,9 +766,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -790,24 +776,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -815,28 +801,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -849,7 +835,7 @@ source = "git+https://github.com/gfx-rs/wgpu?rev=011a4e26d04f388ef40e3baee3f19a2
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags 2.1.0",
+ "bitflags 2.3.2",
  "codespan-reporting",
  "log",
  "naga",
@@ -875,7 +861,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.1.0",
+ "bitflags 2.3.2",
  "block",
  "core-graphics-types",
  "d3d12",
@@ -923,7 +909,7 @@ name = "wgpu-types"
 version = "0.16.0"
 source = "git+https://github.com/gfx-rs/wgpu?rev=011a4e26d04f388ef40e3baee3f19a255b9b5148#011a4e26d04f388ef40e3baee3f19a255b9b5148"
 dependencies = [
- "bitflags 2.1.0",
+ "bitflags 2.3.2",
  "js-sys",
  "serde",
  "web-sys",
@@ -973,35 +959,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1010,20 +972,14 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1033,21 +989,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1057,21 +1001,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1081,21 +1013,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,18 @@ example-enumerate_adapters-release: examples-release
 run-example-enumerate_adapters-release: example-enumerate_adapters-release
 	cd examples/triangle && "../build/RelWithDebInfo/enumerate_adapters/enumerate_adapters"
 
+example-texture_arrays: examples-debug
+	cd examples/build/Debug && cmake --build . --target texture_arrays
+
+run-example-texture_arrays: example-texture_arrays
+	cd examples/texture_arrays && "../build/Debug/texture_arrays/texture_arrays"
+
+example-texture_arrays-release: examples-release
+	cd examples/build/RelWithDebInfo && cmake --build . --target texture_arrays
+
+run-example-texture_arrays-release: example-texture_arrays-release
+	cd examples/texture_arrays && "../build/RelWithDebInfo/texture_arrays/texture_arrays"
+
 example-triangle: examples-debug
 	cd examples/build/Debug && cmake --build . --target triangle
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.20)
 project(examples LANGUAGES C)
 
+set(CMAKE_C_STANDARD 99)
+
 if(APPLE)
     add_compile_options(-x objective-c)
 endif()
@@ -30,6 +32,7 @@ add_subdirectory(framework)
 add_subdirectory(capture)
 add_subdirectory(compute)
 add_subdirectory(enumerate_adapters)
+add_subdirectory(texture_arrays)
 add_subdirectory(triangle)
 
 set(GLFW_USE_WAYLAND 1)

--- a/examples/framework/framework.c
+++ b/examples/framework/framework.c
@@ -88,7 +88,8 @@ cleanup:
 #define MAX(A, B) ((A) > (B) ? (A) : (B))
 
 WGPUBuffer frmwrk_device_create_buffer_init(
-    WGPUDevice device, frmwrk_buffer_init_descriptor descriptor[static 1]) {
+    WGPUDevice device, const frmwrk_buffer_init_descriptor *descriptor) {
+  assert(descriptor);
   if (descriptor->content_size == 0) {
     return wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
                                               .label = descriptor->label,

--- a/examples/framework/framework.c
+++ b/examples/framework/framework.c
@@ -1,8 +1,4 @@
 #include "framework.h"
-#include "wgpu.h"
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 static void log_callback(WGPULogLevel level, char const *message,
                          void *userdata) {
@@ -86,6 +82,38 @@ cleanup:
   if (buf)
     free(buf);
   return shader_module;
+}
+
+#define COPY_BUFFER_ALIGNMENT 4
+#define MAX(A, B) ((A) > (B) ? (A) : (B))
+
+WGPUBuffer frmwrk_device_create_buffer_init(
+    WGPUDevice device, frmwrk_buffer_init_descriptor descriptor[static 1]) {
+  if (descriptor->content_size == 0) {
+    return wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
+                                              .label = descriptor->label,
+                                              .size = 0,
+                                              .usage = descriptor->usage,
+                                              .mappedAtCreation = false,
+                                          });
+  }
+
+  size_t unpadded_size = descriptor->content_size;
+  size_t align_mask = COPY_BUFFER_ALIGNMENT - 1;
+  size_t padded_size =
+      MAX((unpadded_size + align_mask) & ~align_mask, COPY_BUFFER_ALIGNMENT);
+  WGPUBuffer buffer =
+      wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
+                                         .label = descriptor->label,
+                                         .size = padded_size,
+                                         .usage = descriptor->usage,
+                                         .mappedAtCreation = true,
+                                     });
+  void *buf = wgpuBufferGetMappedRange(buffer, 0, unpadded_size);
+  memcpy(buf, descriptor->content, unpadded_size);
+  wgpuBufferUnmap(buffer);
+
+  return buffer;
 }
 
 #define print_storage_report(report, prefix)                                   \

--- a/examples/framework/framework.h
+++ b/examples/framework/framework.h
@@ -21,6 +21,6 @@ void frmwrk_setup_logging(WGPULogLevel level);
 WGPUShaderModule frmwrk_load_shader_module(WGPUDevice device, const char *name);
 void frmwrk_print_global_report(WGPUGlobalReport report);
 WGPUBuffer frmwrk_device_create_buffer_init(
-    WGPUDevice device, frmwrk_buffer_init_descriptor descriptor[static 1]);
+    WGPUDevice device, const frmwrk_buffer_init_descriptor *descriptor);
 
 #endif // FRAMEWORK_H

--- a/examples/framework/framework.h
+++ b/examples/framework/framework.h
@@ -2,11 +2,25 @@
 #define FRAMEWORK_H
 
 #include "wgpu.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define UNUSED(x) (void)x;
+
+typedef struct frmwrk_buffer_init_descriptor {
+  WGPU_NULLABLE char const *label;
+  WGPUBufferUsageFlags usage;
+  void *content;
+  size_t content_size;
+} frmwrk_buffer_init_descriptor;
 
 void frmwrk_setup_logging(WGPULogLevel level);
 WGPUShaderModule frmwrk_load_shader_module(WGPUDevice device, const char *name);
 void frmwrk_print_global_report(WGPUGlobalReport report);
+WGPUBuffer frmwrk_device_create_buffer_init(
+    WGPUDevice device, frmwrk_buffer_init_descriptor descriptor[static 1]);
 
 #endif // FRAMEWORK_H

--- a/examples/texture_arrays/CMakeLists.txt
+++ b/examples/texture_arrays/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.20)
+project(texture_arrays LANGUAGES C)
+
+add_executable(texture_arrays main.c)
+
+if (MSVC)
+    add_compile_options(/W4)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+include_directories(${CMAKE_SOURCE_DIR}/../ffi)
+include_directories(${CMAKE_SOURCE_DIR}/framework)
+include_directories(${DEP_GLFW_DIR}/include)
+
+if (WIN32)
+    add_definitions(-DWGPU_TARGET_WINDOWS)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll)
+elseif(UNIX AND NOT APPLE)
+    add_definitions(-DWGPU_TARGET_LINUX_X11)
+    set(OS_LIBRARIES "-lm -ldl")
+elseif(APPLE)
+    add_definitions(-DWGPU_TARGET_MACOS)
+    set(OS_LIBRARIES "-framework CoreFoundation -framework QuartzCore -framework Metal")
+endif()
+
+target_link_libraries(texture_arrays framework glfw ${WGPU_LIBRARY} ${OS_LIBRARIES})

--- a/examples/texture_arrays/indexing.wgsl
+++ b/examples/texture_arrays/indexing.wgsl
@@ -1,0 +1,61 @@
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) tex_coord: vec2<f32>,
+    @location(2) index: i32,
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) tex_coord: vec2<f32>,
+    @location(1) index: i32,
+}
+
+@vertex
+fn vert_main(vertex: VertexInput) -> VertexOutput {
+    var outval: VertexOutput;
+    outval.position = vec4<f32>(vertex.position.x, vertex.position.y, 0.0, 1.0);
+    outval.tex_coord = vertex.tex_coord;
+    outval.index = vertex.index;
+    return outval;
+}
+
+struct FragmentInput {
+    @location(0) tex_coord: vec2<f32>,
+    @location(1) index: i32,
+}
+
+@group(0) @binding(0)
+var texture_array_top: binding_array<texture_2d<f32>>;
+@group(0) @binding(1)
+var texture_array_bottom: binding_array<texture_2d<f32>>;
+@group(0) @binding(2)
+var sampler_array: binding_array<sampler>;
+
+struct Uniforms {
+    index: u32,
+}
+
+@group(0) @binding(3)
+var<uniform> uniforms: Uniforms;
+
+@fragment
+fn uniform_main(fragment: FragmentInput) -> @location(0) vec4<f32> {
+    var outval: vec3<f32>;
+    if fragment.tex_coord.y <= 0.5 {
+        outval = textureSampleLevel(
+            texture_array_top[uniforms.index],
+            sampler_array[uniforms.index],
+            fragment.tex_coord,
+            0.0
+        ).rgb;
+    } else {
+        outval = textureSampleLevel(
+            texture_array_bottom[uniforms.index],
+            sampler_array[uniforms.index],
+            fragment.tex_coord,
+            0.0
+        ).rgb;
+    }
+
+    return vec4<f32>(outval.x, outval.y, outval.z, 1.0);
+}

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -274,7 +274,7 @@ int main(int argc, char *argv[]) {
 
   wgpuAdapterRequestDevice(
       demo.adapter,
-      &(WGPUDeviceDescriptor){
+      &(const WGPUDeviceDescriptor){
           .requiredFeatureCount = required_device_feature_count,
           .requiredFeatures = required_device_features,
       },
@@ -327,7 +327,7 @@ int main(int argc, char *argv[]) {
   printf("Using fragment entry point: '%s'\n", fragment_entry_point);
 
   WGPUBuffer vertex_buffer = frmwrk_device_create_buffer_init(
-      demo.device, &(frmwrk_buffer_init_descriptor){
+      demo.device, &(const frmwrk_buffer_init_descriptor){
                        .label = "Vertex Buffer",
                        .content = (void *)vertices,
                        .content_size = sizeof(vertices),
@@ -336,7 +336,7 @@ int main(int argc, char *argv[]) {
   assert(vertex_buffer);
 
   WGPUBuffer index_buffer = frmwrk_device_create_buffer_init(
-      demo.device, &(frmwrk_buffer_init_descriptor){
+      demo.device, &(const frmwrk_buffer_init_descriptor){
                        .label = "Index Buffer",
                        .content = (void *)indices,
                        .content_size = sizeof(indices),
@@ -349,7 +349,7 @@ int main(int argc, char *argv[]) {
       [64] = 1,
   };
   WGPUBuffer texture_index_buffer = frmwrk_device_create_buffer_init(
-      demo.device, &(frmwrk_buffer_init_descriptor){
+      demo.device, &(const frmwrk_buffer_init_descriptor){
                        .label = "Texture Index Buffer",
                        .content = texture_index_buffer_contents,
                        .content_size = sizeof(texture_index_buffer_contents),
@@ -374,25 +374,25 @@ int main(int argc, char *argv[]) {
   /* clang-format on */
 
   WGPUTexture red_texture = wgpuDeviceCreateTexture(
-      demo.device, &(WGPUTextureDescriptor){
+      demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
                        .label = "red",
                    });
   assert(red_texture);
   WGPUTexture green_texture = wgpuDeviceCreateTexture(
-      demo.device, &(WGPUTextureDescriptor){
+      demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
                        .label = "green",
                    });
   assert(green_texture);
   WGPUTexture blue_texture = wgpuDeviceCreateTexture(
-      demo.device, &(WGPUTextureDescriptor){
+      demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
                        .label = "blue",
                    });
   assert(blue_texture);
   WGPUTexture white_texture = wgpuDeviceCreateTexture(
-      demo.device, &(WGPUTextureDescriptor){
+      demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
                        .label = "white",
                    });

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -2,12 +2,10 @@
 #include "webgpu-headers/webgpu.h"
 #include "wgpu.h"
 #include <assert.h>
-#include <malloc/_malloc.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/_types/_size_t.h>
 
 #if defined(WGPU_TARGET_MACOS)
 #include <QuartzCore/CAMetalLayer.h>

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -1,0 +1,788 @@
+#include "framework.h"
+#include "webgpu-headers/webgpu.h"
+#include "wgpu.h"
+#include <assert.h>
+#include <malloc/_malloc.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/_types/_size_t.h>
+
+#if defined(WGPU_TARGET_MACOS)
+#include <QuartzCore/CAMetalLayer.h>
+#endif
+
+#include <GLFW/glfw3.h>
+#if defined(WGPU_TARGET_MACOS)
+#define GLFW_EXPOSE_NATIVE_COCOA
+#elif defined(WGPU_TARGET_LINUX_X11)
+#define GLFW_EXPOSE_NATIVE_X11
+#elif defined(WGPU_TARGET_LINUX_WAYLAND)
+#define GLFW_EXPOSE_NATIVE_WAYLAND
+#elif defined(WGPU_TARGET_WINDOWS)
+#define GLFW_EXPOSE_NATIVE_WIN32
+#endif
+#include <GLFW/glfw3native.h>
+
+#define LOG_PREFIX "[texture_arrays]"
+#define MAX_FEATURE_ARRAY_LENGTH 64
+
+struct demo {
+  WGPUInstance instance;
+  WGPUSurface surface;
+  WGPUAdapter adapter;
+  WGPUDevice device;
+  WGPUSurfaceConfiguration config;
+};
+
+static void handle_request_adapter(WGPURequestAdapterStatus status,
+                                   WGPUAdapter adapter, char const *message,
+                                   void *userdata) {
+  if (status == WGPURequestAdapterStatus_Success) {
+    struct demo *demo = userdata;
+    demo->adapter = adapter;
+  } else {
+    printf(LOG_PREFIX " request_adapter status=%#.8x message=%s\n", status,
+           message);
+  }
+}
+static void handle_request_device(WGPURequestDeviceStatus status,
+                                  WGPUDevice device, char const *message,
+                                  void *userdata) {
+  if (status == WGPURequestDeviceStatus_Success) {
+    struct demo *demo = userdata;
+    demo->device = device;
+  } else {
+    printf(LOG_PREFIX " request_device status=%#.8x message=%s\n", status,
+           message);
+  }
+}
+static void handle_glfw_framebuffer_size(GLFWwindow *window, int width,
+                                         int height) {
+  if (width == 0 && height == 0) {
+    return;
+  }
+
+  struct demo *demo = glfwGetWindowUserPointer(window);
+  if (!demo)
+    return;
+
+  demo->config.width = width;
+  demo->config.height = height;
+
+  wgpuSurfaceConfigure(demo->surface, &demo->config);
+}
+
+typedef struct vertex {
+  float pos[2];
+  float tex_coord[2];
+  uint32_t index;
+} vertex;
+
+static const WGPUVertexAttribute vertex_attributes[] = {
+    (const WGPUVertexAttribute){
+        .format = WGPUVertexFormat_Float32x2,
+        .offset = 0,
+        .shaderLocation = 0,
+    },
+    (const WGPUVertexAttribute){
+        .format = WGPUVertexFormat_Float32x2,
+        .offset = 0 + 8, // 0 + sizeof(Float32x2)
+        .shaderLocation = 1,
+    },
+    (const WGPUVertexAttribute){
+        .format = WGPUVertexFormat_Sint32,
+        .offset = 0 + 8 + 8, // 0 + sizeof(Float32x2) + sizeof(Float32x2)
+        .shaderLocation = 2,
+    },
+};
+
+static const WGPUIndexFormat index_format = WGPUIndexFormat_Uint16;
+
+static const vertex vertices[] = {
+    // left rectangle
+    {{-1, -1}, {0, 1}, 0},
+    {{-1, 1}, {0, 0}, 0},
+    {{0, 1}, {1, 0}, 0},
+    {{0, -1}, {1, 1}, 0},
+    // right rectangle
+    {{0, -1}, {0, 1}, 1},
+    {{0, 1}, {0, 0}, 1},
+    {{1, 1}, {1, 0}, 1},
+    {{1, -1}, {1, 1}, 1},
+};
+
+static const uint16_t indices[] = {
+    // Left rectangle
+    0, 1, 2, // 1st
+    2, 0, 3, // 2nd
+    // Right rectangle
+    4, 5, 6, // 1st
+    6, 4, 7, // 2nd
+};
+
+static const uint8_t red_texture_data[4] = {255, 0, 0, 255};
+static const uint8_t green_texture_data[4] = {0, 255, 0, 255};
+static const uint8_t blue_texture_data[4] = {0, 0, 255, 255};
+static const uint8_t white_texture_data[4] = {255, 255, 255, 255};
+
+int main(int argc, char *argv[]) {
+  UNUSED(argc)
+  UNUSED(argv)
+  frmwrk_setup_logging(WGPULogLevel_Warn);
+
+#if defined(WGPU_TARGET_LINUX_WAYLAND)
+  glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_WAYLAND);
+#endif
+  assert(glfwInit());
+
+  struct demo demo = {0};
+  demo.instance = wgpuCreateInstance(NULL);
+  assert(demo.instance);
+
+  glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  GLFWwindow *window = glfwCreateWindow(
+      640, 480, "texture_arrays [wgpu-native + glfw]", NULL, NULL);
+  assert(window);
+  glfwSetWindowUserPointer(window, (void *)&demo);
+  glfwSetFramebufferSizeCallback(window, handle_glfw_framebuffer_size);
+
+#if defined(WGPU_TARGET_MACOS)
+  {
+    id metal_layer = NULL;
+    NSWindow *ns_window = glfwGetCocoaWindow(window);
+    [ns_window.contentView setWantsLayer:YES];
+    metal_layer = [CAMetalLayer layer];
+    [ns_window.contentView setLayer:metal_layer];
+    demo.surface = wgpuInstanceCreateSurface(
+        demo.instance,
+        &(const WGPUSurfaceDescriptor){
+            .nextInChain =
+                (const WGPUChainedStruct *)&(
+                    const WGPUSurfaceDescriptorFromMetalLayer){
+                    .chain =
+                        (const WGPUChainedStruct){
+                            .sType = WGPUSType_SurfaceDescriptorFromMetalLayer,
+                        },
+                    .layer = metal_layer,
+                },
+        });
+    assert(demo.surface);
+  }
+#elif defined(WGPU_TARGET_LINUX_X11)
+  {
+    Display *x11_display = glfwGetX11Display();
+    Window x11_window = glfwGetX11Window(window);
+    demo.surface = wgpuInstanceCreateSurface(
+        demo.instance,
+        &(const WGPUSurfaceDescriptor){
+            .nextInChain =
+                (const WGPUChainedStruct *)&(
+                    const WGPUSurfaceDescriptorFromXlibWindow){
+                    .chain =
+                        (const WGPUChainedStruct){
+                            .sType = WGPUSType_SurfaceDescriptorFromXlibWindow,
+                        },
+                    .display = x11_display,
+                    .window = x11_window,
+                },
+        });
+    assert(demo.surface);
+  }
+#elif defined(WGPU_TARGET_LINUX_WAYLAND)
+  {
+    struct wl_display *wayland_display = glfwGetWaylandDisplay();
+    struct wl_surface *wayland_surface = glfwGetWaylandWindow(window);
+    demo.surface = wgpuInstanceCreateSurface(
+        demo.instance,
+        &(const WGPUSurfaceDescriptor){
+            .nextInChain =
+                (const WGPUChainedStruct *)&(
+                    const WGPUSurfaceDescriptorFromWaylandSurface){
+                    .chain =
+                        (const WGPUChainedStruct){
+                            .sType =
+                                WGPUSType_SurfaceDescriptorFromWaylandSurface,
+                        },
+                    .display = wayland_display,
+                    .surface = wayland_surface,
+                },
+        });
+    assert(demo.surface);
+  }
+#elif defined(WGPU_TARGET_WINDOWS)
+  {
+    HWND hwnd = glfwGetWin32Window(window);
+    HINSTANCE hinstance = GetModuleHandle(NULL);
+    demo.surface = wgpuInstanceCreateSurface(
+        demo.instance,
+        &(const WGPUSurfaceDescriptor){
+            .nextInChain =
+                (const WGPUChainedStruct *)&(
+                    const WGPUSurfaceDescriptorFromWindowsHWND){
+                    .chain =
+                        (const WGPUChainedStruct){
+                            .sType = WGPUSType_SurfaceDescriptorFromWindowsHWND,
+                        },
+                    .hinstance = hinstance,
+                    .hwnd = hwnd,
+                },
+        });
+    assert(demo.surface);
+  }
+#else
+#error "Unsupported WGPU_TARGET"
+#endif
+
+  wgpuInstanceRequestAdapter(demo.instance,
+                             &(const WGPURequestAdapterOptions){
+                                 .compatibleSurface = demo.surface,
+                             },
+                             handle_request_adapter, &demo);
+  assert(demo.adapter);
+
+  WGPUSurfaceCapabilities surface_capabilities = {0};
+  wgpuSurfaceGetCapabilities(demo.surface, demo.adapter, &surface_capabilities);
+
+  WGPUFeatureName adapter_features[MAX_FEATURE_ARRAY_LENGTH] = {0};
+  size_t adapter_feature_count =
+      wgpuAdapterEnumerateFeatures(demo.adapter, adapter_features);
+  assert(adapter_feature_count <= MAX_FEATURE_ARRAY_LENGTH);
+  bool adapter_has_required_features = false;
+  bool adapter_has_optional_features = false;
+  for (size_t i = 0; i < adapter_feature_count; i++) {
+    switch ((uint32_t)adapter_features[i]) {
+    case WGPUNativeFeature_TextureBindingArray:
+      adapter_has_required_features = true;
+      break;
+    case WGPUNativeFeature_SampledTextureAndStorageBufferArrayNonUniformIndexing:
+      adapter_has_optional_features = true;
+      break;
+    }
+  }
+  assert(
+          adapter_has_required_features /* Adapter must support WGPUNativeFeature_TextureBindingArray feature for this example */);
+
+  WGPUFeatureName required_device_features[2] = {
+      (WGPUFeatureName)WGPUNativeFeature_TextureBindingArray,
+  };
+  size_t required_device_feature_count = 1;
+  if (adapter_has_optional_features) {
+    required_device_features[required_device_feature_count] = (WGPUFeatureName)
+        WGPUNativeFeature_SampledTextureAndStorageBufferArrayNonUniformIndexing;
+    required_device_feature_count++;
+  }
+
+  wgpuAdapterRequestDevice(
+      demo.adapter,
+      &(WGPUDeviceDescriptor){
+          .requiredFeatureCount = required_device_feature_count,
+          .requiredFeatures = required_device_features,
+      },
+      handle_request_device, &demo);
+  assert(demo.device);
+
+  WGPUQueue queue = wgpuDeviceGetQueue(demo.device);
+  assert(queue);
+
+  demo.config = (const WGPUSurfaceConfiguration){
+      .device = demo.device,
+      .usage = WGPUTextureUsage_RenderAttachment,
+      .format = surface_capabilities.formats[0],
+      .presentMode = WGPUPresentMode_Fifo,
+      .alphaMode = surface_capabilities.alphaModes[0],
+  };
+
+  {
+    int width, height;
+    glfwGetWindowSize(window, &width, &height);
+    printf(LOG_PREFIX " initial window size: width=%d height=%d\n", width,
+           height);
+    demo.config.width = width;
+    demo.config.height = height;
+  }
+  wgpuSurfaceConfigure(demo.surface, &demo.config);
+
+  char *fragment_entry_point = NULL;
+  bool use_uniform_workaround = false;
+  if (adapter_has_optional_features) {
+    fragment_entry_point = "non_uniform_main";
+  } else {
+    use_uniform_workaround = true;
+    fragment_entry_point = "uniform_main";
+  }
+
+  WGPUShaderModule base_shader_module =
+      frmwrk_load_shader_module(demo.device, "indexing.wgsl");
+  assert(base_shader_module);
+
+  WGPUShaderModule fragment_shader_module = NULL;
+  if (!use_uniform_workaround) {
+    fragment_shader_module =
+        frmwrk_load_shader_module(demo.device, "non_uniform_indexing.wgsl");
+  } else {
+    fragment_shader_module =
+        frmwrk_load_shader_module(demo.device, "indexing.wgsl");
+  }
+  assert(fragment_shader_module);
+  printf("Using fragment entry point: '%s'\n", fragment_entry_point);
+
+  WGPUBuffer vertex_buffer = frmwrk_device_create_buffer_init(
+      demo.device, &(frmwrk_buffer_init_descriptor){
+                       .label = "Vertex Buffer",
+                       .content = (void *)vertices,
+                       .content_size = sizeof(vertices),
+                       .usage = WGPUBufferUsage_Vertex,
+                   });
+  assert(vertex_buffer);
+
+  WGPUBuffer index_buffer = frmwrk_device_create_buffer_init(
+      demo.device, &(frmwrk_buffer_init_descriptor){
+                       .label = "Index Buffer",
+                       .content = (void *)indices,
+                       .content_size = sizeof(indices),
+                       .usage = WGPUBufferUsage_Index,
+                   });
+  assert(index_buffer);
+
+  uint32_t texture_index_buffer_contents[128] = {
+      [0] = 0,
+      [64] = 1,
+  };
+  WGPUBuffer texture_index_buffer = frmwrk_device_create_buffer_init(
+      demo.device, &(frmwrk_buffer_init_descriptor){
+                       .label = "Texture Index Buffer",
+                       .content = texture_index_buffer_contents,
+                       .content_size = sizeof(texture_index_buffer_contents),
+                       .usage = WGPUBufferUsage_Uniform,
+                   });
+  assert(texture_index_buffer);
+
+  const WGPUExtent3D extent_3d_default = (const WGPUExtent3D){
+      .width = 1,
+      .height = 1,
+      .depthOrArrayLayers = 1,
+  };
+
+#define COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS                                 \
+  /* clang-format off */                                                       \
+  .size = extent_3d_default,                                                \
+  .mipLevelCount = 1,                                                          \
+  .sampleCount = 1,                                                            \
+  .dimension = WGPUTextureDimension_2D,                                        \
+  .format = WGPUTextureFormat_RGBA8UnormSrgb,                                  \
+  .usage = WGPUTextureUsage_TextureBinding | WGPUTextureUsage_CopyDst
+  /* clang-format on */
+
+  WGPUTexture red_texture = wgpuDeviceCreateTexture(
+      demo.device, &(WGPUTextureDescriptor){
+                       COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
+                       .label = "red",
+                   });
+  assert(red_texture);
+  WGPUTexture green_texture = wgpuDeviceCreateTexture(
+      demo.device, &(WGPUTextureDescriptor){
+                       COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
+                       .label = "green",
+                   });
+  assert(green_texture);
+  WGPUTexture blue_texture = wgpuDeviceCreateTexture(
+      demo.device, &(WGPUTextureDescriptor){
+                       COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
+                       .label = "blue",
+                   });
+  assert(blue_texture);
+  WGPUTexture white_texture = wgpuDeviceCreateTexture(
+      demo.device, &(WGPUTextureDescriptor){
+                       COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
+                       .label = "white",
+                   });
+  assert(white_texture);
+
+  WGPUTextureView red_texture_view = wgpuTextureCreateView(red_texture, NULL);
+  assert(red_texture_view);
+  WGPUTextureView green_texture_view =
+      wgpuTextureCreateView(green_texture, NULL);
+  assert(green_texture_view);
+  WGPUTextureView blue_texture_view = wgpuTextureCreateView(blue_texture, NULL);
+  assert(blue_texture_view);
+  WGPUTextureView white_texture_view =
+      wgpuTextureCreateView(white_texture, NULL);
+  assert(white_texture_view);
+
+#define COLOR_IMAGE_COPY_TEXTURE_COMMON_FIELDS                                 \
+  /* clang-format off */                                                       \
+  .mipLevel = 0,                                                               \
+  .origin = (const WGPUOrigin3D){.x = 0, .y = 0, .z = 0},                      \
+  .aspect = WGPUTextureAspect_All
+  /* clang-format on */
+
+  const WGPUTextureDataLayout texture_data_layout_common =
+      (const WGPUTextureDataLayout){
+          .offset = 0,
+          .bytesPerRow = 4,
+          .rowsPerImage = WGPU_COPY_STRIDE_UNDEFINED,
+      };
+
+  wgpuQueueWriteTexture(queue,
+                        &(const WGPUImageCopyTexture){
+                            .texture = red_texture,
+                            COLOR_IMAGE_COPY_TEXTURE_COMMON_FIELDS,
+                        },
+                        red_texture_data, sizeof(red_texture_data),
+                        &texture_data_layout_common, &extent_3d_default);
+  wgpuQueueWriteTexture(queue,
+                        &(const WGPUImageCopyTexture){
+                            .texture = green_texture,
+                            COLOR_IMAGE_COPY_TEXTURE_COMMON_FIELDS,
+                        },
+                        green_texture_data, sizeof(green_texture_data),
+                        &texture_data_layout_common, &extent_3d_default);
+  wgpuQueueWriteTexture(queue,
+                        &(const WGPUImageCopyTexture){
+                            .texture = blue_texture,
+                            COLOR_IMAGE_COPY_TEXTURE_COMMON_FIELDS,
+                        },
+                        blue_texture_data, sizeof(blue_texture_data),
+                        &texture_data_layout_common, &extent_3d_default);
+  wgpuQueueWriteTexture(queue,
+                        &(const WGPUImageCopyTexture){
+                            .texture = white_texture,
+                            COLOR_IMAGE_COPY_TEXTURE_COMMON_FIELDS,
+                        },
+                        white_texture_data, sizeof(white_texture_data),
+                        &texture_data_layout_common, &extent_3d_default);
+
+  WGPUSampler sampler = wgpuDeviceCreateSampler(demo.device, NULL);
+  assert(sampler);
+
+  const WGPUBindGroupLayoutEntry bind_group_layout_entries[] = {
+      (const WGPUBindGroupLayoutEntry){
+          .binding = 0,
+          .visibility = WGPUShaderStage_Fragment,
+          .texture =
+              (const WGPUTextureBindingLayout){
+                  .sampleType = WGPUTextureSampleType_Float,
+                  .viewDimension = WGPUTextureViewDimension_2D,
+                  .multisampled = false,
+              },
+          .nextInChain =
+              (const WGPUChainedStruct *)&(WGPUBindGroupLayoutEntryExtras){
+                  .chain =
+                      (const WGPUChainedStruct){
+                          .sType =
+                              (WGPUSType)WGPUSType_BindGroupLayoutEntryExtras,
+                      },
+                  .count = 2,
+              },
+      },
+      (const WGPUBindGroupLayoutEntry){
+          .binding = 1,
+          .visibility = WGPUShaderStage_Fragment,
+          .texture =
+              (const WGPUTextureBindingLayout){
+                  .sampleType = WGPUTextureSampleType_Float,
+                  .viewDimension = WGPUTextureViewDimension_2D,
+                  .multisampled = false,
+              },
+          .nextInChain =
+              (const WGPUChainedStruct *)&(WGPUBindGroupLayoutEntryExtras){
+                  .chain =
+                      (const WGPUChainedStruct){
+                          .sType =
+                              (WGPUSType)WGPUSType_BindGroupLayoutEntryExtras,
+                      },
+                  .count = 2,
+              },
+      },
+      (const WGPUBindGroupLayoutEntry){
+          .binding = 2,
+          .visibility = WGPUShaderStage_Fragment,
+          .sampler =
+              (const WGPUSamplerBindingLayout){
+                  .type = WGPUSamplerBindingType_Filtering,
+              },
+          .nextInChain =
+              (const WGPUChainedStruct *)&(WGPUBindGroupLayoutEntryExtras){
+                  .chain =
+                      (const WGPUChainedStruct){
+                          .sType =
+                              (WGPUSType)WGPUSType_BindGroupLayoutEntryExtras,
+                      },
+                  .count = 2,
+              },
+      },
+      (const WGPUBindGroupLayoutEntry){
+          .binding = 3,
+          .visibility = WGPUShaderStage_Fragment,
+          .buffer =
+              (const WGPUBufferBindingLayout){
+                  .type = WGPUBufferBindingType_Uniform,
+                  .hasDynamicOffset = true,
+                  .minBindingSize = 4,
+              },
+      },
+  };
+  WGPUBindGroupLayout bind_group_layout = wgpuDeviceCreateBindGroupLayout(
+      demo.device, &(const WGPUBindGroupLayoutDescriptor){
+                       .label = "bind group layout",
+                       .entryCount = sizeof(bind_group_layout_entries) /
+                                     sizeof(bind_group_layout_entries[0]),
+                       .entries = bind_group_layout_entries,
+                   });
+  assert(bind_group_layout);
+
+  const WGPUBindGroupEntry bind_group_entries[] = {
+      (const WGPUBindGroupEntry){
+          .binding = 0,
+          .nextInChain =
+              (const WGPUChainedStruct *)&(const WGPUBindGroupEntryExtras){
+                  .chain =
+                      (const WGPUChainedStruct){
+                          .sType = (WGPUSType)WGPUSType_BindGroupEntryExtras,
+                      },
+                  .textureViewCount = 2,
+                  .textureViews =
+                      (const WGPUTextureView[]){
+                          red_texture_view,
+                          green_texture_view,
+                      },
+              },
+      },
+      (const WGPUBindGroupEntry){
+          .binding = 1,
+          .nextInChain =
+              (const WGPUChainedStruct *)&(const WGPUBindGroupEntryExtras){
+                  .chain =
+                      (const WGPUChainedStruct){
+                          .sType = (WGPUSType)WGPUSType_BindGroupEntryExtras,
+                      },
+                  .textureViewCount = 2,
+                  .textureViews =
+                      (const WGPUTextureView[]){
+                          blue_texture_view,
+                          white_texture_view,
+                      },
+              },
+      },
+      (const WGPUBindGroupEntry){
+          .binding = 2,
+          .nextInChain =
+              (const WGPUChainedStruct *)&(const WGPUBindGroupEntryExtras){
+                  .chain =
+                      (const WGPUChainedStruct){
+                          .sType = (WGPUSType)WGPUSType_BindGroupEntryExtras,
+                      },
+                  .samplerCount = 2,
+                  .samplers =
+                      (const WGPUSampler[]){
+                          sampler,
+                          sampler,
+                      },
+              },
+      },
+      (const WGPUBindGroupEntry){
+          .binding = 3,
+          .buffer = texture_index_buffer,
+          .offset = 0,
+          .size = 4,
+      },
+  };
+  WGPUBindGroup bind_group = wgpuDeviceCreateBindGroup(
+      demo.device, &(const WGPUBindGroupDescriptor){
+                       .layout = bind_group_layout,
+                       .label = "bind group",
+                       .entryCount = sizeof(bind_group_entries) /
+                                     sizeof(bind_group_entries[0]),
+                       .entries = bind_group_entries,
+                   });
+  assert(bind_group);
+
+  WGPUPipelineLayout pipeline_layout = wgpuDeviceCreatePipelineLayout(
+      demo.device, &(const WGPUPipelineLayoutDescriptor){
+                       .label = "main",
+                       .bindGroupLayoutCount = 1,
+                       .bindGroupLayouts =
+                           (const WGPUBindGroupLayout[]){
+                               bind_group_layout,
+                           },
+                   });
+  assert(pipeline_layout);
+
+  WGPURenderPipeline pipeline = wgpuDeviceCreateRenderPipeline(
+      demo.device,
+      &(const WGPURenderPipelineDescriptor){
+          .layout = pipeline_layout,
+          .vertex =
+              (const WGPUVertexState){
+                  .module = base_shader_module,
+                  .entryPoint = "vert_main",
+                  .bufferCount = 1,
+                  .buffers =
+                      (const WGPUVertexBufferLayout[]){
+                          (const WGPUVertexBufferLayout){
+                              .arrayStride = sizeof(vertex),
+                              .stepMode = WGPUVertexStepMode_Vertex,
+                              .attributeCount = sizeof(vertex_attributes) /
+                                                sizeof(vertex_attributes[0]),
+                              .attributes = vertex_attributes,
+                          },
+                      },
+              },
+          .fragment =
+              &(const WGPUFragmentState){
+                  .module = fragment_shader_module,
+                  .entryPoint = fragment_entry_point,
+                  .targetCount = 1,
+                  .targets =
+                      (const WGPUColorTargetState[]){
+                          (const WGPUColorTargetState){
+                              .format = surface_capabilities.formats[0],
+                              .writeMask = WGPUColorWriteMask_All,
+                          },
+                      },
+              },
+          .primitive =
+              (const WGPUPrimitiveState){
+                  .frontFace = WGPUFrontFace_CCW,
+                  .topology = WGPUPrimitiveTopology_TriangleList,
+              },
+          .multisample =
+              (const WGPUMultisampleState){
+                  .count = 1,
+                  .mask = 0xFFFFFFFF,
+              },
+      });
+  assert(pipeline);
+
+  while (!glfwWindowShouldClose(window)) {
+    glfwPollEvents();
+
+    WGPUSurfaceTexture surface_texture;
+    wgpuSurfaceGetCurrentTexture(demo.surface, &surface_texture);
+    switch (surface_texture.status) {
+    case WGPUSurfaceGetCurrentTextureStatus_Success:
+      // All good, could check for `surface_texture.suboptimal` here.
+      break;
+    case WGPUSurfaceGetCurrentTextureStatus_Timeout:
+    case WGPUSurfaceGetCurrentTextureStatus_Outdated:
+    case WGPUSurfaceGetCurrentTextureStatus_Lost: {
+      // Skip this frame, and re-configure surface.
+      wgpuTextureRelease(surface_texture.texture);
+      int width, height;
+      glfwGetWindowSize(window, &width, &height);
+      if (width != 0 && height != 0) {
+        demo.config.width = width;
+        demo.config.height = height;
+        wgpuSurfaceConfigure(demo.surface, &demo.config);
+      }
+      continue;
+    }
+    case WGPUSurfaceGetCurrentTextureStatus_OutOfMemory:
+    case WGPUSurfaceGetCurrentTextureStatus_DeviceLost:
+    case WGPUSurfaceGetCurrentTextureStatus_Force32:
+      // Fatal error
+      printf(LOG_PREFIX " get_current_texture status=%#.8x\n",
+             surface_texture.status);
+      abort();
+    }
+    assert(surface_texture.texture);
+
+    WGPUTextureView frame =
+        wgpuTextureCreateView(surface_texture.texture, NULL);
+    assert(frame);
+
+    WGPUCommandEncoder command_encoder = wgpuDeviceCreateCommandEncoder(
+        demo.device, &(const WGPUCommandEncoderDescriptor){
+                         .label = "command_encoder",
+                     });
+    assert(command_encoder);
+
+    WGPURenderPassEncoder render_pass_encoder =
+        wgpuCommandEncoderBeginRenderPass(
+            command_encoder, &(const WGPURenderPassDescriptor){
+                                 .label = "render_pass_encoder",
+                                 .colorAttachmentCount = 1,
+                                 .colorAttachments =
+                                     (const WGPURenderPassColorAttachment[]){
+                                         (const WGPURenderPassColorAttachment){
+                                             .view = frame,
+                                             .loadOp = WGPULoadOp_Clear,
+                                             .storeOp = WGPUStoreOp_Store,
+                                             .clearValue =
+                                                 (const WGPUColor){
+                                                     .r = 0.0,
+                                                     .g = 0.0,
+                                                     .b = 0.0,
+                                                     .a = 1.0,
+                                                 },
+                                         },
+                                     },
+
+                             });
+    assert(render_pass_encoder);
+
+    wgpuRenderPassEncoderSetPipeline(render_pass_encoder, pipeline);
+    wgpuRenderPassEncoderSetVertexBuffer(render_pass_encoder, 0, vertex_buffer,
+                                         0, WGPU_WHOLE_SIZE);
+    wgpuRenderPassEncoderSetIndexBuffer(render_pass_encoder, index_buffer,
+                                        index_format, 0, WGPU_WHOLE_SIZE);
+    if (use_uniform_workaround) {
+      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 0, bind_group, 1,
+                                        (const uint32_t[]){0});
+      wgpuRenderPassEncoderDrawIndexed(render_pass_encoder, 6, 1, 0, 0, 0);
+      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 0, bind_group, 1,
+                                        (const uint32_t[]){256});
+      wgpuRenderPassEncoderDrawIndexed(render_pass_encoder, 6, 1, 6, 0, 0);
+    } else {
+      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 0, bind_group, 1,
+                                        (const uint32_t[]){0});
+      wgpuRenderPassEncoderDrawIndexed(render_pass_encoder, 12, 1, 0, 0, 0);
+    }
+    wgpuRenderPassEncoderEnd(render_pass_encoder);
+
+    WGPUCommandBuffer command_buffer = wgpuCommandEncoderFinish(
+        command_encoder, &(const WGPUCommandBufferDescriptor){
+                             .label = "command_buffer",
+                         });
+    assert(command_buffer);
+
+    wgpuQueueSubmit(queue, 1, (const WGPUCommandBuffer[]){command_buffer});
+    wgpuSurfacePresent(demo.surface);
+
+    wgpuCommandBufferRelease(command_buffer);
+    wgpuRenderPassEncoderRelease(render_pass_encoder);
+    wgpuCommandEncoderRelease(command_encoder);
+    wgpuTextureViewRelease(frame);
+    wgpuTextureRelease(surface_texture.texture);
+  }
+
+  wgpuRenderPipelineRelease(pipeline);
+  wgpuPipelineLayoutRelease(pipeline_layout);
+  wgpuBindGroupRelease(bind_group);
+  wgpuBindGroupLayoutRelease(bind_group_layout);
+  wgpuSamplerRelease(sampler);
+  wgpuTextureViewRelease(white_texture_view);
+  wgpuTextureViewRelease(blue_texture_view);
+  wgpuTextureViewRelease(green_texture_view);
+  wgpuTextureViewRelease(red_texture_view);
+  wgpuTextureRelease(white_texture);
+  wgpuTextureRelease(blue_texture);
+  wgpuTextureRelease(green_texture);
+  wgpuTextureRelease(red_texture);
+  wgpuBufferRelease(texture_index_buffer);
+  wgpuBufferRelease(index_buffer);
+  wgpuBufferRelease(vertex_buffer);
+  wgpuShaderModuleRelease(fragment_shader_module);
+  wgpuShaderModuleRelease(base_shader_module);
+  wgpuQueueRelease(queue);
+  wgpuDeviceRelease(demo.device);
+  wgpuSurfaceCapabilitiesFreeMembers(surface_capabilities);
+  wgpuAdapterRelease(demo.adapter);
+  wgpuSurfaceRelease(demo.surface);
+  glfwDestroyWindow(window);
+  wgpuInstanceRelease(demo.instance);
+  glfwTerminate();
+  return 0;
+}

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -79,17 +79,17 @@ typedef struct vertex {
 } vertex;
 
 static const WGPUVertexAttribute vertex_attributes[] = {
-    (const WGPUVertexAttribute){
+    {
         .format = WGPUVertexFormat_Float32x2,
         .offset = 0,
         .shaderLocation = 0,
     },
-    (const WGPUVertexAttribute){
+    {
         .format = WGPUVertexFormat_Float32x2,
         .offset = 0 + 8, // 0 + sizeof(Float32x2)
         .shaderLocation = 1,
     },
-    (const WGPUVertexAttribute){
+    {
         .format = WGPUVertexFormat_Sint32,
         .offset = 0 + 8 + 8, // 0 + sizeof(Float32x2) + sizeof(Float32x2)
         .shaderLocation = 2,

--- a/examples/texture_arrays/non_uniform_indexing.wgsl
+++ b/examples/texture_arrays/non_uniform_indexing.wgsl
@@ -1,0 +1,33 @@
+struct FragmentInput {
+    @location(0) tex_coord: vec2<f32>,
+    @location(1) index: i32,
+}
+
+@group(0) @binding(0)
+var texture_array_top: binding_array<texture_2d<f32>>;
+@group(0) @binding(1)
+var texture_array_bottom: binding_array<texture_2d<f32>>;
+@group(0) @binding(2)
+var sampler_array: binding_array<sampler>;
+
+@fragment
+fn non_uniform_main(fragment: FragmentInput) -> @location(0) vec4<f32> {
+    var outval: vec3<f32>;
+    if fragment.tex_coord.y <= 0.5 {
+        outval = textureSampleLevel(
+            texture_array_top[fragment.index],
+            sampler_array[fragment.index],
+            fragment.tex_coord,
+            0.0
+        ).rgb;
+    } else {
+        outval = textureSampleLevel(
+            texture_array_bottom[fragment.index],
+            sampler_array[fragment.index],
+            fragment.tex_coord,
+            0.0
+        ).rgb;
+    }
+
+    return vec4<f32>(outval.x, outval.y, outval.z, 1.0);
+}

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -5,8 +5,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define WGPU_TARGET_WINDOWS 1
-
 #if defined(WGPU_TARGET_MACOS)
 #include <Foundation/Foundation.h>
 #include <QuartzCore/CAMetalLayer.h>

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define WGPU_TARGET_WINDOWS 1
+
 #if defined(WGPU_TARGET_MACOS)
 #include <Foundation/Foundation.h>
 #include <QuartzCore/CAMetalLayer.h>

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -13,6 +13,7 @@ typedef enum WGPUNativeSType {
     WGPUSType_SupportedLimitsExtras = 0x60000003,
     WGPUSType_InstanceExtras = 0x60000006,
     WGPUSType_SwapChainDescriptorExtras = 0x60000007,
+    WGPUSType_BindGroupEntryExtras = 0x60000008,
     WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeSType;
 
@@ -179,6 +180,16 @@ typedef struct WGPUSwapChainDescriptorExtras {
     size_t viewFormatCount;
     WGPUTextureFormat const * viewFormats;
 } WGPUSwapChainDescriptorExtras;
+
+typedef struct WGPUBindGroupEntryExtras {
+    WGPUChainedStruct const * nextInChain;
+    WGPUBuffer const * buffers;
+    size_t bufferCount;
+    WGPUSampler const * samplers;
+    size_t samplerCount;
+    WGPUTextureView const * textureViews;
+    size_t textureViewCount;
+} WGPUBindGroupEntryExtras;
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void * userdata);
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -165,7 +165,7 @@ typedef struct WGPUInstanceEnumerateAdapterOptions {
 } WGPUInstanceEnumerateAdapterOptions;
 
 typedef struct WGPUBindGroupEntryExtras {
-    WGPUChainedStruct const * nextInChain;
+    WGPUChainedStruct chain;
     WGPUBuffer const * buffers;
     size_t bufferCount;
     WGPUSampler const * samplers;
@@ -175,7 +175,7 @@ typedef struct WGPUBindGroupEntryExtras {
 } WGPUBindGroupEntryExtras;
 
 typedef struct WGPUBindGroupLayoutEntryExtras {
-    WGPUChainedStruct const * nextInChain;
+    WGPUChainedStruct chain;
     uint32_t count;
 } WGPUBindGroupLayoutEntryExtras;
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -23,6 +23,7 @@ typedef enum WGPUNativeFeature {
     WGPUNativeFeature_MultiDrawIndirectCount = 0x60000004,
     WGPUNativeFeature_VertexWritableStorage = 0x60000005,
     WGPUNativeFeature_TextureBindingArray = 0x60000006,
+    WGPUNativeFeature_SampledTextureAndStorageBufferArrayNonUniformIndexing = 0x60000007,
     WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -12,6 +12,7 @@ typedef enum WGPUNativeSType {
     WGPUSType_SupportedLimitsExtras = 0x60000005,
     WGPUSType_InstanceExtras = 0x60000006,
     WGPUSType_BindGroupEntryExtras = 0x60000007,
+    WGPUSType_BindGroupLayoutEntryExtras = 0x60000008,
     WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeSType;
 
@@ -163,6 +164,11 @@ typedef struct WGPUBindGroupEntryExtras {
     WGPUTextureView const * textureViews;
     size_t textureViewCount;
 } WGPUBindGroupEntryExtras;
+
+typedef struct WGPUBindGroupLayoutEntryExtras {
+    WGPUChainedStruct const * nextInChain;
+    uint32_t count;
+} WGPUBindGroupLayoutEntryExtras;
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void * userdata);
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -22,6 +22,7 @@ typedef enum WGPUNativeFeature {
     WGPUNativeFeature_MultiDrawIndirect = 0x60000003,
     WGPUNativeFeature_MultiDrawIndirectCount = 0x60000004,
     WGPUNativeFeature_VertexWritableStorage = 0x60000005,
+    WGPUNativeFeature_TextureBindingArray = 0x60000006,
     WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1033,7 +1033,9 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     }
     if features.contains(wgt::Features::TEXTURE_BINDING_ARRAY) {
         temp.push(native::WGPUNativeFeature_TextureBindingArray);
-        //temp.push(native::);
+    }
+    if features.contains(wgt::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING) {
+        temp.push(native::WGPUNativeFeature_SampledTextureAndStorageBufferArrayNonUniformIndexing);
     }
 
     temp
@@ -1062,7 +1064,7 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUNativeFeature_MultiDrawIndirectCount => Some(Features::MULTI_DRAW_INDIRECT_COUNT),
         native::WGPUNativeFeature_VertexWritableStorage => Some(Features::VERTEX_WRITABLE_STORAGE),
         native::WGPUNativeFeature_TextureBindingArray => Some(Features::TEXTURE_BINDING_ARRAY),
-        
+        native::WGPUNativeFeature_SampledTextureAndStorageBufferArrayNonUniformIndexing => Some(Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING),
         // not available in wgpu-core
         native::WGPUFeatureName_RG11B10UfloatRenderable => None,
         native::WGPUFeatureName_BGRA8UnormStorage => None,

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1031,6 +1031,10 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::VERTEX_WRITABLE_STORAGE) {
         temp.push(native::WGPUNativeFeature_VertexWritableStorage);
     }
+    if features.contains(wgt::Features::TEXTURE_BINDING_ARRAY) {
+        temp.push(native::WGPUNativeFeature_TextureBindingArray);
+        //temp.push(native::);
+    }
 
     temp
 }
@@ -1057,7 +1061,8 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUNativeFeature_MultiDrawIndirect => Some(Features::MULTI_DRAW_INDIRECT),
         native::WGPUNativeFeature_MultiDrawIndirectCount => Some(Features::MULTI_DRAW_INDIRECT_COUNT),
         native::WGPUNativeFeature_VertexWritableStorage => Some(Features::VERTEX_WRITABLE_STORAGE),
-
+        native::WGPUNativeFeature_TextureBindingArray => Some(Features::TEXTURE_BINDING_ARRAY),
+        
         // not available in wgpu-core
         native::WGPUFeatureName_RG11B10UfloatRenderable => None,
         native::WGPUFeatureName_BGRA8UnormStorage => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use conv::{
-    map_bind_group_entry, map_device_descriptor, map_instance_backend_flags,
-    map_instance_descriptor, map_pipeline_layout_descriptor, map_primitive_state,
-    map_shader_module, map_surface, CreateSurfaceParams,
+    map_bind_group_entry, map_bind_group_layout_entry, map_device_descriptor,
+    map_instance_backend_flags, map_instance_descriptor, map_pipeline_layout_descriptor,
+    map_primitive_state, map_shader_module, map_surface, CreateSurfaceParams,
 };
 use parking_lot::{Mutex, RwLock};
 use smallvec::SmallVec;
@@ -1691,41 +1691,9 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroup(
     let entries = make_slice(descriptor.entries, descriptor.entryCount)
         .iter()
         .map(|entry| {
-            if let Some(buffer) = entry.buffer.as_ref() {
-                wgc::binding_model::BindGroupEntry {
-                    binding: entry.binding,
-                    resource: wgc::binding_model::BindingResource::Buffer(
-                        wgc::binding_model::BufferBinding {
-                            buffer_id: buffer.id,
-                            offset: entry.offset,
-                            size: match entry.size {
-                                0 => panic!("invalid size"),
-                                conv::WGPU_WHOLE_SIZE => None,
-                                _ => Some(NonZeroU64::new_unchecked(entry.size)),
-                            },
-                        },
-                    ),
-                }
-            } else if let Some(sampler) = entry.sampler.as_ref() {
-                wgc::binding_model::BindGroupEntry {
-                    binding: entry.binding,
-                    resource: wgc::binding_model::BindingResource::Sampler(sampler.id),
-                }
-            } else if let Some(texture_view) = entry.textureView.as_ref() {
-                wgc::binding_model::BindGroupEntry {
-                    binding: entry.binding,
-                    resource: wgc::binding_model::BindingResource::TextureView(texture_view.id),
-                }
-            } else {
-                let bind_group_entry = follow_chain!(map_bind_group_entry(entry, WGPUSType_BindGroupEntryExtras => native::WGPUBindGroupEntryExtras));
-
-                if bind_group_entry.is_some() {
-                    bind_group_entry.unwrap()
-                }
-                else {
-                    panic!("invalid bind group entry for bind group descriptor");
-                }
-            }
+            follow_chain!(map_bind_group_entry(entry,
+                WGPUSType_BindGroupEntryExtras => native::WGPUBindGroupEntryExtras)
+            )
         })
         .collect::<Vec<_>>();
 
@@ -1767,121 +1735,9 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
     let entries = make_slice(descriptor.entries, descriptor.entryCount)
         .iter()
         .map(|entry| {
-            let is_buffer = entry.buffer.type_ != native::WGPUBufferBindingType_Undefined;
-            let is_sampler = entry.sampler.type_ != native::WGPUSamplerBindingType_Undefined;
-            let is_texture = entry.texture.sampleType != native::WGPUTextureSampleType_Undefined;
-
-            let is_storage_texture =
-                entry.storageTexture.access != native::WGPUStorageTextureAccess_Undefined;
-
-            let ty = if is_texture {
-                wgt::BindingType::Texture {
-                    sample_type: match entry.texture.sampleType {
-                        native::WGPUTextureSampleType_Float => {
-                            wgt::TextureSampleType::Float { filterable: true }
-                        }
-                        native::WGPUTextureSampleType_UnfilterableFloat => {
-                            wgt::TextureSampleType::Float { filterable: false }
-                        }
-                        native::WGPUTextureSampleType_Depth => wgt::TextureSampleType::Depth,
-                        native::WGPUTextureSampleType_Sint => wgt::TextureSampleType::Sint,
-                        native::WGPUTextureSampleType_Uint => wgt::TextureSampleType::Uint,
-                        _ => panic!("invalid sample type for texture binding layout"),
-                    },
-                    view_dimension: match entry.texture.viewDimension {
-                        native::WGPUTextureViewDimension_1D => wgt::TextureViewDimension::D1,
-                        native::WGPUTextureViewDimension_2D => wgt::TextureViewDimension::D2,
-                        native::WGPUTextureViewDimension_2DArray => {
-                            wgt::TextureViewDimension::D2Array
-                        }
-                        native::WGPUTextureViewDimension_Cube => wgt::TextureViewDimension::Cube,
-                        native::WGPUTextureViewDimension_CubeArray => {
-                            wgt::TextureViewDimension::CubeArray
-                        }
-                        native::WGPUTextureViewDimension_3D => wgt::TextureViewDimension::D3,
-                        _ => panic!("invalid texture view dimension for texture binding layout"),
-                    },
-                    multisampled: entry.texture.multisampled != 0,
-                }
-            } else if is_sampler {
-                match entry.sampler.type_ {
-                    native::WGPUSamplerBindingType_Filtering => {
-                        wgt::BindingType::Sampler(wgt::SamplerBindingType::Filtering)
-                    }
-                    native::WGPUSamplerBindingType_NonFiltering => {
-                        wgt::BindingType::Sampler(wgt::SamplerBindingType::NonFiltering)
-                    }
-                    native::WGPUSamplerBindingType_Comparison => {
-                        wgt::BindingType::Sampler(wgt::SamplerBindingType::Comparison)
-                    }
-                    _ => panic!("invalid sampler binding type for sampler binding layout"),
-                }
-            } else if is_storage_texture {
-                wgt::BindingType::StorageTexture {
-                    access: match entry.storageTexture.access {
-                        native::WGPUStorageTextureAccess_WriteOnly => {
-                            wgt::StorageTextureAccess::WriteOnly
-                        }
-                        _ => {
-                            panic!(
-                                "invalid storage texture access for storage texture binding layout"
-                            )
-                        }
-                    },
-                    format: conv::map_texture_format(entry.storageTexture.format)
-                        .expect("invalid texture format for storage texture binding layout"),
-                    view_dimension: match entry.storageTexture.viewDimension {
-                        native::WGPUTextureViewDimension_1D => wgt::TextureViewDimension::D1,
-                        native::WGPUTextureViewDimension_2D => wgt::TextureViewDimension::D2,
-                        native::WGPUTextureViewDimension_2DArray => {
-                            wgt::TextureViewDimension::D2Array
-                        }
-                        native::WGPUTextureViewDimension_Cube => wgt::TextureViewDimension::Cube,
-                        native::WGPUTextureViewDimension_CubeArray => {
-                            wgt::TextureViewDimension::CubeArray
-                        }
-                        native::WGPUTextureViewDimension_3D => wgt::TextureViewDimension::D3,
-                        _ => {
-                            panic!(
-                                "invalid texture view dimension for storage texture binding layout"
-                            )
-                        }
-                    },
-                }
-            } else if is_buffer {
-                wgt::BindingType::Buffer {
-                    ty: match entry.buffer.type_ {
-                        native::WGPUBufferBindingType_Uniform => wgt::BufferBindingType::Uniform,
-                        native::WGPUBufferBindingType_Storage => {
-                            wgt::BufferBindingType::Storage { read_only: false }
-                        }
-                        native::WGPUBufferBindingType_ReadOnlyStorage => {
-                            wgt::BufferBindingType::Storage { read_only: true }
-                        }
-                        _ => panic!("invalid buffer binding type for buffer binding layout"),
-                    },
-                    has_dynamic_offset: entry.buffer.hasDynamicOffset != 0,
-                    min_binding_size: {
-                        assert_ne!(
-                            entry.buffer.minBindingSize,
-                            conv::WGPU_WHOLE_SIZE,
-                            "invalid min binding size for buffer binding layout, use 0 instead"
-                        );
-
-                        NonZeroU64::new(entry.buffer.minBindingSize)
-                    },
-                }
-            } else {
-                panic!("invalid bind group layout entry for bind group layout descriptor");
-            };
-
-            wgt::BindGroupLayoutEntry {
-                ty,
-                binding: entry.binding,
-                visibility: wgt::ShaderStages::from_bits(entry.visibility)
-                    .expect("invalid visibility for bind group layout entry"),
-                count: None,
-            }
+            follow_chain!(map_bind_group_layout_entry(entry,
+                WGPUSType_BindGroupLayoutEntryExtras => native::WGPUBindGroupLayoutEntryExtras)
+            )
         })
         .collect::<Vec<_>>();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1334,16 +1334,14 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroup(
                     resource: wgc::binding_model::BindingResource::Sampler(sampler.id),
                 }
             } else if entry.samplerArray.as_ref().is_some() {
-                let mut samplers: Vec<SamplerId> = Vec::new();
-                for i in 0..entry.samplerArrayLength {
-                    let sampler = (entry.samplerArray.as_ref().unwrap().offset(i as isize)).as_ref().unwrap();
-                
-                    samplers.push(sampler.id);
-                }
+                let samplers = slice::from_raw_parts(entry.samplerArray, usize::try_from(entry.samplerArrayLength).unwrap())
+                    .iter()
+                    .map(|sampler_ptr| sampler_ptr.as_ref().unwrap().id)
+                    .collect();//Vec::new();
 
                 wgc::binding_model::BindGroupEntry {
                     binding: entry.binding,
-                    resource: wgc::binding_model::BindingResource::SamplerArray(Cow::from(samplers)),
+                    resource: wgc::binding_model::BindingResource::SamplerArray(samplers),
                 }
             } else if let Some(texture_view) = entry.textureView.as_ref() {
                 wgc::binding_model::BindGroupEntry {


### PR DESCRIPTION
I've been using the wgpu-native bindings from C# and realised that one of the features I required was missing, namely texture view arrays/sampler arrays as specified here (https://wgpu.rs/doc/wgpu/enum.BindingResource.html), so I implemented the features and created this pull request. It also exposes TEXTURE_BINDING_ARRAY and SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING as features to the C API via wgpu.h

I'm not a rust developer and have never written anything in rust before. This is also my first pull request so any feedback is appreciated!