### PR TITLE
Change include path in `wgpu.h`

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1,7 +1,7 @@
 #ifndef WGPU_H_
 #define WGPU_H_
 
-#include "webgpu.h"
+#include <webgpu/webgpu.h>
 
 typedef enum WGPUNativeSType {
     // Start at 0003 since that's allocated range for wgpu-native


### PR DESCRIPTION
The generated release zips files are organized as follows:

```
 - include/
   - webgpu/
     - webgpu.h
   - wgpu/
     - wgpu.h
 - lib/
   - ...
```

However, `wgpu.h` includes `webgpu.h` with `#include "webgpu.h"`, which forces to add `include/webgpu/` to the include directories, while it feels more idiomatic to only include `include/`. Other implementations also have `webgpu.h` in a `include/webgpu/` subfolder so I suggest leaving this so, leading to two possible fixes:

 - **Option A:** Change the include path in `wgpu.h` (this PR)
 - **Option B:** Distribute `wgpu.h` in `include/webgpu/` instead of `include/wgpu/` (what I had been doing manually in my distributions so far) -> edit: alternative PR for this option: https://github.com/gfx-rs/wgpu-native/pull/425