### PR TITLE
Update headers

### DIFF
--- a/examples/enumerate_adapters/main.c
+++ b/examples/enumerate_adapters/main.c
@@ -22,23 +22,23 @@ int main(int argc, char *argv[]) {
     WGPUAdapter adapter = adapters[i];
     assert(adapter);
 
-    WGPUAdapterProperties props;
-    wgpuAdapterGetProperties(adapter, &props);
+    WGPUAdapterInfo info = {0};
+    wgpuAdapterGetInfo(adapter, &info);
     printf("WGPUAdapter: %d\n", i);
-    printf("WGPUAdapterProperties {\n"
-           "\tvendorID: %" PRIu32 "\n"
-           "\tvendorName: %s\n"
+    printf("WGPUAdapterInfo {\n"
+           "\tvendor: %s\n"
            "\tarchitecture: %s\n"
-           "\tdeviceID: %" PRIu32 "\n"
-           "\tname: %s\n"
-           "\tdriverDescription: %s\n"
-           "\tadapterType: %#.8x\n"
+           "\tdevice: %s\n"
+           "\tdescription: %s\n"
            "\tbackendType: %#.8x\n"
+           "\tadapterType: %#.8x\n"
+           "\tvendorID: %" PRIu32 "\n"
+           "\tdeviceID: %" PRIu32 "\n"
            "}\n",
-           props.vendorID, props.vendorName, props.architecture, props.deviceID,
-           props.name, props.driverDescription, props.adapterType,
-           props.backendType);
+           info.vendor, info.architecture, info.device, info.description,
+           info.backendType, info.adapterType, info.vendorID, info.deviceID);
 
+    wgpuAdapterInfoFreeMembers(info);
     wgpuAdapterRelease(adapter);
   }
 

--- a/examples/framework/framework.c
+++ b/examples/framework/framework.c
@@ -165,7 +165,7 @@ void frmwrk_print_global_report(WGPUGlobalReport report) {
   printf("}\n");
 }
 
-void frmwrk_print_adapter_info(WGPUAdapter *adapter) {
+void frmwrk_print_adapter_info(WGPUAdapter adapter) {
   struct WGPUAdapterInfo info = {0};
   wgpuAdapterGetInfo(adapter, &info);
   printf("description: %s\n", info.description);

--- a/examples/framework/framework.c
+++ b/examples/framework/framework.c
@@ -164,3 +164,17 @@ void frmwrk_print_global_report(WGPUGlobalReport report) {
   }
   printf("}\n");
 }
+
+void frmwrk_print_adapter_info(WGPUAdapter *adapter) {
+  struct WGPUAdapterInfo info = {0};
+  wgpuAdapterGetInfo(adapter, &info);
+  printf("description: %s\n", info.description);
+  printf("vendor: %s\n", info.vendor);
+  printf("architecture: %s\n", info.architecture);
+  printf("device: %s\n", info.device);
+  printf("backend type: %u\n", info.backendType);
+  printf("adapter type: %u\n", info.adapterType);
+  printf("vendorID: %x\n", info.vendorID);
+  printf("deviceID: %x\n", info.deviceID);
+  wgpuAdapterInfoFreeMembers(info);
+}

--- a/examples/framework/framework.h
+++ b/examples/framework/framework.h
@@ -22,6 +22,6 @@ WGPUShaderModule frmwrk_load_shader_module(WGPUDevice device, const char *name);
 void frmwrk_print_global_report(WGPUGlobalReport report);
 WGPUBuffer frmwrk_device_create_buffer_init(
     WGPUDevice device, const frmwrk_buffer_init_descriptor *descriptor);
-void frmwrk_print_adapter_info(WGPUAdapter *adapter);
+void frmwrk_print_adapter_info(WGPUAdapter adapter);
 
 #endif // FRAMEWORK_H

--- a/examples/framework/framework.h
+++ b/examples/framework/framework.h
@@ -22,5 +22,6 @@ WGPUShaderModule frmwrk_load_shader_module(WGPUDevice device, const char *name);
 void frmwrk_print_global_report(WGPUGlobalReport report);
 WGPUBuffer frmwrk_device_create_buffer_init(
     WGPUDevice device, const frmwrk_buffer_init_descriptor *descriptor);
+void frmwrk_print_adapter_info(WGPUAdapter *adapter);
 
 #endif // FRAMEWORK_H

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -188,6 +188,8 @@ int main(int argc, char *argv[]) {
                              handle_request_adapter, &demo);
   assert(demo.adapter);
 
+  frmwrk_print_adapter_info(demo.adapter);
+
   wgpuAdapterRequestDevice(demo.adapter, NULL, handle_request_device, &demo);
   assert(demo.device);
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1531,6 +1531,24 @@ pub fn map_texture_usage_flags(flags: native::WGPUTextureUsage) -> wgt::TextureU
     temp
 }
 
