### PR TITLE
Fix renamed wgpu symbols

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -895,7 +895,7 @@ pub fn map_stencil_face_state(
 }
 
 #[inline]
-pub fn map_storage_report(report: wgc::hub::StorageReport) -> native::WGPUStorageReport {
+pub fn map_storage_report(report: wgc::storage::StorageReport) -> native::WGPUStorageReport {
     native::WGPUStorageReport {
         numOccupied: report.num_occupied,
         numVacant: report.num_error,
@@ -928,7 +928,7 @@ pub fn map_hub_report(report: wgc::hub::HubReport) -> native::WGPUHubReport {
 #[inline]
 pub fn write_global_report(
     native_report: &mut native::WGPUGlobalReport,
-    report: wgc::hub::GlobalReport,
+    report: wgc::global::GlobalReport,
 ) {
     native_report.surfaces = map_storage_report(report.surfaces);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod native {
 
 const LABEL: &str = "label";
 
-pub type Context = wgc::hub::Global<wgc::hub::IdentityManagerFactory>;
+pub type Context = wgc::global::Global<wgc::identity::IdentityManagerFactory>;
 
 pub struct WGPUContextHandle<I: id::TypedId> {
     pub context: Arc<Context>,
@@ -358,7 +358,7 @@ pub unsafe extern "C" fn wgpuCreateInstance(
     Box::into_raw(Box::new(WGPUInstanceImpl {
         context: Arc::new(Context::new(
             "wgpu",
-            wgc::hub::IdentityManagerFactory,
+            wgc::identity::IdentityManagerFactory,
             instance_desc,
         )),
     }))


### PR DESCRIPTION
Seems like they moved some wgpu symbols (HubReport, GlobalReport, Global, IdentityManagerFactory)
Renamed them so wgpu-native can compile with latest.

I needed these fixes to get wgpu working on the trunk branch (works on Vision now)
I'm not sure how to deal with versions since this is targeting trunk on the wgpu repository and probably doesn't have a release & version number yet, does wgpu-native use the staging branch for this?