### PR TITLE
Fix: Get correct adapter info consistent with `wgpuAdapterGetProperties`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,14 +699,14 @@ pub unsafe extern "C" fn wgpuAdapterGetInfo(
         Err(err) => handle_error_fatal(err, "wgpuAdapterGetInfo"),
     };
 
-    info.vendor = CString::new(format!("{:#x}", result.vendor))
+    info.vendor = CString::new(result.driver)
         .unwrap()
         .into_raw();
     info.architecture = CString::default().into_raw();
-    info.device = CString::new(format!("{:#x}", result.device))
+    info.device = CString::new(result.name)
         .unwrap()
         .into_raw();
-    info.description = CString::new(result.name).unwrap().into_raw();
+    info.description = CString::new(result.driver_info).unwrap().into_raw();
     info.backendType = map_backend_type(result.backend);
     info.adapterType = map_adapter_type(result.device_type);
     info.vendorID = result.vendor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,13 +699,9 @@ pub unsafe extern "C" fn wgpuAdapterGetInfo(
         Err(err) => handle_error_fatal(err, "wgpuAdapterGetInfo"),
     };
 
-    info.vendor = CString::new(result.driver)
-        .unwrap()
-        .into_raw();
+    info.vendor = CString::new(result.driver).unwrap().into_raw();
     info.architecture = CString::default().into_raw();
-    info.device = CString::new(result.name)
-        .unwrap()
-        .into_raw();
+    info.device = CString::new(result.name).unwrap().into_raw();
     info.description = CString::new(result.driver_info).unwrap().into_raw();
     info.backendType = map_backend_type(result.backend);
     info.adapterType = map_adapter_type(result.device_type);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -700,7 +700,7 @@ pub unsafe extern "C" fn wgpuAdapterGetInfo(
     };
 
     info.vendor = CString::new(result.driver).unwrap().into_raw();
-    info.architecture = CString::default().into_raw();
+    info.architecture = CString::default().into_raw(); // TODO(webgpu.h)
     info.device = CString::new(result.name).unwrap().into_raw();
     info.description = CString::new(result.driver_info).unwrap().into_raw();
     info.backendType = map_backend_type(result.backend);


### PR DESCRIPTION
`wgpuAdapterGetInfo` was returning incorrect adapter info, which was inconsistent with the previous version (`wgpuAdapterGetProperties`).

With `wgpuAdapterGetProperties`:

```
vendorID: 4098
vendorName: AMD proprietary driver
architecture: 
deviceID: 5686
name: AMD Radeon(TM) Graphics
driverDescription: 24.3.1 (AMD proprietary shader compiler)
adapterType: 0x1
backendType: 0x6
```

With `wgpuAdapterGetInfo`:

```
vendorID: 4098
vendorName: 0x1002
architecture:
deviceID: 5686
name: 0x1636
driverDescription: AMD Radeon(TM) Graphics
adapterType: 0x1
backendType: 0x6
```

This is what `AdapterInfo` struct contains:

```rust
AdapterInfo {
    name: "AMD Radeon(TM) Graphics",
    vendor: 4098,
    device_type: IntegratedGpu,
    driver: "AMD proprietary driver",
    driver_info: "24.3.1 (AMD proprietary shader compiler)",
    backend: Vulkan,
}
```

And this is the output after my patch:

```
vendorID: 4098
vendorName: AMD proprietary driver
architecture:
deviceID: 5686
name: AMD Radeon(TM) Graphics
driverDescription: 24.3.1 (AMD proprietary shader compiler)
adapterType: 0x1
backendType: 0x6
```

All outputs were fetched from C++.