### PR TITLE
Buffer mapping example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build
 dist
 .idea
+__pycache__

--- a/examples/py/README.md
+++ b/examples/py/README.md
@@ -1,0 +1,10 @@
+# Python examples
+
+These examples use the wgpu-native DLL using `cffi`. It makes it
+relatively easy to write examples and tests. Everything is deliberately
+pretty raw, so the code does not look very Pythonic, but this way there
+is no magic.
+
+To run these examples, you need a Python 3 interpreter, and have a recent version of `cffi` installed (e.g. using `pip install -U cffi`).
+
+Note: running the code from within Visual Studio Code is fragile, it looks like Code's debugger does not play well with the ffi or something.

--- a/examples/py/buffer_mapping.py
+++ b/examples/py/buffer_mapping.py
@@ -1,0 +1,81 @@
+# %% Imports
+
+from wgpu_native import ffi, lib, ptr2memoryview
+from create_device import device, queue
+
+# %% Create buffer
+
+buffer_des = ffi.new("WGPUBufferDescriptor *")
+buffer_des.size = 64
+buffer_des.mappedAtCreation = True
+buffer_des.usage = lib.WGPUBufferUsage_MapRead
+buffer = lib.wgpuDeviceCreateBuffer(device, buffer_des)
+
+# %% Write data (buffer is already mapped at creation)
+
+data_ptr = lib.wgpuBufferGetMappedRange(buffer, 0, 64)
+data = ptr2memoryview(data_ptr, 64)
+for i in range(len(data)):
+    data[i] = 42
+
+del data
+lib.wgpuBufferUnmap(buffer)
+
+
+# %% Read data
+
+status = 999
+
+
+@ffi.callback("void(WGPUBufferMapAsyncStatus, void*)")
+def callback(status_, user_data_p):
+    global status
+    status = status_
+
+
+lib.wgpuBufferMapAsync(buffer, lib.WGPUMapMode_Read, 0, 64, callback, ffi.NULL)
+lib.wgpuDevicePoll(device, True, ffi.NULL)
+assert status == 0
+
+data_ptr = lib.wgpuBufferGetMappedRange(buffer, 0, 64)
+data = ptr2memoryview(data_ptr, 64)
+
+print("All zeros (data has not been flushed):")
+print(data.tolist())
+
+del data
+lib.wgpuBufferUnmap(buffer)
+
+# %% Submit an empty command buffer
+
+encoder_des = ffi.new("WGPUCommandEncoderDescriptor *")
+encoder = lib.wgpuDeviceCreateCommandEncoder(device, encoder_des)
+command_buffer_des = ffi.new("WGPUCommandBufferDescriptor *")
+command_buffer = lib.wgpuCommandEncoderFinish(encoder, command_buffer_des)
+lib.wgpuQueueSubmit(queue, 1, ffi.new("WGPUCommandBuffer []", [command_buffer]))
+
+# %% Read data (again)
+
+status = 999
+
+
+@ffi.callback("void(WGPUBufferMapAsyncStatus, void*)")
+def callback(status_, user_data_p):
+    global status
+    status = status_
+
+
+lib.wgpuBufferMapAsync(buffer, lib.WGPUMapMode_Read, 0, 64, callback, ffi.NULL)
+lib.wgpuDevicePoll(device, True, ffi.NULL)
+assert status == 0
+
+data_ptr = lib.wgpuBufferGetMappedRange(buffer, 0, 64)
+data = ptr2memoryview(data_ptr, 64)
+
+print("All 42's:")
+print(data.tolist())
+
+del data
+lib.wgpuBufferUnmap(buffer)
+
+# %%

--- a/examples/py/buffer_mapping.py
+++ b/examples/py/buffer_mapping.py
@@ -43,6 +43,10 @@ data = ptr2memoryview(data_ptr, 64)
 print("All zeros (data has not been flushed):")
 print(data.tolist())
 
+# Question, is this expected or:
+# * should wgpuBufferMapAsync fail?
+# * should it show the 42s?
+
 del data
 lib.wgpuBufferUnmap(buffer)
 

