### PR TITLE
fix `WGPUInstanceEnumerateAdapterOptions`, `wgpuSwapChainGetCurrentTextureView` & `wgpuDevicePopErrorScope`

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -179,7 +179,7 @@ typedef struct WGPUSwapChainDescriptorExtras {
 } WGPUSwapChainDescriptorExtras;
 
 typedef struct WGPUInstanceEnumerateAdapterOptions {
-    WGPUChainedStruct chain;
+    WGPUChainedStruct const * nextInChain;
     WGPUInstanceBackendFlags backends;
 } WGPUInstanceEnumerateAdapterOptions;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3696,6 +3696,9 @@ pub unsafe extern "C" fn wgpuSwapChainGetCurrentTextureView(
                 }))
             }
             _ => {
+                if let Some(texture_id) = result.texture_id {
+                    gfx_select!(texture_id => context.texture_drop(texture_id, false));
+                }
                 handle_error(
                     context,
                     error_sink,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2574,20 +2574,27 @@ pub unsafe extern "C" fn wgpuDevicePopErrorScope(
     let mut error_sink = device.error_sink.lock();
     let scope = error_sink.scopes.pop().unwrap();
 
-    if let Some(error) = scope.error {
-        let typ = match error {
-            crate::Error::OutOfMemory { .. } => native::WGPUErrorType_OutOfMemory,
-            crate::Error::Validation { .. } => native::WGPUErrorType_Validation,
-            // We handle device lost error early in ErrorSinkRaw::handle_error
-            // so we should never get device lost error here.
-            crate::Error::DeviceLost { .. } => unreachable!(),
-        };
+    match scope.error {
+        Some(error) => {
+            let typ = match error {
+                crate::Error::OutOfMemory { .. } => native::WGPUErrorType_OutOfMemory,
+                crate::Error::Validation { .. } => native::WGPUErrorType_Validation,
+                // We handle device lost error early in ErrorSinkRaw::handle_error
+                // so we should never get device lost error here.
+                crate::Error::DeviceLost { .. } => unreachable!(),
+            };
 
-        let msg = CString::new(error.to_string()).unwrap();
-        unsafe {
-            callback(typ, msg.as_ptr(), userdata);
+            let msg = CString::new(error.to_string()).unwrap();
+            unsafe {
+                callback(typ, msg.as_ptr(), userdata);
+            };
         }
-    }
+        None => {
+            unsafe {
+                callback(native::WGPUErrorType_NoError, std::ptr::null(), userdata);
+            };
+        }
+    };
 }
 
 #[no_mangle]


### PR DESCRIPTION
#### Changes
- `WGPUInstanceEnumerateAdapterOptions` should take `nextInChain` pointer instead of `chain`.
- `wgpuDevicePopErrorScope` should always call the callback, even when no error occured in the error scope.
- correctly handle `wgpuSwapChainGetCurrentTextureView` errors in the `triangle` example.
- fix a potential leak of texture object in `wgpuSwapChainGetCurrentTextureView`.

#### Testing
ran the examples on linux

fixes #275
fixes #267 