### PR TITLE
Add 16bit norm and NV12 textures

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -252,17 +252,17 @@ typedef struct WGPUSurfaceConfigurationExtras {
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void * userdata);
 
-typedef enum WGPUTextureFormatExtras {
-    // From Features::TEXTURE_FORMAT_16BIT_NORM 
-    WGPUTextureFormatExtras_R16Unorm = 0x00030001,
-    WGPUTextureFormatExtras_R16Snorm = 0x00030002,
-    WGPUTextureFormatExtras_Rg16Unorm = 0x00030003,
-    WGPUTextureFormatExtras_Rg16Snorm = 0x00030004,
-    WGPUTextureFormatExtras_Rgba16Unorm = 0x00030005,
-    WGPUTextureFormatExtras_Rgba16Snorm = 0x00030006,
+typedef enum WGPUNativeTextureFormat {
+    // From Features::TEXTURE_FORMAT_16BIT_NORM
+    WGPUNativeTextureFormat_R16Unorm = 0x00030001,
+    WGPUNativeTextureFormat_R16Snorm = 0x00030002,
+    WGPUNativeTextureFormat_Rg16Unorm = 0x00030003,
+    WGPUNativeTextureFormat_Rg16Snorm = 0x00030004,
+    WGPUNativeTextureFormat_Rgba16Unorm = 0x00030005,
+    WGPUNativeTextureFormat_Rgba16Snorm = 0x00030006,
     // From Features::TEXTURE_FORMAT_NV12
-    WGPUTextureFormatExtras_NV12 = 0x00030007,
-} WGPUTextureFormatExtras;
+    WGPUNativeTextureFormat_NV12 = 0x00030007,
+} WGPUNativeTextureFormat;
 
 #ifdef __cplusplus
 extern "C" {

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -252,6 +252,18 @@ typedef struct WGPUSurfaceConfigurationExtras {
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void * userdata);
 
+typedef enum WGPUTextureFormatExtras {
+    // From Features::TEXTURE_FORMAT_16BIT_NORM 
+    WGPUTextureFormatExtras_R16Unorm = 0x00030001,
+    WGPUTextureFormatExtras_R16Snorm = 0x00030002,
+    WGPUTextureFormatExtras_Rg16Unorm = 0x00030003,
+    WGPUTextureFormatExtras_Rg16Snorm = 0x00030004,
+    WGPUTextureFormatExtras_Rgba16Unorm = 0x00030005,
+    WGPUTextureFormatExtras_Rgba16Snorm = 0x00030006,
+    // From Features::TEXTURE_FORMAT_NV12
+    WGPUTextureFormatExtras_NV12 = 0x00030007,
+} WGPUTextureFormatExtras;
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -819,13 +819,15 @@ pub fn map_texture_format(value: native::WGPUTextureFormat) -> Option<wgt::Textu
         native::WGPUTextureFormat_ASTC12x10UnormSrgb => Some(wgt::TextureFormat::Astc { block: AstcBlock::B12x10, channel: AstcChannel::UnormSrgb }),
         native::WGPUTextureFormat_ASTC12x12Unorm => Some(wgt::TextureFormat::Astc { block: AstcBlock::B12x12, channel: AstcChannel::Unorm }),
         native::WGPUTextureFormat_ASTC12x12UnormSrgb => Some(wgt::TextureFormat::Astc { block: AstcBlock::B12x12, channel: AstcChannel::UnormSrgb }),
-        native::WGPUTextureFormatExtras_R16Unorm => Some(wgt::TextureFormat::R16Unorm),
-        native::WGPUTextureFormatExtras_R16Snorm => Some(wgt::TextureFormat::R16Snorm),
-        native::WGPUTextureFormatExtras_Rg16Unorm => Some(wgt::TextureFormat::Rg16Unorm),
-        native::WGPUTextureFormatExtras_Rg16Snorm => Some(wgt::TextureFormat::Rg16Snorm),
-        native::WGPUTextureFormatExtras_Rgba16Unorm => Some(wgt::TextureFormat::Rgba16Unorm),
-        native::WGPUTextureFormatExtras_Rgba16Snorm => Some(wgt::TextureFormat::Rgba16Snorm),
-        native::WGPUTextureFormatExtras_NV12  => Some(wgt::TextureFormat::NV12),
+
+        // wgpu.h extended
+        native::WGPUNativeTextureFormat_R16Unorm => Some(wgt::TextureFormat::R16Unorm),
+        native::WGPUNativeTextureFormat_R16Snorm => Some(wgt::TextureFormat::R16Snorm),
+        native::WGPUNativeTextureFormat_Rg16Unorm => Some(wgt::TextureFormat::Rg16Unorm),
+        native::WGPUNativeTextureFormat_Rg16Snorm => Some(wgt::TextureFormat::Rg16Snorm),
+        native::WGPUNativeTextureFormat_Rgba16Unorm => Some(wgt::TextureFormat::Rgba16Unorm),
+        native::WGPUNativeTextureFormat_Rgba16Snorm => Some(wgt::TextureFormat::Rgba16Snorm),
+        native::WGPUNativeTextureFormat_NV12  => Some(wgt::TextureFormat::NV12),
         _ => None,
     }
 }
