### PR TITLE
Limits fallback

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1,5 +1,3 @@
-use wgc::Label;
-
 use crate::native;
 use crate::utils::{make_slice, ptr_into_label, ptr_into_pathbuf};
 use crate::{follow_chain, map_enum};
@@ -298,12 +296,15 @@ pub fn map_instance_descriptor(
 pub fn map_device_descriptor<'a>(
     des: &native::WGPUDeviceDescriptor,
     extras: Option<&native::WGPUDeviceExtras>,
-) -> (wgt::DeviceDescriptor<Label<'a>>, *const std::ffi::c_char) {
+) -> (
+    wgt::DeviceDescriptor<wgc::Label<'a>>,
+    *const std::ffi::c_char,
+) {
     let limits = unsafe { des.requiredLimits.as_ref() }.map_or(
         wgt::Limits::default(),
         |required_limits| unsafe {
             follow_chain!(
-                map_required_limits(required_limits,
+                map_required_limits((required_limits),
                 WGPUSType_RequiredLimitsExtras => native::WGPURequiredLimitsExtras)
             )
         },

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -295,16 +295,20 @@ pub fn map_instance_descriptor(
 #[inline]
 pub fn map_device_descriptor<'a>(
     des: &native::WGPUDeviceDescriptor,
+    use_downlevel: bool,
     extras: Option<&native::WGPUDeviceExtras>,
 ) -> (
     wgt::DeviceDescriptor<wgc::Label<'a>>,
     *const std::ffi::c_char,
 ) {
     let limits = unsafe { des.requiredLimits.as_ref() }.map_or(
-        wgt::Limits::default(),
+        match use_downlevel {
+            true => wgt::Limits::downlevel_defaults(),
+            false => wgt::Limits::default(),
+        },
         |required_limits| unsafe {
             follow_chain!(
-                map_required_limits((required_limits),
+                map_required_limits((required_limits, use_downlevel),
                 WGPUSType_RequiredLimitsExtras => native::WGPURequiredLimitsExtras)
             )
         },
@@ -423,10 +427,14 @@ pub fn write_limits_struct(
 #[inline]
 pub fn map_required_limits(
     required_limits: &native::WGPURequiredLimits,
+    use_downlevel: bool,
     extras: Option<&native::WGPURequiredLimitsExtras>,
 ) -> wgt::Limits {
     let limits = required_limits.limits;
-    let mut wgt_limits = wgt::Limits::default();
+    let mut wgt_limits = match use_downlevel {
+        true => wgt::Limits::downlevel_defaults(),
+        false => wgt::Limits::default(),
+    };
     if limits.maxTextureDimension1D != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_texture_dimension_1d = limits.maxTextureDimension1D;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,7 +576,7 @@ pub unsafe extern "C" fn wgpuCreateInstance(
 ) -> native::WGPUInstance {
     let instance_desc = match descriptor {
         Some(descriptor) => follow_chain!(map_instance_descriptor(
-            descriptor,
+            (descriptor),
             WGPUSType_InstanceExtras => native::WGPUInstanceExtras
         )),
         None => wgt::InstanceDescriptor::default(),
@@ -724,7 +724,7 @@ pub unsafe extern "C" fn wgpuAdapterRequestDevice(
     let (desc, trace_str, device_lost_handler) = match descriptor {
         Some(descriptor) => {
             let (desc, trace_str) = follow_chain!(
-                map_device_descriptor(descriptor,
+                map_device_descriptor((descriptor),
                 WGPUSType_DeviceExtras => native::WGPUDeviceExtras)
             );
             let device_lost_handler = DeviceLostCallback {
@@ -1728,7 +1728,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroup(
     let entries = make_slice(descriptor.entries, descriptor.entryCount)
         .iter()
         .map(|entry| {
-            follow_chain!(map_bind_group_entry(entry,
+            follow_chain!(map_bind_group_entry((entry),
                 WGPUSType_BindGroupEntryExtras => native::WGPUBindGroupEntryExtras)
             )
         })
@@ -1772,7 +1772,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
     let entries = make_slice(descriptor.entries, descriptor.entryCount)
         .iter()
         .map(|entry| {
-            follow_chain!(map_bind_group_layout_entry(entry,
+            follow_chain!(map_bind_group_layout_entry((entry),
                 WGPUSType_BindGroupLayoutEntryExtras => native::WGPUBindGroupLayoutEntryExtras)
             )
         })
@@ -1955,7 +1955,7 @@ pub unsafe extern "C" fn wgpuDeviceCreatePipelineLayout(
 
     let desc = follow_chain!(
         map_pipeline_layout_descriptor(
-            descriptor,
+            (descriptor),
             WGPUSType_PipelineLayoutExtras => native::WGPUPipelineLayoutExtras)
     );
     let (pipeline_layout_id, error) =
@@ -2113,7 +2113,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
             },
             unclipped_depth: follow_chain!(
                 map_primitive_state(
-                    &descriptor.primitive,
+                    (&descriptor.primitive),
                     WGPUSType_PrimitiveDepthClipControl => native::WGPUPrimitiveDepthClipControl
                 )
             ),
@@ -2292,7 +2292,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModule(
     let descriptor = descriptor.expect("invalid descriptor");
 
     let source = follow_chain!(
-        map_shader_module(descriptor,
+        map_shader_module((descriptor),
         WGPUSType_ShaderModuleSPIRVDescriptor => native::WGPUShaderModuleSPIRVDescriptor,
         WGPUSType_ShaderModuleWGSLDescriptor => native::WGPUShaderModuleWGSLDescriptor,
         WGPUSType_ShaderModuleGLSLDescriptor => native::WGPUShaderModuleGLSLDescriptor)
@@ -2548,7 +2548,7 @@ pub unsafe extern "C" fn wgpuInstanceCreateSurface(
     let descriptor = descriptor.expect("invalid descriptor");
 
     let create_surface_params = follow_chain!(
-        map_surface(descriptor,
+        map_surface((descriptor),
             WGPUSType_SurfaceDescriptorFromWindowsHWND => native::WGPUSurfaceDescriptorFromWindowsHWND,
             WGPUSType_SurfaceDescriptorFromXcbWindow => native::WGPUSurfaceDescriptorFromXcbWindow,
             WGPUSType_SurfaceDescriptorFromXlibWindow => native::WGPUSurfaceDescriptorFromXlibWindow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use std::{
     sync::Arc,
     thread,
 };
-use utils::{make_slice, ptr_into_label, ptr_into_path};
+use utils::{make_slice, ptr_into_label, ptr_into_path, should_use_downlevel_limits};
 use wgc::{
     command::{self, bundle_ffi, compute_ffi, render_ffi},
     gfx_select, id, resource, Label,
@@ -734,7 +734,7 @@ pub unsafe extern "C" fn wgpuAdapterRequestDevice(
             return;
         }
     };
-    let use_downlevel = !wgt::Limits::default().check_limits(&adapter_limits);
+    let use_downlevel = should_use_downlevel_limits(&adapter_limits);
 
     let (desc, trace_str, device_lost_handler) = match descriptor {
         Some(descriptor) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,6 +54,11 @@ pub(crate) fn make_slice<'a, T: 'a>(ptr: *const T, len: usize) -> &'a [T] {
     }
 }
 
+// Check if downlevel limits should be preffered over the default limits.
+pub fn should_use_downlevel_limits(adapter_limits: &wgt::Limits) -> bool {
+    !wgt::Limits::default().check_limits(adapter_limits)
+}
+
 /// Follow a chain of next pointers and automatically resolve them to the underlying structs.
 ///
 /// # Syntax:
@@ -222,4 +227,29 @@ macro_rules! map_enum {
             map_fn(value).expect($err_msg)
         }
     };
+}
+
+#[test]
+pub fn test_should_use_downlevel_limits() {
+    {
+        let adapter_limits = wgt::Limits {
+            max_bind_groups: 2, // default are 4
+            ..Default::default()
+        };
+        assert_eq!(should_use_downlevel_limits(&adapter_limits), true);
+    }
+    {
+        let adapter_limits = wgt::Limits {
+            max_bind_groups: 4, // default are 4
+            ..Default::default()
+        };
+        assert_eq!(should_use_downlevel_limits(&adapter_limits), false);
+    }
+    {
+        let adapter_limits = wgt::Limits {
+            max_bind_groups: 8, // default are 4
+            ..Default::default()
+        };
+        assert_eq!(should_use_downlevel_limits(&adapter_limits), false);
+    }
 }


### PR DESCRIPTION
Fixes #297

#### Context
Support creating devices with lower than [`Limits::default()`](https://docs.rs/wgpu-types/0.17.0/src/wgpu_types/lib.rs.html#926-960) limits, by falling back to [`Limits::downlevel_default()`](https://docs.rs/wgpu-types/0.17.0/src/wgpu_types/lib.rs.html#964-996) if adapter's limits are lower than [`Limits::default()`](https://docs.rs/wgpu-types/0.17.0/src/wgpu_types/lib.rs.html#926-960). (checked by using [`wgt::Limits::check_limits()`](https://docs.rs/wgpu-types/latest/wgpu_types/struct.Limits.html#method.check_limits))

#### Testing
untested, but added a unit test