### PR TITLE
examples: Improve glfw build integration.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -37,5 +37,4 @@ add_subdirectory(triangle)
 
 set(GLFW_BUILD_DOCS OFF)
 set(GLFW_USE_WAYLAND ON)
-set(DEP_GLFW_DIR ${CMAKE_SOURCE_DIR}/vendor/glfw)
-add_subdirectory(${DEP_GLFW_DIR})
+add_subdirectory(vendor/glfw)

--- a/examples/texture_arrays/CMakeLists.txt
+++ b/examples/texture_arrays/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/../ffi)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
-include_directories(${DEP_GLFW_DIR}/include)
 
 if (WIN32)
     add_definitions(-DWGPU_TARGET_WINDOWS)

--- a/examples/triangle/CMakeLists.txt
+++ b/examples/triangle/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/../ffi)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
-include_directories(${DEP_GLFW_DIR}/include)
 
 if (WIN32)
     add_definitions(-DWGPU_TARGET_WINDOWS)


### PR DESCRIPTION
Use the `glfw` target from cmake to configure other build targets.