+#[inline]
+pub fn to_native_texture_usage_flags(flags: wgt::TextureUsages) -> native::WGPUTextureUsageFlags {
+    let mut flag = 0;
+    if flags.contains(wgt::TextureUsages::COPY_SRC) {
+        flag |= native::WGPUTextureUsage_CopySrc;
+    }
+    if flags.contains(wgt::TextureUsages::COPY_DST) {
+        flag |= native::WGPUTextureUsage_CopySrc;
+    }
+    if flags.contains(wgt::TextureUsages::TEXTURE_BINDING) {
+        flag |= native::WGPUTextureUsage_TextureBinding;
+    }
+    if flags.contains(wgt::TextureUsages::RENDER_ATTACHMENT) {
+        flag |= native::WGPUTextureUsage_RenderAttachment;
+    }
+    flag
+}
+
 pub enum CreateSurfaceParams {
     Raw(
         (

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1532,7 +1532,7 @@ pub fn map_texture_usage_flags(flags: native::WGPUTextureUsage) -> wgt::TextureU
 }
 
 #[inline]
-pub fn to_native_texture_usage_flags(flags: wgt::TextureUsages) -> native::WGPUTextureUsageFlags {
+pub fn to_native_texture_usage_flags(flags: wgt::TextureUsages) -> native::WGPUTextureUsage {
     let mut flag = 0;
     if flags.contains(wgt::TextureUsages::COPY_SRC) {
         flag |= native::WGPUTextureUsage_CopySrc;

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1,6 +1,6 @@
-use crate::native;
 use crate::utils::{make_slice, ptr_into_label, ptr_into_pathbuf};
 use crate::{follow_chain, map_enum};
+use crate::{native, UncapturedErrorCallback};
 use std::num::{NonZeroIsize, NonZeroU32, NonZeroU64};
 use std::ptr::NonNull;
 use std::{borrow::Cow, ffi::CStr};
@@ -302,13 +302,14 @@ pub fn map_instance_descriptor(
 }
 
 #[inline]
-pub fn map_device_descriptor<'a>(
+pub(crate) fn map_device_descriptor<'a>(
     des: &native::WGPUDeviceDescriptor,
     base_limits: wgt::Limits,
     extras: Option<&native::WGPUDeviceExtras>,
 ) -> (
     wgt::DeviceDescriptor<wgc::Label<'a>>,
     *const std::ffi::c_char,
+    Option<UncapturedErrorCallback>,
 ) {
     (
         wgt::DeviceDescriptor {
@@ -330,6 +331,13 @@ pub fn map_device_descriptor<'a>(
         match extras {
             Some(extras) => extras.tracePath,
             None => std::ptr::null(),
+        },
+        match des.uncapturedErrorCallbackInfo.callback {
+            None => None,
+            callback => Some(UncapturedErrorCallback {
+                callback,
+                userdata: des.uncapturedErrorCallbackInfo.userdata,
+            }),
         },
     )
 }
@@ -1631,5 +1639,26 @@ pub fn map_surface_configuration(
             // Default is 2, https://github.com/gfx-rs/wgpu/blob/484457d95993b00b91905fae0e539a093423cc28/wgpu/src/lib.rs#L4796
             None => 2,
         },
+    }
+}
+
+pub fn map_backend_type(backend: wgt::Backend) -> native::WGPUBackendType {
+    match backend {
+        wgt::Backend::Empty => native::WGPUBackendType_Null,
+        wgt::Backend::Vulkan => native::WGPUBackendType_Vulkan,
+        wgt::Backend::Metal => native::WGPUBackendType_Metal,
+        wgt::Backend::Dx12 => native::WGPUBackendType_D3D12,
+        wgt::Backend::Gl => native::WGPUBackendType_OpenGL,
+        wgt::Backend::BrowserWebGpu => native::WGPUBackendType_WebGPU,
+    }
+}
+
+pub fn map_adapter_type(device_type: wgt::DeviceType) -> native::WGPUAdapterType {
+    match device_type {
+        wgt::DeviceType::Other => native::WGPUAdapterType_Unknown,
+        wgt::DeviceType::IntegratedGpu => native::WGPUAdapterType_IntegratedGPU,
+        wgt::DeviceType::DiscreteGpu => native::WGPUAdapterType_DiscreteGPU,
+        wgt::DeviceType::VirtualGpu => native::WGPUAdapterType_CPU, // close enough?
+        wgt::DeviceType::Cpu => native::WGPUAdapterType_CPU,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3694,7 +3694,7 @@ pub unsafe extern "C" fn wgpuSurfaceGetCapabilities(
         Err(cause) => handle_error_fatal(context, cause, "wgpuSurfaceGetCapabilities"),
     };
 
-    capabilities.usages = caps.usages.bits();
+    capabilities.usages = conv::to_native_texture_usage_flags(caps.usages);
 
     let formats = caps
         .formats

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,7 +714,9 @@ pub unsafe extern "C" fn wgpuAdapterGetInfo(
         Err(err) => handle_error_fatal(context, err, "wgpuAdapterGetInfo"),
     };
 
-    info.vendor = CString::new(result.driver).unwrap().into_raw();
+    info.vendor = CString::new(format!("{:#x}", result.vendor))
+        .unwrap()
+        .into_raw();
     info.architecture = CString::default().into_raw();
     info.device = CString::new(format!("{:#x}", result.device))
         .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3694,7 +3694,8 @@ pub unsafe extern "C" fn wgpuSurfaceGetCapabilities(
         Err(cause) => handle_error_fatal(context, cause, "wgpuSurfaceGetCapabilities"),
     };
 
-    capabilities.usages = conv::to_native_texture_usage_flags(caps.usages);
+    capabilities.usages =
+        conv::to_native_texture_usage_flags(caps.usages) as native::WGPUTextureUsageFlags;
 
     let formats = caps
         .formats

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -1,15 +1,6 @@
 use crate::native;
 
 #[no_mangle]
-pub extern "C" fn wgpuAdapterRequestAdapterInfo(
-    _adapter: native::WGPUAdapter,
-    _callback: native::WGPUAdapterRequestAdapterInfoCallback,
-    _userdata: *mut ::std::os::raw::c_void,
-) {
-    unimplemented!();
-}
-
-#[no_mangle]
 pub extern "C" fn wgpuGetProcAddress(
     _device: native::WGPUDevice,
     _proc_name: *const ::std::os::raw::c_char,


### PR DESCRIPTION
Add wgpuAdapterGetInfo to replace wgpuAdapterRequestAdapterInfo. Actually implemented this time unlike wgpuAdapterRequestAdapterInfo. And wgpuAdapterInfoFreeMembers.

wgpuDeviceSetUncapturedErrorCallback replaced in favor of field on instance descriptor

wgpuSurfaceGetPreferredFormat deleted

Add usage to WGPUSurfaceCapabilities