--- a/examples/py/create_device.py
+++ b/examples/py/create_device.py
@@ -1,0 +1,58 @@
+# %% Create instance
+
+from wgpu_native import ffi, lib
+
+instance_des = ffi.new("WGPUInstanceDescriptor *")
+instance = lib.wgpuCreateInstance(instance_des)
+
+# %% Create adapter
+
+adapter = None
+
+
+@ffi.callback("void(WGPURequestAdapterStatus, WGPUAdapter, char *, void *)")
+def callback(status, result, message, userdata):
+    if status != 0:
+        msg = "-" if message == ffi.NULL else ffi.string(message).decode()
+        assert False, f"Request adapter failed ({status}): {msg}"
+    else:
+        global adapter
+        adapter = result
+
+
+adapter_opts = ffi.new("WGPURequestAdapterOptions *")
+adapter_opts.backendType = lib.WGPUBackendType_Undefined
+adapter_opts.compatibleSurface = ffi.NULL
+adapter_opts.forceFallbackAdapter = False
+adapter_opts.powerPreference = lib.WGPUPowerPreference_HighPerformance
+lib.wgpuInstanceRequestAdapter(instance, adapter_opts, callback, ffi.NULL)
+
+assert adapter is not None
+
+supported_limits = ffi.new("WGPUSupportedLimits *")
+lib.wgpuAdapterGetLimits(adapter, supported_limits)
+
+# %% Create device
+
+device = None
+
+
+@ffi.callback("void(WGPURequestDeviceStatus, WGPUDevice, char *, void *)")
+def callback(status, result, message, userdata):
+    if status != 0:
+        msg = "-" if message == ffi.NULL else ffi.string(message).decode()
+        assert False, f"Request device failed ({status}): {msg}"
+    else:
+        global device
+        device = result
+
+
+device_des = ffi.new("WGPUDeviceDescriptor *")
+device_des.requiredLimits = ffi.new("WGPURequiredLimits *")
+device_des.requiredLimits.limits = supported_limits.limits
+device_des.defaultQueue = ffi.new("WGPUQueueDescriptor *")[0]
+lib.wgpuAdapterRequestDevice(adapter, device_des, callback, ffi.NULL)
+
+assert device is not None
+
+queue = lib.wgpuDeviceGetQueue(device)

--- a/examples/py/wgpu_native.py
+++ b/examples/py/wgpu_native.py
@@ -1,0 +1,88 @@
+"""
+Little library to instaniate the dynamic library.
+The paths to the header files and DLL are taken relative to this file.
+"""
+
+import os
+import sys
+import ctypes
+
+import cffi
+
+
+this_dir = os.path.abspath(os.path.dirname(__file__))
+repo_dir = os.path.dirname(os.path.dirname(this_dir))
+
+
+def get_wgpu_lib_path():
+    # If path is given, use that or fail trying
+    override_path = os.getenv("WGPU_LIB_PATH", "").strip()
+    if override_path:
+        return override_path
+
+    # Load the debug binary if requested
+    build = "debug"
+
+    # Get lib filename for supported platforms
+    if sys.platform.startswith("win"):
+        lib_filename = "wgpu_native.dll"
+    elif sys.platform.startswith("darwin"):
+        lib_filename = "libwgpu_native.dylib"
+    elif sys.platform.startswith("linux"):
+        lib_filename = "libwgpu_native.so"
+    else:
+        raise RuntimeError("No WGPU library found. Build it, or set WGPU_LIB_PATH.")
+
+    return os.path.join(repo_dir, "target", build, lib_filename)
+
+
+def get_wgpu_header(*filenames):
+    """Combine headers into a single textual representation."""
+    # Read files
+    lines1 = []
+    for filename in filenames:
+        with open(filename) as f:
+            lines1.extend(f.readlines())
+    # Deal with pre-processor commands, because cffi cannot handle them.
+    # Just removing them, plus a few extra lines, seems to do the trick.
+    lines2 = []
+    for line in lines1:
+        if line.startswith("#define ") and len(line.split()) > 2 and "0x" in line:
+            line = line.replace("(", "").replace(")", "")
+        elif line.startswith("#"):
+            continue
+        elif 'extern "C"' in line:
+            continue
+        for define_to_drop in [
+            "WGPU_EXPORT ",
+            "WGPU_NULLABLE ",
+            " WGPU_OBJECT_ATTRIBUTE",
+            " WGPU_ENUM_ATTRIBUTE",
+            " WGPU_FUNCTION_ATTRIBUTE",
+            " WGPU_STRUCTURE_ATTRIBUTE",
+        ]:
+            line = line.replace(define_to_drop, "")
+        lines2.append(line)
+    return "\n".join(lines2)
+
+
+WEBGPU_H_PATH = os.path.join(repo_dir, "ffi", "webgpu-headers", "webgpu.h")
+WGPU_H_PATH = os.path.join(repo_dir, "ffi", "wgpu.h")
+LIB_PATH = get_wgpu_lib_path()
+
+header = get_wgpu_header(WEBGPU_H_PATH, WGPU_H_PATH)
+
+ffi = cffi.FFI()
+ffi.cdef(header)
+ffi.set_source("wgpu.h", None)
+lib = ffi.dlopen(LIB_PATH)
+
+
+# %%% Some helper functions
+
+
+def ptr2memoryview(ptr, nbytes, format="B"):
+    """Get a memoryview from an ffi pointer and a byte count."""
+    address = int(ffi.cast("intptr_t", ptr))
+    c_array = (ctypes.c_uint8 * nbytes).from_address(address)
+    return memoryview(c_array).cast(format, shape=(nbytes,))


### PR DESCRIPTION
Following up on #305 I created an example that demonstrates behavior related to buffer mapping that may or may not be expected.

As an experiment, I wrote this in Python, not via wgpu-py, but only using `cffi` as an interface. If this works for the other devs, this could be a nice way to quickly produce examples like these, and also interact with the `lib` interactively (e.g. in a Jupyter notebook). Otherwise I'll translate it to a C example :)