### PR TITLE
Add option for gles3 minor version in instance extras

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,7 +307,7 @@ checksum = "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a"
 dependencies = [
  "bitflags 1.3.2",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -323,6 +329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,7 +347,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
  "serde",
 ]
 
@@ -452,13 +474,13 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "naga"
 version = "0.13.0"
-source = "git+https://github.com/gfx-rs/naga?rev=bac2d82a430fbfcf100ee22b7c3bc12f3d593079#bac2d82a430fbfcf100ee22b7c3bc12f3d593079"
+source = "git+https://github.com/gfx-rs/naga?rev=cc87b8f9eb30bb55d0735b89d3df3e099e1a6e7c#cc87b8f9eb30bb55d0735b89d3df3e099e1a6e7c"
 dependencies = [
  "bit-set",
  "bitflags 2.3.3",
  "codespan-reporting",
  "hexf-parse",
- "indexmap",
+ "indexmap 2.0.0",
  "log",
  "num-traits",
  "petgraph",
@@ -557,7 +579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -870,7 +892,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.17.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=21098cdaceee49c22a7e3a9648ce019b4e74beec#21098cdaceee49c22a7e3a9648ce019b4e74beec"
+source = "git+https://github.com/gfx-rs/wgpu?rev=0ffdae31a1f75e1041ed4472eb0552c487831efe#0ffdae31a1f75e1041ed4472eb0552c487831efe"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -894,7 +916,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.17.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=21098cdaceee49c22a7e3a9648ce019b4e74beec#21098cdaceee49c22a7e3a9648ce019b4e74beec"
+source = "git+https://github.com/gfx-rs/wgpu?rev=0ffdae31a1f75e1041ed4472eb0552c487831efe#0ffdae31a1f75e1041ed4472eb0552c487831efe"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -910,7 +932,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.0",
+ "libloading 0.7.4",
  "log",
  "metal",
  "naga",
@@ -947,7 +969,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.17.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=21098cdaceee49c22a7e3a9648ce019b4e74beec#21098cdaceee49c22a7e3a9648ce019b4e74beec"
+source = "git+https://github.com/gfx-rs/wgpu?rev=0ffdae31a1f75e1041ed4472eb0552c487831efe#0ffdae31a1f75e1041ed4472eb0552c487831efe"
 dependencies = [
  "bitflags 2.3.3",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,8 +453,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "metal"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623b5e6cefd76e58f774bd3cc0c6f5c7615c58c03a97815245a25c3c9bdee318"
+source = "git+https://github.com/gfx-rs/metal-rs/?rev=d24f1a4#d24f1a4ae92470bf87a0c65ecfe78c9299835505"
 dependencies = [
  "bitflags 2.3.3",
  "block",
@@ -474,7 +473,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "naga"
 version = "0.13.0"
-source = "git+https://github.com/gfx-rs/naga?rev=cc87b8f9eb30bb55d0735b89d3df3e099e1a6e7c#cc87b8f9eb30bb55d0735b89d3df3e099e1a6e7c"
+source = "git+https://github.com/gfx-rs/naga?rev=df8107b7#df8107b78812cc2b1e3d5de35279cedc1f0da3fb"
 dependencies = [
  "bit-set",
  "bitflags 2.3.3",
@@ -892,7 +891,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.17.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=0ffdae31a1f75e1041ed4472eb0552c487831efe#0ffdae31a1f75e1041ed4472eb0552c487831efe"
+source = "git+https://github.com/gfx-rs/wgpu?rev=9a76c483da4891fb7046c579e36d7c54bdb0b251#9a76c483da4891fb7046c579e36d7c54bdb0b251"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -916,7 +915,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.17.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=0ffdae31a1f75e1041ed4472eb0552c487831efe#0ffdae31a1f75e1041ed4472eb0552c487831efe"
+source = "git+https://github.com/gfx-rs/wgpu?rev=9a76c483da4891fb7046c579e36d7c54bdb0b251#9a76c483da4891fb7046c579e36d7c54bdb0b251"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -969,7 +968,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.17.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=0ffdae31a1f75e1041ed4472eb0552c487831efe#0ffdae31a1f75e1041ed4472eb0552c487831efe"
+source = "git+https://github.com/gfx-rs/wgpu?rev=9a76c483da4891fb7046c579e36d7c54bdb0b251#9a76c483da4891fb7046c579e36d7c54bdb0b251"
 dependencies = [
  "bitflags 2.3.3",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,40 +30,40 @@ trace = ["wgc/trace"]
 [dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "21098cdaceee49c22a7e3a9648ce019b4e74beec"
+rev = "0ffdae31a1f75e1041ed4472eb0552c487831efe"
 version = "0.17"
 features = ["raw-window-handle", "gles"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "21098cdaceee49c22a7e3a9648ce019b4e74beec"
+rev = "0ffdae31a1f75e1041ed4472eb0552c487831efe"
 version = "0.17"
 features = ["metal"]
 
 [target.'cfg(windows)'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "21098cdaceee49c22a7e3a9648ce019b4e74beec"
+rev = "0ffdae31a1f75e1041ed4472eb0552c487831efe"
 version = "0.17"
 features = ["dx11", "dx12"]
 
 [target.'cfg(any(windows, all(unix, not(target_arch = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "21098cdaceee49c22a7e3a9648ce019b4e74beec"
+rev = "0ffdae31a1f75e1041ed4472eb0552c487831efe"
 version = "0.17"
 features = ["vulkan"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "21098cdaceee49c22a7e3a9648ce019b4e74beec"
+rev = "0ffdae31a1f75e1041ed4472eb0552c487831efe"
 version = "0.17"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "bac2d82a430fbfcf100ee22b7c3bc12f3d593079"
+rev = "cc87b8f9eb30bb55d0735b89d3df3e099e1a6e7c"
 version = "0.13.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,40 +30,40 @@ trace = ["wgc/trace"]
 [dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "0ffdae31a1f75e1041ed4472eb0552c487831efe"
+rev = "9a76c483da4891fb7046c579e36d7c54bdb0b251"
 version = "0.17"
 features = ["raw-window-handle", "gles"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "0ffdae31a1f75e1041ed4472eb0552c487831efe"
+rev = "9a76c483da4891fb7046c579e36d7c54bdb0b251"
 version = "0.17"
 features = ["metal"]
 
 [target.'cfg(windows)'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "0ffdae31a1f75e1041ed4472eb0552c487831efe"
+rev = "9a76c483da4891fb7046c579e36d7c54bdb0b251"
 version = "0.17"
 features = ["dx11", "dx12"]
 
 [target.'cfg(any(windows, all(unix, not(target_arch = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "0ffdae31a1f75e1041ed4472eb0552c487831efe"
+rev = "9a76c483da4891fb7046c579e36d7c54bdb0b251"
 version = "0.17"
 features = ["vulkan"]
 
 [dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "0ffdae31a1f75e1041ed4472eb0552c487831efe"
+rev = "9a76c483da4891fb7046c579e36d7c54bdb0b251"
 version = "0.17"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-rev = "cc87b8f9eb30bb55d0735b89d3df3e099e1a6e7c"
+rev = "df8107b7"
 version = "0.13.0"
 
 [dependencies]

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -58,6 +58,14 @@ typedef enum WGPUDx12Compiler {
     WGPUDx12Compiler_Force32 = 0x7FFFFFFF
 } WGPUDx12Compiler;
 
+typedef enum WGPUGles3MinorVersion {
+    WGPUGles3MinorVersion_Automatic = 0x00000000,
+    WGPUGles3MinorVersion_Version0 = 0x00000001,
+    WGPUGles3MinorVersion_Version1 = 0x00000002,
+    WGPUGles3MinorVersion_Version2 = 0x00000003,
+    WGPUGles3MinorVersion_Force32 = 0x7FFFFFFF
+} WGPUGles3MinorVersion;
+
 typedef enum WGPUCompositeAlphaMode {
     WGPUCompositeAlphaMode_Auto = 0x00000000,
     WGPUCompositeAlphaMode_Opaque = 0x00000001,
@@ -71,6 +79,7 @@ typedef struct WGPUInstanceExtras {
     WGPUChainedStruct chain;
     WGPUInstanceBackendFlags backends;
     WGPUDx12Compiler dx12ShaderCompiler;
+    WGPUGles3MinorVersion gles3MinorVersion;
     const char * dxilPath;
     const char * dxcPath;
 } WGPUInstanceExtras;

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -208,6 +208,17 @@ map_enum!(
     Inherit
 );
 
+map_enum!(
+    map_gles3_minor_version,
+    WGPUGles3MinorVersion,
+    wgt::Gles3MinorVersion,
+    "Unknown gles3 minor version",
+    Automatic,
+    Version0,
+    Version1,
+    Version2
+);
+
 pub const WGPU_WHOLE_SIZE: ::std::os::raw::c_ulonglong = native::WGPU_WHOLE_SIZE as _;
 pub const WGPU_LIMIT_U64_UNDEFINED: ::std::os::raw::c_ulonglong =
     native::WGPU_LIMIT_U64_UNDEFINED as _;
@@ -274,6 +285,8 @@ pub fn map_instance_descriptor(
         wgt::InstanceDescriptor {
             backends: map_instance_backend_flags(extras.backends as native::WGPUInstanceBackend),
             dx12_shader_compiler,
+            gles_minor_version: map_gles3_minor_version(extras.gles3MinorVersion),
+
         }
     } else {
         wgt::InstanceDescriptor::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -999,6 +999,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginComputePass(
     let desc = match descriptor {
         Some(descriptor) => wgc::command::ComputePassDescriptor {
             label: ptr_into_label(descriptor.label),
+            timestamp_writes: None,
         },
         None => wgc::command::ComputePassDescriptor::default(),
     };
@@ -1069,6 +1070,8 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
                 .collect(),
         ),
         depth_stencil_attachment: depth_stencil_attachment.as_ref(),
+        timestamp_writes: None,
+        occlusion_query_set: None,
     };
 
     Arc::into_raw(Arc::new(WGPURenderPassEncoderImpl {


### PR DESCRIPTION
This was added to `wgpu-core` lately (commit extracted from #296 )