@@ -837,13 +839,6 @@ pub fn to_native_texture_format(rs_type: wgt::TextureFormat) -> Option<native::W
 
     match rs_type {
         // unimplemented in webgpu.h
-        wgt::TextureFormat::R16Unorm => None,
-        wgt::TextureFormat::R16Snorm => None,
-        wgt::TextureFormat::Rg16Unorm => None,
-        wgt::TextureFormat::Rg16Snorm => None,
-        wgt::TextureFormat::Rgba16Unorm => None,
-        wgt::TextureFormat::Rgba16Snorm => None,
-        wgt::TextureFormat::NV12 => None,
         wgt::TextureFormat::Astc { block:_, channel: AstcChannel::Hdr } => None,
 
         wgt::TextureFormat::R8Unorm => Some(native::WGPUTextureFormat_R8Unorm),
@@ -941,6 +936,15 @@ pub fn to_native_texture_format(rs_type: wgt::TextureFormat) -> Option<native::W
         wgt::TextureFormat::Astc { block: AstcBlock::B12x10, channel: AstcChannel::UnormSrgb } => Some(native::WGPUTextureFormat_ASTC12x10UnormSrgb),
         wgt::TextureFormat::Astc { block: AstcBlock::B12x12, channel: AstcChannel::Unorm } => Some(native::WGPUTextureFormat_ASTC12x12Unorm),
         wgt::TextureFormat::Astc { block: AstcBlock::B12x12, channel: AstcChannel::UnormSrgb } => Some(native::WGPUTextureFormat_ASTC12x12UnormSrgb),
+
+        // wgpu.h extended
+        wgt::TextureFormat::R16Unorm => Some(native::WGPUNativeTextureFormat_R16Unorm),
+        wgt::TextureFormat::R16Snorm => Some(native::WGPUNativeTextureFormat_R16Snorm),
+        wgt::TextureFormat::Rg16Unorm => Some(native::WGPUNativeTextureFormat_Rg16Unorm),
+        wgt::TextureFormat::Rg16Snorm => Some(native::WGPUNativeTextureFormat_Rg16Snorm),
+        wgt::TextureFormat::Rgba16Unorm => Some(native::WGPUNativeTextureFormat_Rgba16Unorm),
+        wgt::TextureFormat::Rgba16Snorm => Some(native::WGPUNativeTextureFormat_Rgba16Snorm),
+        wgt::TextureFormat::NV12 => Some(native::WGPUNativeTextureFormat_NV12),
     }
 }
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -819,6 +819,13 @@ pub fn map_texture_format(value: native::WGPUTextureFormat) -> Option<wgt::Textu
         native::WGPUTextureFormat_ASTC12x10UnormSrgb => Some(wgt::TextureFormat::Astc { block: AstcBlock::B12x10, channel: AstcChannel::UnormSrgb }),
         native::WGPUTextureFormat_ASTC12x12Unorm => Some(wgt::TextureFormat::Astc { block: AstcBlock::B12x12, channel: AstcChannel::Unorm }),
         native::WGPUTextureFormat_ASTC12x12UnormSrgb => Some(wgt::TextureFormat::Astc { block: AstcBlock::B12x12, channel: AstcChannel::UnormSrgb }),
+        native::WGPUTextureFormatExtras_R16Unorm => Some(wgt::TextureFormat::R16Unorm),
+        native::WGPUTextureFormatExtras_R16Snorm => Some(wgt::TextureFormat::R16Snorm),
+        native::WGPUTextureFormatExtras_Rg16Unorm => Some(wgt::TextureFormat::Rg16Unorm),
+        native::WGPUTextureFormatExtras_Rg16Snorm => Some(wgt::TextureFormat::Rg16Snorm),
+        native::WGPUTextureFormatExtras_Rgba16Unorm => Some(wgt::TextureFormat::Rgba16Unorm),
+        native::WGPUTextureFormatExtras_Rgba16Snorm => Some(wgt::TextureFormat::Rgba16Snorm),
+        native::WGPUTextureFormatExtras_NV12  => Some(wgt::TextureFormat::NV12),
         _ => None,
     }
 }


### PR DESCRIPTION
`Features::TEXTURE_FORMAT_16BIT_NORM` and `Features::TEXTURE_FORMAT_NV12` are currently exposed as native features. This PR adds a new enum `WGPUTextureFormatExtras` which will make the texture formats of the mentioned features accessible.
 
