### PR TITLE
Add missing webgpu features

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1059,9 +1059,6 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::DEPTH32FLOAT_STENCIL8) {
         temp.push(native::WGPUFeatureName_Depth32FloatStencil8);
     }
-    if features.contains(wgt::Features::TIMESTAMP_QUERY) {
-        temp.push(native::WGPUFeatureName_TimestampQuery);
-    }
     if features.contains(wgt::Features::TEXTURE_COMPRESSION_BC) {
         temp.push(native::WGPUFeatureName_TextureCompressionBC);
     }
@@ -1070,6 +1067,9 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     }
     if features.contains(wgt::Features::TEXTURE_COMPRESSION_ASTC) {
         temp.push(native::WGPUFeatureName_TextureCompressionASTC);
+    }
+    if features.contains(wgt::Features::TIMESTAMP_QUERY) {
+        temp.push(native::WGPUFeatureName_TimestampQuery);
     }
     if features.contains(wgt::Features::INDIRECT_FIRST_INSTANCE) {
         temp.push(native::WGPUFeatureName_IndirectFirstInstance);
@@ -1080,6 +1080,12 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::RG11B10UFLOAT_RENDERABLE) {
         temp.push(native::WGPUFeatureName_RG11B10UfloatRenderable);
     }
+    if features.contains(wgt::Features::BGRA8UNORM_STORAGE) {
+        temp.push(native::WGPUFeatureName_BGRA8UnormStorage);
+    }
+    //if features.contains(wgt::Features::FLOAT32_FILTERABLE) {
+    //    temp.push(native::WGPUFeatureName_Float32Filterable);
+    //} -> not yet available in wgpu-core
 
     // wgpu-rs only features
     if features.contains(wgt::Features::PUSH_CONSTANTS) {


### PR DESCRIPTION
The features specified by WebGPU (copied from https://gpuweb.github.io/gpuweb/#gpufeaturename):
```idl
enum GPUFeatureName {
    "depth-clip-control",
    "depth32float-stencil8",
    "texture-compression-bc",
    "texture-compression-etc2",
    "texture-compression-astc",
    "timestamp-query",
    "indirect-first-instance",
    "shader-f16",
    "rg11b10ufloat-renderable",
    "bgra8unorm-storage",
    "float32-filterable",
};
```

Features by wgpy-core: https://docs.rs/wgpu-types/0.18.0/wgpu_types/struct.Features.html

This PR adds one missing feature: "bgra8unorm-storage". (The "timestamp-query" was just moved so the order of the list is the same as in the spec.)

The final missing feature "float32-filterable" I cannot add because wgpu-core does not define it yet. 

We are interested in having it, since we rely on it in pygfx because it's somewhat crucial in e.g. volume rendering. So I looked a bit into wgpu-core, and found [the pr that adds bgra8unorm-storage](https://github.com/gfx-rs/wgpu/pull/4228). Seems like quite a bit of work, so for now I'm going to leave it at leaving the code for this feature commented here. We can keep using `TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES` (which includes float32-filterable)  for now. 😅 
