### PR TITLE
GetBindGroupLayout 'raises error' instead of panicing on invalid index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3504,11 +3504,22 @@ pub unsafe extern "C" fn wgpuRenderPipelineGetBindGroupLayout(
 ) -> native::WGPUBindGroupLayout {
     let (render_pipeline_id, context, error_sink) = {
         let render_pipeline = render_pipeline.as_ref().expect("invalid render pipeline");
-        (render_pipeline.id, &render_pipeline.context, &render_pipeline.error_sink)
+        (
+            render_pipeline.id,
+            &render_pipeline.context,
+            &render_pipeline.error_sink,
+        )
     };
     let (bind_group_layout_id, error) = gfx_select!(render_pipeline_id => context.render_pipeline_get_bind_group_layout(render_pipeline_id, group_index, ()));
     if let Some(cause) = error {
-        handle_error(context, error_sink, cause, "", None, "wgpuRenderPipelineGetBindGroupLayout")
+        handle_error(
+            context,
+            error_sink,
+            cause,
+            "",
+            None,
+            "wgpuRenderPipelineGetBindGroupLayout",
+        )
     }
 
     Arc::into_raw(Arc::new(WGPUBindGroupLayoutImpl {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,7 @@ pub struct WGPURenderPassEncoderImpl {
 pub struct WGPURenderPipelineImpl {
     context: Arc<Context>,
     id: id::RenderPipelineId,
+    error_sink: ErrorSink,
 }
 impl Drop for WGPURenderPipelineImpl {
     fn drop(&mut self) {
@@ -2227,6 +2228,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
     Arc::into_raw(Arc::new(WGPURenderPipelineImpl {
         context: context.clone(),
         id: render_pipeline_id,
+        error_sink: error_sink.clone(),
     }))
 }
 
@@ -3500,17 +3502,13 @@ pub unsafe extern "C" fn wgpuRenderPipelineGetBindGroupLayout(
     render_pipeline: native::WGPURenderPipeline,
     group_index: u32,
 ) -> native::WGPUBindGroupLayout {
-    let (render_pipeline_id, context) = {
+    let (render_pipeline_id, context, error_sink) = {
         let render_pipeline = render_pipeline.as_ref().expect("invalid render pipeline");
-        (render_pipeline.id, &render_pipeline.context)
+        (render_pipeline.id, &render_pipeline.context, &render_pipeline.error_sink)
     };
-
     let (bind_group_layout_id, error) = gfx_select!(render_pipeline_id => context.render_pipeline_get_bind_group_layout(render_pipeline_id, group_index, ()));
     if let Some(cause) = error {
-        panic!(
-            "Error in wgpuRenderPipelineGetBindGroupLayout: Error reflecting bind group {group_index}: {f}",
-            f = format_error(context, &cause)
-        );
+        handle_error(context, error_sink, cause, "", None, "wgpuRenderPipelineGetBindGroupLayout")
     }
 
     Arc::into_raw(Arc::new(WGPUBindGroupLayoutImpl {


### PR DESCRIPTION
Ref discussion in https://github.com/pygfx/wgpu-py/pull/423

We have `wgpuRenderPipelineGetBindGroupLayout` and `wgpuComputePipelineGetBindGroupLayout`. End-users calling this code (e.g. people writing code against wgpu-py), may accidentally use an invalid index, which now causes a panic. In order for a wrapper to handle such errors gracefully, they must either know the number of layouts, or the call should not panic but generate an error instead. This PR does the latter (leading to a Python exception in wgpu-py).

Tested with wgpu-py (on the v0.18.1.1 tag).