### PR TITLE
Add perl bindings link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The bindings are based on the WebGPU-native header found at `ffi/webgpu-headers/
 - [rajveermalviya/go-webgpu](https://github.com/rajveermalviya/go-webgpu) - Go wrapper
 - [WebGPU-C++](https://github.com/eliemichel/WebGPU-Cpp) - Auto-generated C++ wrapper (developed for the [Learn WebGPU native](https://eliemichel.github.io/LearnWebGPU) course)
 - [jai_wgpu_native](https://github.com/SogoCZE/jai_wgpu_native) - Raw Jai bindings
+- [WebGPU::Direct](https://github.com/atrodo/WebGPU-Direct) - Perl wrapper ([package](https://metacpan.org/pod/WebGPU::Direct))
 
 ## Pre-built binaries
 


### PR DESCRIPTION
I have released a WebGPU perl module that uses wgpu-native, so I was hoping to add it to the list.