### PR TITLE
actions: avoid relying on included ndk, setup manually

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,7 @@ name: CD
 
 env:
   CACHE_SUFFIX: a
+  WGPU_ANDROID_NDK_VERSION: r27b # 27.1.12297006
 
 on:
   workflow_dispatch:
@@ -87,7 +88,7 @@ jobs:
             target: i686-linux-android
             setup_env: |
               set -x
-              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973
+              ANDROID_NDK_HOME=$HOME/wgpu-deps/ndk/android-ndk-$WGPU_ANDROID_NDK_VERSION
               CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang
 
               echo "CC=$CC" >> $GITHUB_ENV
@@ -101,7 +102,7 @@ jobs:
             target: x86_64-linux-android
             setup_env: |
               set -x
-              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973
+              ANDROID_NDK_HOME=$HOME/wgpu-deps/ndk/android-ndk-$WGPU_ANDROID_NDK_VERSION
               CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang
 
               echo "CC=$CC" >> $GITHUB_ENV
@@ -115,7 +116,7 @@ jobs:
             target: aarch64-linux-android
             setup_env: |
               set -x
-              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973
+              ANDROID_NDK_HOME=$HOME/wgpu-deps/ndk/android-ndk-$WGPU_ANDROID_NDK_VERSION
               CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang
 
               echo "CC=$CC" >> $GITHUB_ENV
@@ -129,7 +130,7 @@ jobs:
             target: armv7-linux-androideabi
             setup_env: |
               set -x
-              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973
+              ANDROID_NDK_HOME=$HOME/wgpu-deps/ndk/android-ndk-$WGPU_ANDROID_NDK_VERSION
               CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang
 
               echo "CC=$CC" >> $GITHUB_ENV
@@ -158,6 +159,13 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: build-${{ matrix.TARGET }}-${{ matrix.CACHE_SUFFIX }}
+      - name: Setup Android NDK
+        run: |
+          mkdir -p $HOME/wgpu-deps/ndk
+          cd $HOME/wgpu-deps/ndk
+          curl -LO https://dl.google.com/android/repository/android-ndk-$WGPU_ANDROID_NDK_VERSION-linux.zip
+          unzip android-ndk-$WGPU_ANDROID_NDK_VERSION-linux.zip
+          rm android-ndk-$WGPU_ANDROID_NDK_VERSION-linux.zip
       - name: Setup Environment
         run: ${{ matrix.setup_env }}
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
   CACHE_SUFFIX: a
+  WGPU_ANDROID_NDK_VERSION: r27b # 27.1.12297006
 
 jobs:
   # A build that does some "meta" checks on the code integrity where the Rust compiler can't.
@@ -83,7 +84,7 @@ jobs:
             target: aarch64-linux-android
             setup_env: |
               set -x
-              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973
+              ANDROID_NDK_HOME=$HOME/wgpu-deps/ndk/android-ndk-$WGPU_ANDROID_NDK_VERSION
               CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang
 
               echo "CC=$CC" >> $GITHUB_ENV
@@ -98,7 +99,7 @@ jobs:
             target: armv7-linux-androideabi
             setup_env: |
               set -x
-              ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.0.12077973
+              ANDROID_NDK_HOME=$HOME/wgpu-deps/ndk/android-ndk-$WGPU_ANDROID_NDK_VERSION
               CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang
 
               echo "CC=$CC" >> $GITHUB_ENV
@@ -126,6 +127,14 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: clippy-${{ matrix.target }}-${{ env.CACHE_SUFFIX }}
+      - if: contains(matrix.target, 'android')
+        name: Setup Android NDK
+        run: |
+          mkdir -p $HOME/wgpu-deps/ndk
+          cd $HOME/wgpu-deps/ndk
+          curl -LO https://dl.google.com/android/repository/android-ndk-$WGPU_ANDROID_NDK_VERSION-linux.zip
+          unzip android-ndk-$WGPU_ANDROID_NDK_VERSION-linux.zip
+          rm android-ndk-$WGPU_ANDROID_NDK_VERSION-linux.zip
       - name: Setup Environment
         run: ${{ matrix.setup_env }}
       - name: Run clippy


### PR DESCRIPTION
Fixes Android workflow failures — https://github.com/gfx-rs/wgpu-native/pull/419#issuecomment-2345456934

While the exact root cause of the failures related to the Android NDK version included in the GitHub Actions images is unclear, we've encountered similar issues before. Therefore, it's more reliable to avoid depending on the NDK versions provided by GitHub.

This update now uses the latest LTS NDK version (`27.1.12297006`) — https://developer.android.com/ndk/downloads#lts-downloads