### PR TITLE
Allow Undefined value for load/store op

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -27,11 +27,11 @@ map_enum!(
     Store
 );
 #[inline]
-pub fn map_load_op(value: i32) -> wgc::command::LoadOp {
+pub fn map_load_op(value: native::WGPULoadOp) -> wgc::command::LoadOp {
     return _raw_map_load_op(value).unwrap_or(wgc::command::LoadOp::Clear)
 }
 #[inline]
-pub fn map_store_op(value: i32) -> wgc::command::StoreOp {
+pub fn map_store_op(value: native::WGPUStoreOp) -> wgc::command::StoreOp {
     return _raw_map_store_op(value).unwrap_or(wgc::command::StoreOp::Discard)
 }
 map_enum!(

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -5,22 +5,35 @@ use crate::utils::{make_slice, ptr_into_label, ptr_into_pathbuf};
 use crate::{follow_chain, map_enum};
 use std::{borrow::Cow, ffi::CStr};
 
+// Ultimately map_load_op and map_store_op should be able to use the map_enum!
+// macro, but not until wgc supports "Undefined" as a valid value. For now the
+// "_raw_" map enum version is wrapped into a function that falls back to an
+// arbitrary default value.
+// (This is the easyfix of https://github.com/gfx-rs/wgpu-native/issues/290)
 map_enum!(
-    map_load_op,
+    _raw_map_load_op,
     WGPULoadOp,
     wgc::command::LoadOp,
-    "Unknown load op",
+    //"Unknown load op",
     Clear,
     Load
 );
 map_enum!(
-    map_store_op,
+    _raw_map_store_op,
     WGPUStoreOp,
     wgc::command::StoreOp,
-    "Unknown store op",
+    //"Unknown store op",
     Discard,
     Store
 );
+#[inline]
+pub fn map_load_op(value: i32) -> wgc::command::LoadOp {
+    return _raw_map_load_op(value).unwrap_or(wgc::command::LoadOp::Clear)
+}
+#[inline]
+pub fn map_store_op(value: i32) -> wgc::command::StoreOp {
+    return _raw_map_store_op(value).unwrap_or(wgc::command::StoreOp::Discard)
+}
 map_enum!(
     map_address_mode,
     WGPUAddressMode,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -149,7 +149,7 @@ macro_rules! follow_chain {
 /// ```
 /// Which expands into:
 /// ```ignore
-/// pub fn map_index_format(value: i32) -> Result<wgt::IndexFormat, i32> {
+/// pub fn map_index_format(value: native::WGPUIndexFormat) -> Result<wgt::IndexFormat, native::WGPUIndexFormat> {
 ///      match value {
 ///          native::WGPUIndexFormat_Uint16 => Ok(wgt::IndexFormat::Uint16),
 ///          native::WGPUIndexFormat_Uint32 => Ok(wgt::IndexFormat::Uint32),


### PR DESCRIPTION
This is the "easyfix" for #290 by wrapping the `map_load_op` and `map_store_op` conversion utils so that instead of panic-ing they return an arbitrary value.