### PR TITLE
Change artifact folder structure

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,7 @@ on:
 jobs:
 
   # -----
-  iOS:
+  ios:
     # Config
     name: release - ${{ matrix.name }}
     runs-on: macos-latest
@@ -59,7 +59,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - name: Add iOS targets
+      - name: Add ios targets
         run: rustup target add ${{ matrix.TARGET }}
       - name: Setup caching
         uses: Swatinem/rust-cache@v2
@@ -335,7 +335,7 @@ jobs:
   publish:
     name: Publish Github release
     needs:
-      - iOS
+      - ios
       - android
       - linux
       - windows
@@ -358,7 +358,7 @@ jobs:
         run: |
           echo $GITHUB_SHA > dist/commit-sha
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.WGPU_NATIVE_VERSION }}
           name: ${{ env.WGPU_NATIVE_VERSION }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -331,8 +331,7 @@ jobs:
           name: ${{ env.ARCHIVE_NAME }}
 
   # Create a Github release and upload the binary libs that we just built.
-  # There should be a release and debug build for each platform (win32, win64, MacOS64, Linux64),
-  # plus a file containing the commit sha.
+  # There should be a release and debug build for each platform, plus a file containing the commit sha.
   publish:
     name: Publish Github release
     needs:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,11 +38,11 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - name: iOS-aarch64
+          - name: ios-aarch64
             target: aarch64-apple-ios
-          - name: iOS-aarch64-simulator
+          - name: ios-aarch64-simulator
             target: aarch64-apple-ios-sim
-          - name: iOS-x86_64-simulator
+          - name: ios-x86_64-simulator
             target: x86_64-apple-ios
     env:
       TARGET: ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -56,17 +56,17 @@ package: lib-native lib-native-release
 		mkdir dist/$$ARCHIVEDIR; \
 		mkdir dist/$$ARCHIVEDIR/include; \
 		mkdir dist/$$ARCHIVEDIR/lib; \
-		cp ./dist/wgpu-native-git-tag  			dist/$$ARCHIVEDIR | true; \
-		cp ./ffi/webgpu-headers/webgpu.h  		dist/$$ARCHIVEDIR/include | true; \
-		cp ./ffi/wgpu.h  						dist/$$ARCHIVEDIR/include | true; \
-		cp ./$$LIBDIR/libwgpu_native.os  		dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/libwgpu_native.dylib  	dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/libwgpu_native.a  		dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/libwgpu_native.dll.a  	dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/wgpu_native.dll  			dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/wgpu_native.lib  			dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/wgpu_native.dll.lib  		dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/wgpu_native.pdb  			dist/$$ARCHIVEDIR/lib | true; \
+		cp ./dist/wgpu-native-git-tag         dist/$$ARCHIVEDIR | true; \
+		cp ./ffi/webgpu-headers/webgpu.h      dist/$$ARCHIVEDIR/include | true; \
+		cp ./ffi/wgpu.h                       dist/$$ARCHIVEDIR/include | true; \
+		cp ./$$LIBDIR/libwgpu_native.os       dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/libwgpu_native.dylib    dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/libwgpu_native.a        dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/libwgpu_native.dll.a    dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/wgpu_native.dll         dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/wgpu_native.lib         dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/wgpu_native.dll.lib     dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/wgpu_native.pdb         dist/$$ARCHIVEDIR/lib | true; \
 		cd dist/$$ARCHIVEDIR; \
 		if [ $(OS_NAME) = windows ]; then \
 			7z a -tzip ../$$ARCHIVEFILE *; \

--- a/Makefile
+++ b/Makefile
@@ -45,20 +45,34 @@ endif
 
 package: lib-native lib-native-release
 	mkdir -p dist
-	echo "$(GIT_TAG_FULL)" > dist/commit-sha
+	echo "$(GIT_TAG_FULL)" > dist/wgpu-native-git-tag
 	for RELEASE in debug release; do \
-		ARCHIVE=$(ARCHIVE_NAME)-$$RELEASE.zip; \
+		ARCHIVEDIR=toarchive; \
+		ARCHIVEFILE=$(ARCHIVE_NAME)-$$RELEASE.zip; \
 		LIBDIR=$(TARGET_DIR)/$$RELEASE; \
-		rm -f dist/$$ARCHIVE; \
+		rm -r -f dist/$$ARCHIVEDIR; \
+		rm -f dist/$$ARCHIVEFILE; \
+		mkdir dist/$$ARCHIVEDIR; \
+		mkdir dist/$$ARCHIVEDIR/include; \
+		mkdir dist/$$ARCHIVEDIR/lib; \
+		cp ./dist/wgpu-native-git-tag  			dist/$$ARCHIVEDIR | true; \
+		cp ./ffi/webgpu-headers/webgpu.h  		dist/$$ARCHIVEDIR/include | true; \
+		cp ./ffi/wgpu.h  						dist/$$ARCHIVEDIR/include | true; \
+		cp ./$$LIBDIR/libwgpu_native.os  		dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/libwgpu_native.dylib  	dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/libwgpu_native.a  		dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/libwgpu_native.dll.a  	dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/wgpu_native.dll  			dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/wgpu_native.lib  			dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/wgpu_native.dll.lib  		dist/$$ARCHIVEDIR/lib | true; \
+		cp ./$$LIBDIR/wgpu_native.pdb  			dist/$$ARCHIVEDIR/lib | true; \
+		pushd dist/$$ARCHIVEDIR; \
 		if [ $(OS_NAME) = windows ]; then \
-			if [[ "$(TARGET)" == *"gnu"* ]]; then \
-				7z a -tzip dist/$$ARCHIVE ./$$LIBDIR/wgpu_native.dll ./$$LIBDIR/libwgpu_native.dll.a ./$$LIBDIR/libwgpu_native.a ./ffi/webgpu-headers/*.h ./ffi/wgpu.h ./dist/commit-sha; \
-			else \
-				7z a -tzip dist/$$ARCHIVE ./$$LIBDIR/wgpu_native.dll ./$$LIBDIR/wgpu_native.dll.lib ./$$LIBDIR/wgpu_native.pdb ./$$LIBDIR/wgpu_native.lib ./ffi/webgpu-headers/*.h ./ffi/wgpu.h ./dist/commit-sha; \
-			fi; \
+			7z a -tzip ../$$ARCHIVEFILE *; \
 		else \
-			zip -j dist/$$ARCHIVE ./$$LIBDIR/libwgpu_native.so ./$$LIBDIR/libwgpu_native.dylib ./$$LIBDIR/libwgpu_native.a ./ffi/webgpu-headers/*.h ./ffi/wgpu.h ./dist/commit-sha; \
+			zip -r ../$$ARCHIVEFILE *; \
 		fi; \
+		popd; \
 	done
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -56,17 +56,29 @@ package: lib-native lib-native-release
 		mkdir dist/$$ARCHIVEDIR; \
 		mkdir dist/$$ARCHIVEDIR/include; \
 		mkdir dist/$$ARCHIVEDIR/lib; \
-		cp ./dist/wgpu-native-git-tag         dist/$$ARCHIVEDIR | true; \
-		cp ./ffi/webgpu-headers/webgpu.h      dist/$$ARCHIVEDIR/include | true; \
-		cp ./ffi/wgpu.h                       dist/$$ARCHIVEDIR/include | true; \
-		cp ./$$LIBDIR/libwgpu_native.os       dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/libwgpu_native.dylib    dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/libwgpu_native.a        dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/libwgpu_native.dll.a    dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/wgpu_native.dll         dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/wgpu_native.lib         dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/wgpu_native.dll.lib     dist/$$ARCHIVEDIR/lib | true; \
-		cp ./$$LIBDIR/wgpu_native.pdb         dist/$$ARCHIVEDIR/lib | true; \
+		cp ./dist/wgpu-native-git-tag                 dist/$$ARCHIVEDIR; \
+		cp ./ffi/webgpu-headers/webgpu.h              dist/$$ARCHIVEDIR/include; \
+		cp ./ffi/wgpu.h                               dist/$$ARCHIVEDIR/include; \
+		if [ $(OS_NAME) = linux ]; then \
+			cp ./$$LIBDIR/libwgpu_native.so           dist/$$ARCHIVEDIR/lib; \
+			cp ./$$LIBDIR/libwgpu_native.a            dist/$$ARCHIVEDIR/lib; \
+		fi; \
+		if [ $(OS_NAME) = macos ]; then \
+			cp ./$$LIBDIR/libwgpu_native.dylib        dist/$$ARCHIVEDIR/lib; \
+			cp ./$$LIBDIR/libwgpu_native.a            dist/$$ARCHIVEDIR/lib; \
+		fi; \
+		if [ $(OS_NAME) = windows ]; then \
+			if [[ "$(TARGET)" == *"gnu"* ]]; then \
+				cp ./$$LIBDIR/wgpu_native.dll         dist/$$ARCHIVEDIR/lib; \
+				cp ./$$LIBDIR/libwgpu_native.a        dist/$$ARCHIVEDIR/lib; \
+				cp ./$$LIBDIR/libwgpu_native.dll.a    dist/$$ARCHIVEDIR/lib; \
+			else \
+				cp ./$$LIBDIR/wgpu_native.dll         dist/$$ARCHIVEDIR/lib; \
+				cp ./$$LIBDIR/wgpu_native.lib         dist/$$ARCHIVEDIR/lib; \
+				cp ./$$LIBDIR/wgpu_native.dll.lib     dist/$$ARCHIVEDIR/lib; \
+				cp ./$$LIBDIR/wgpu_native.pdb         dist/$$ARCHIVEDIR/lib; \
+			fi;\
+		fi; \
 		cd dist/$$ARCHIVEDIR; \
 		if [ $(OS_NAME) = windows ]; then \
 			7z a -tzip ../$$ARCHIVEFILE *; \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ endif
 
 package: lib-native lib-native-release
 	mkdir -p dist
+	echo "Zipping the binaries ..."
 	echo "$(GIT_TAG_FULL)" > dist/wgpu-native-git-tag
 	for RELEASE in debug release; do \
 		ARCHIVEDIR=toarchive; \
@@ -66,13 +67,13 @@ package: lib-native lib-native-release
 		cp ./$$LIBDIR/wgpu_native.lib  			dist/$$ARCHIVEDIR/lib | true; \
 		cp ./$$LIBDIR/wgpu_native.dll.lib  		dist/$$ARCHIVEDIR/lib | true; \
 		cp ./$$LIBDIR/wgpu_native.pdb  			dist/$$ARCHIVEDIR/lib | true; \
-		pushd dist/$$ARCHIVEDIR; \
+		cd dist/$$ARCHIVEDIR; \
 		if [ $(OS_NAME) = windows ]; then \
 			7z a -tzip ../$$ARCHIVEFILE *; \
 		else \
 			zip -r ../$$ARCHIVEFILE *; \
 		fi; \
-		popd; \
+		cd ../..; \
 	done
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ package: lib-native lib-native-release
 			zip -r ../$$ARCHIVEFILE *; \
 		fi; \
 		cd ../..; \
+		rm -r -f dist/$$ARCHIVEDIR; \
 	done
 
 clean:


### PR DESCRIPTION
Closes #410 

This updates the package command in the makefile to introduce a folder structure instead of putting all files in a flat namespace. The idea is to prepare the contents of the archive in a directory and then zipping that dir as a whole.

Results can be seen here: https://github.com/almarklein/wgpu-native/actions/runs/10703101259 (can others access these?)

One example:

<img width="786" alt="image" src="https://github.com/user-attachments/assets/c36e7cc2-6b37-47f2-9091-0088b1a27a35">
