### PR TITLE
wgpu.h: Don't require preprocessing to use.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,11 @@ package: lib-native lib-native-release
 		ARCHIVE=$(ARCHIVE_NAME)-$$RELEASE.zip; \
 		LIBDIR=$(TARGET_DIR)/$$RELEASE; \
 		rm -f dist/$$ARCHIVE; \
-		sed 's/webgpu-headers\///' ffi/wgpu.h > wgpu.h ;\
 		if [ $(OS_NAME) = windows ]; then \
-			7z a -tzip dist/$$ARCHIVE ./$$LIBDIR/wgpu_native.dll ./$$LIBDIR/wgpu_native.dll.lib ./$$LIBDIR/wgpu_native.pdb ./$$LIBDIR/wgpu_native.lib ./ffi/webgpu-headers/*.h ./wgpu.h ./dist/commit-sha; \
+			7z a -tzip dist/$$ARCHIVE ./$$LIBDIR/wgpu_native.dll ./$$LIBDIR/wgpu_native.dll.lib ./$$LIBDIR/wgpu_native.pdb ./$$LIBDIR/wgpu_native.lib ./ffi/webgpu-headers/*.h ./ffi/wgpu.h ./dist/commit-sha; \
 		else \
-			zip -j dist/$$ARCHIVE ./$$LIBDIR/libwgpu_native.so ./$$LIBDIR/libwgpu_native.dylib ./$$LIBDIR/libwgpu_native.a ./ffi/webgpu-headers/*.h ./wgpu.h ./dist/commit-sha; \
+			zip -j dist/$$ARCHIVE ./$$LIBDIR/libwgpu_native.so ./$$LIBDIR/libwgpu_native.dylib ./$$LIBDIR/libwgpu_native.a ./ffi/webgpu-headers/*.h ./ffi/wgpu.h ./dist/commit-sha; \
 		fi; \
-		rm wgpu.h ;\
 	done
 
 clean:

--- a/build.rs
+++ b/build.rs
@@ -42,8 +42,8 @@ fn main() {
         ("WGPUTextureView", "WGPUTextureViewImpl"),
     ];
     let mut builder = bindgen::Builder::default()
-        .header("ffi/webgpu-headers/webgpu.h")
         .header("ffi/wgpu.h")
+        .clang_arg("-Iffi/webgpu-headers")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .blocklist_function("wgpuGetProcAddress")
         .prepend_enum_name(false)

--- a/examples/capture/CMakeLists.txt
+++ b/examples/capture/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 add_definitions(-DSTB_IMAGE_WRITE_IMPLEMENTATION)
 
 include_directories(${CMAKE_SOURCE_DIR}/../ffi)
+include_directories(${CMAKE_SOURCE_DIR}/../ffi/webgpu-headers)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)

--- a/examples/compute/CMakeLists.txt
+++ b/examples/compute/CMakeLists.txt
@@ -10,6 +10,7 @@ else()
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/../ffi)
+include_directories(${CMAKE_SOURCE_DIR}/../ffi/webgpu-headers)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)

--- a/examples/enumerate_adapters/CMakeLists.txt
+++ b/examples/enumerate_adapters/CMakeLists.txt
@@ -10,6 +10,7 @@ else()
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/../ffi)
+include_directories(${CMAKE_SOURCE_DIR}/../ffi/webgpu-headers)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)

--- a/examples/framework/CMakeLists.txt
+++ b/examples/framework/CMakeLists.txt
@@ -10,6 +10,7 @@ else()
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/../ffi)
+include_directories(${CMAKE_SOURCE_DIR}/../ffi/webgpu-headers)
 
 if (WIN32)
     set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32)

--- a/examples/texture_arrays/CMakeLists.txt
+++ b/examples/texture_arrays/CMakeLists.txt
@@ -10,6 +10,7 @@ else()
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/../ffi)
+include_directories(${CMAKE_SOURCE_DIR}/../ffi/webgpu-headers)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)

--- a/examples/triangle/CMakeLists.txt
+++ b/examples/triangle/CMakeLists.txt
@@ -10,6 +10,7 @@ else()
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/../ffi)
+include_directories(${CMAKE_SOURCE_DIR}/../ffi/webgpu-headers)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1,7 +1,7 @@
 #ifndef WGPU_H_
 #define WGPU_H_
 
-#include "webgpu-headers/webgpu.h"
+#include "webgpu.h"
 
 typedef enum WGPUNativeSType {
     // Start at 0003 since that's allocated range for wgpu-native


### PR DESCRIPTION
Right now, `wgpu.h` can be included directly and it then includes `webgpu-headers/webgpu.h`. This is altered during creation of a distribution package to remove the `"webgpu-headers"`, but by adding `ffi/webgpu-headers` to the include search path, we can avoid having to preprocess the `wgpu.h`.