### PR TITLE
Update native headers to latest commit

### DIFF
--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -130,6 +130,7 @@ int main(int argc, char *argv[]) {
                                        .view = texture_view,
                                        .loadOp = WGPULoadOp_Clear,
                                        .storeOp = WGPUStoreOp_Store,
+                                       .depthSlice = WGPU_DEPTH_SLICE_UNDEFINED,
                                        .clearValue =
                                            (const WGPUColor){
                                                .r = 1,

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -698,6 +698,7 @@ int main(int argc, char *argv[]) {
                                              .view = frame,
                                              .loadOp = WGPULoadOp_Clear,
                                              .storeOp = WGPUStoreOp_Store,
+                                             .depthSlice = WGPU_DEPTH_SLICE_UNDEFINED,
                                              .clearValue =
                                                  (const WGPUColor){
                                                      .r = 0.0,

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -315,6 +315,7 @@ int main(int argc, char *argv[]) {
                                              .view = frame,
                                              .loadOp = WGPULoadOp_Clear,
                                              .storeOp = WGPUStoreOp_Store,
+                                             .depthSlice = WGPU_DEPTH_SLICE_UNDEFINED,
                                              .clearValue =
                                                  (const WGPUColor){
                                                      .r = 0.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,7 +772,7 @@ pub unsafe extern "C" fn wgpuAdapterHasFeature(
 pub unsafe extern "C" fn wgpuAdapterRequestDevice(
     adapter: native::WGPUAdapter,
     descriptor: Option<&native::WGPUDeviceDescriptor>,
-    callback: native::WGPURequestDeviceCallback,
+    callback: native::WGPUAdapterRequestDeviceCallback,
     userdata: *mut std::os::raw::c_void,
 ) {
     let (adapter_id, context) = {
@@ -982,7 +982,7 @@ pub unsafe extern "C" fn wgpuBufferMapAsync(
     mode: native::WGPUMapModeFlags,
     offset: usize,
     size: usize,
-    callback: native::WGPUBufferMapCallback,
+    callback: native::WGPUBufferMapAsyncCallback,
     userdata: *mut std::ffi::c_void,
 ) {
     let (buffer_id, context, error_sink) = {
@@ -1172,6 +1172,10 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
             make_slice(descriptor.colorAttachments, descriptor.colorAttachmentCount)
                 .iter()
                 .map(|color_attachment| {
+                    if color_attachment.depthSlice != 0 {
+                        unimplemented!("Depth slice on color attachments is not implemented");
+                    }
+
                     color_attachment.view.as_ref().map(|view| {
                         wgc::command::RenderPassColorAttachment {
                             view: view.id,
@@ -2683,7 +2687,7 @@ pub unsafe extern "C" fn wgpuInstanceCreateSurface(
 pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
     instance: native::WGPUInstance,
     options: Option<&native::WGPURequestAdapterOptions>,
-    callback: native::WGPURequestAdapterCallback,
+    callback: native::WGPUInstanceRequestAdapterCallback,
     userdata: *mut std::os::raw::c_void,
 ) {
     let instance = instance.as_ref().expect("invalid instance");
@@ -2853,7 +2857,7 @@ pub unsafe extern "C" fn wgpuQuerySetRelease(query_set: native::WGPUQuerySet) {
 #[no_mangle]
 pub unsafe extern "C" fn wgpuQueueOnSubmittedWorkDone(
     queue: native::WGPUQueue,
-    callback: native::WGPUQueueWorkDoneCallback,
+    callback: native::WGPUQueueOnSubmittedWorkDoneCallback,
     userdata: *mut ::std::os::raw::c_void,
 ) {
     let (queue_id, context) = {
@@ -3901,21 +3905,21 @@ pub unsafe extern "C" fn wgpuSurfaceCapabilitiesFreeMembers(
 ) {
     if !capabilities.formats.is_null() && capabilities.formatCount > 0 {
         drop(Vec::from_raw_parts(
-            capabilities.formats,
+            capabilities.formats as *mut native::WGPUTextureFormat,
             capabilities.formatCount,
             capabilities.formatCount,
         ));
     }
     if !capabilities.presentModes.is_null() && capabilities.presentModeCount > 0 {
         drop(Vec::from_raw_parts(
-            capabilities.presentModes,
+            capabilities.presentModes as *mut native::WGPUPresentMode,
             capabilities.presentModeCount,
             capabilities.presentModeCount,
         ));
     }
     if !capabilities.alphaModes.is_null() && capabilities.alphaModeCount > 0 {
         drop(Vec::from_raw_parts(
-            capabilities.alphaModes,
+            capabilities.alphaModes as *mut native::WGPUCompositeAlphaMode,
             capabilities.alphaModeCount,
             capabilities.alphaModeCount,
         ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1172,7 +1172,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
             make_slice(descriptor.colorAttachments, descriptor.colorAttachmentCount)
                 .iter()
                 .map(|color_attachment| {
-                    if color_attachment.depthSlice != 0 {
+                    if color_attachment.depthSlice != native::WGPU_DEPTH_SLICE_UNDEFINED {
                         unimplemented!("Depth slice on color attachments is not implemented");
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1173,7 +1173,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
                 .iter()
                 .map(|color_attachment| {
                     if color_attachment.depthSlice != native::WGPU_DEPTH_SLICE_UNDEFINED {
-                        unimplemented!("Depth slice on color attachments is not implemented");
+                        log::warn!("Depth slice on color attachments is not implemented");
                     }
 
                     color_attachment.view.as_ref().map(|view| {

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -1,6 +1,15 @@
 use crate::native;
 
 #[no_mangle]
+pub extern "C" fn wgpuAdapterRequestAdapterInfo(
+    _adapter: native::WGPUAdapter,
+    _callback: native::WGPUAdapterRequestAdapterInfoCallback,
+    _userdata: *mut ::std::os::raw::c_void,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
 pub extern "C" fn wgpuGetProcAddress(
     _device: native::WGPUDevice,
     _proc_name: *const ::std::os::raw::c_char,
@@ -73,7 +82,7 @@ pub extern "C" fn wgpuComputePipelineSetLabel(
 pub extern "C" fn wgpuDeviceCreateComputePipelineAsync(
     _device: native::WGPUDevice,
     _descriptor: *const native::WGPUComputePipelineDescriptor,
-    _callback: native::WGPUCreateComputePipelineAsyncCallback,
+    _callback: native::WGPUDeviceCreateComputePipelineAsyncCallback,
     _userdata: *mut ::std::os::raw::c_void,
 ) {
     unimplemented!();
@@ -83,7 +92,7 @@ pub extern "C" fn wgpuDeviceCreateComputePipelineAsync(
 pub extern "C" fn wgpuDeviceCreateRenderPipelineAsync(
     _device: native::WGPUDevice,
     _descriptor: *const native::WGPURenderPipelineDescriptor,
-    _callback: native::WGPUCreateRenderPipelineAsyncCallback,
+    _callback: native::WGPUDeviceCreateRenderPipelineAsyncCallback,
     _userdata: *mut ::std::os::raw::c_void,
 ) {
     unimplemented!();
@@ -94,6 +103,14 @@ pub extern "C" fn wgpuDeviceSetLabel(
     _device: native::WGPUDevice,
     _label: *const ::std::os::raw::c_char,
 ) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuInstanceHasWGSLLanguageFeature(
+    _instance: native::WGPUInstance,
+    _feature: native::WGPUWGSLFeatureName,
+) -> bool {
     unimplemented!();
 }
 
@@ -169,7 +186,7 @@ pub extern "C" fn wgpuSamplerSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuShaderModuleGetCompilationInfo(
     _shader_module: native::WGPUShaderModule,
-    _callback: native::WGPUCompilationInfoCallback,
+    _callback: native::WGPUShaderModuleGetCompilationInfoCallback,
     _userdata: *mut ::std::os::raw::c_void,
 ) {
     unimplemented!();
@@ -178,6 +195,14 @@ pub extern "C" fn wgpuShaderModuleGetCompilationInfo(
 #[no_mangle]
 pub extern "C" fn wgpuShaderModuleSetLabel(
     _shader_module: native::WGPUShaderModule,
+    _label: *const ::std::os::raw::c_char,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuSurfaceSetLabel(
+    _surface: native::WGPUSurface,
     _label: *const ::std::os::raw::c_char,
 ) {
     unimplemented!();


### PR DESCRIPTION
Everything is just marked as unimplemented for now, due to lacking support in main wgpu.

The biggest reason I did this is because the added depthSlice field in WGPURenderPassColorAttachment caused conflicts when trying to use up-to-date headers with wgpu-native.