### PR TITLE
examples: Don't build docs for glfw.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,6 +35,7 @@ add_subdirectory(enumerate_adapters)
 add_subdirectory(texture_arrays)
 add_subdirectory(triangle)
 
-set(GLFW_USE_WAYLAND 1)
+set(GLFW_BUILD_DOCS OFF)
+set(GLFW_USE_WAYLAND ON)
 set(DEP_GLFW_DIR ${CMAKE_SOURCE_DIR}/vendor/glfw)
 add_subdirectory(${DEP_GLFW_DIR})


### PR DESCRIPTION
Also, update to using `ON` rather than `1` for the flag for using Wayland.