### PR TITLE
add linux/aarch64 support.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,13 +73,13 @@ jobs:
           name: dist
 
   # -----
-  linux-arm64:
+  linux-aarch64:
     # Config
-    name: release - linux-arm64
+    name: release - linux-aarch64
     runs-on: ubuntu-latest
     env:
       TARGET: aarch64-unknown-linux-gnu
-      ARCHIVE_NAME: wgpu-linux-arm64
+      ARCHIVE_NAME: wgpu-linux-aarch64
       TOOLCHAIN: stable-aarch64-unknown-linux-gnu
       IMAGE: manylinux_2_28_aarch64
     steps:
@@ -279,7 +279,7 @@ jobs:
   publish:
     name: Publish Github release
     needs:
-      [linux-x86_64, linux-arm64, windows-x86_64, windows-i686, macos-x86_64, macos-arm64]
+      [linux-x86_64, linux-aarch64, windows-x86_64, windows-i686, macos-x86_64, macos-arm64]
     runs-on: ubuntu-latest
     if: success() && contains(github.ref, 'tags/v')
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,10 +48,6 @@ jobs:
       - name: Set WGPU_NATIVE_VERSION
         run: echo "WGPU_NATIVE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
         shell: bash
-      - name: Setup caching
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: build-${{ env.TARGET }}-${{ env.CACHE_SUFFIX }}
       # Build
       - name: Build
         run: |
@@ -94,10 +90,6 @@ jobs:
       - name: Set WGPU_NATIVE_VERSION
         run: echo "WGPU_NATIVE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
         shell: bash
-      - name: Setup caching
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: build-${{ env.TARGET }}-${{ env.CACHE_SUFFIX }}
       # prepare qemu for cross-compilation
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,10 +48,65 @@ jobs:
       - name: Set WGPU_NATIVE_VERSION
         run: echo "WGPU_NATIVE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
         shell: bash
+      - name: Setup caching
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: build-${{ env.TARGET }}-${{ env.CACHE_SUFFIX }}
       # Build
       - name: Build
         run: |
           CID=$(docker create -t -w /tmp/wgpu-native -v $PWD:/tmp/src:ro -e TARGET -e ARCHIVE_NAME -e WGPU_NATIVE_VERSION quay.io/pypa/$IMAGE bash -c "\
+            cp -r /tmp/src/. . && \
+            rm -rf ./dist && \
+            export PATH=/root/.cargo/bin:\$PATH && \
+            export USER=root && \
+            curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none && \
+            rustup toolchain install --no-self-update $TOOLCHAIN && \
+            rustup default $TOOLCHAIN && \
+            dnf install clang-devel zip -y && \
+            make package")
+          docker start -ai $CID
+          mkdir -p dist
+          docker cp $CID:/tmp/wgpu-native/dist/. dist/.
+          docker rm $CID
+      # Upload (same for each build)
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          path: dist
+          name: dist
+
+  # -----
+  linux-arm64:
+    # Config
+    name: release - linux-arm64
+    runs-on: ubuntu-latest
+    env:
+      TARGET: aarch64-unknown-linux-gnu
+      ARCHIVE_NAME: wgpu-linux-arm64
+      TOOLCHAIN: stable-aarch64-unknown-linux-gnu
+      IMAGE: manylinux_2_28_aarch64
+    steps:
+      # Common part (same for nearly each build)
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Set WGPU_NATIVE_VERSION
+        run: echo "WGPU_NATIVE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        shell: bash
+      - name: Setup caching
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: build-${{ env.TARGET }}-${{ env.CACHE_SUFFIX }}
+      # prepare qemu for cross-compilation
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      # Build
+      - name: Build
+        run: |
+          CID=$(docker create --platform linux/arm64 -t -w /tmp/wgpu-native -v $PWD:/tmp/src:ro -e TARGET -e ARCHIVE_NAME -e WGPU_NATIVE_VERSION quay.io/pypa/$IMAGE bash -c "\
             cp -r /tmp/src/. . && \
             rm -rf ./dist && \
             export PATH=/root/.cargo/bin:\$PATH && \
@@ -232,7 +287,7 @@ jobs:
   publish:
     name: Publish Github release
     needs:
-      [linux-x86_64, windows-x86_64, windows-i686, macos-x86_64, macos-arm64]
+      [linux-x86_64, linux-arm64, windows-x86_64, windows-i686, macos-x86_64, macos-arm64]
     runs-on: ubuntu-latest
     if: success() && contains(github.ref, 'tags/v')
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -239,13 +239,13 @@ jobs:
           name: dist
 
   # -----
-  macos-arm64:
+  macos-aarch64:
     # Config
-    name: release - macos-arm64
+    name: release - macos-aarch64
     runs-on: macos-latest
     env:
       TARGET: aarch64-apple-darwin
-      ARCHIVE_NAME: wgpu-macos-arm64
+      ARCHIVE_NAME: wgpu-macos-aarch64
       MACOSX_DEPLOYMENT_TARGET: "11.0"
     steps:
       # Common part (same for each build)
@@ -279,7 +279,7 @@ jobs:
   publish:
     name: Publish Github release
     needs:
-      [linux-x86_64, linux-aarch64, windows-x86_64, windows-i686, macos-x86_64, macos-arm64]
+      [linux-x86_64, linux-aarch64, windows-x86_64, windows-i686, macos-x86_64, macos-aarch64]
     runs-on: ubuntu-latest
     if: success() && contains(github.ref, 'tags/v')
     steps:


### PR DESCRIPTION
This PR adds configurations to create binary files for arm64 architecture, which are necessary for platforms like Raspberry Pi. The build process takes approximately 30-40 minutes due to the use of QEMU. Currently, I am testing the functionality using Raspberry Pi 4 and wgpu-py, and so far, it seems that the library loading is successful.

You can use the artifacts in the CD from the following link. Feel free to use it for testing as needed.

https://github.com/dskkato/wgpu-native/releases/tag/v0.18.1.3

![ss_raspi](https://github.com/gfx-rs/wgpu-native/assets/46243939/86aa0551-4cfd-4f39-afdf-bf70f2f3d636)

Verified environments:

```sh
dskkato@raspberrypi:~ $ uname -m
aarch64
dskkato@raspberrypi:~ $ cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

Related to #142

