### PR TITLE
Update library to latest webgpu-native headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,6 +1025,7 @@ name = "wgpu-native"
 version = "0.0.0"
 dependencies = [
  "bindgen",
+ "bitflags 2.6.0",
  "log",
  "naga",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ log = "0.4"
 thiserror = "1"
 parking_lot = "0.12"
 smallvec = "1"
+bitflags = "2.6.0"
 
 [build-dependencies]
 bindgen = "0.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ log = "0.4"
 thiserror = "1"
 parking_lot = "0.12"
 smallvec = "1"
-bitflags = "2.6.0"
+bitflags = "2"
 
 [build-dependencies]
 bindgen = "0.70"

--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,8 @@ fn main() {
         .prepend_enum_name(false)
         .size_t_is_usize(true)
         .ignore_functions()
-        .layout_tests(true);
+        .layout_tests(true)
+        .clang_macro_fallback();
 
     for (old_name, new_name) in types_to_rename {
         let line = format!("pub type {old_name} = *const crate::{new_name};");

--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -14,7 +14,7 @@ const size_t IMAGE_HEIGHT = 200;
 const size_t COPY_BYTES_PER_ROW_ALIGNMENT = 256;
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
-                                   WGPUAdapter adapter, char const *message,
+                                   WGPUAdapter adapter, WGPUStringView message,
                                    void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
@@ -22,7 +22,7 @@ static void handle_request_adapter(WGPURequestAdapterStatus status,
   *(WGPUAdapter *)userdata1 = adapter;
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
-                                  WGPUDevice device, char const *message,
+                                  WGPUDevice device, WGPUStringView message,
                                   void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
@@ -30,7 +30,7 @@ static void handle_request_device(WGPURequestDeviceStatus status,
   *(WGPUDevice *)userdata1 = device;
 }
 static void handle_buffer_map(WGPUMapAsyncStatus status, 
-                              char const *message,
+                              WGPUStringView message,
                               void *userdata1, void *userdata2) {
   UNUSED(message)
   UNUSED(userdata1)
@@ -99,7 +99,7 @@ int main(int argc, char *argv[]) {
 
   WGPUBuffer output_buffer = wgpuDeviceCreateBuffer(
       device, &(const WGPUBufferDescriptor){
-                  .label = "output_buffer",
+                  .label = {"output_buffer", WGPU_STRLEN},
                   .size = buffer_size,
                   .usage = WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst,
                   .mappedAtCreation = false,
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
   WGPUTexture texture = wgpuDeviceCreateTexture(
       device,
       &(const WGPUTextureDescriptor){
-          .label = "texture",
+          .label = {"texture", WGPU_STRLEN},
           .size = texture_extent,
           .mipLevelCount = 1,
           .sampleCount = 1,
@@ -129,13 +129,13 @@ int main(int argc, char *argv[]) {
 
   WGPUCommandEncoder command_encoder = wgpuDeviceCreateCommandEncoder(
       device, &(const WGPUCommandEncoderDescriptor){
-                  .label = "command_encoder",
+                  .label = {"command_encoder", WGPU_STRLEN},
               });
   assert(command_encoder);
 
   WGPURenderPassEncoder render_pass_encoder = wgpuCommandEncoderBeginRenderPass(
       command_encoder, &(const WGPURenderPassDescriptor){
-                           .label = "rende_pass_encoder",
+                           .label = {"rende_pass_encoder", WGPU_STRLEN},
                            .colorAttachmentCount = 1,
                            .colorAttachments =
                                (const WGPURenderPassColorAttachment[]){
@@ -180,7 +180,7 @@ int main(int argc, char *argv[]) {
 
   WGPUCommandBuffer command_buffer = wgpuCommandEncoderFinish(
       command_encoder, &(const WGPUCommandBufferDescriptor){
-                           .label = "command_buffer",
+                           .label = {"command_buffer", WGPU_STRLEN},
                        });
   assert(command_buffer);
 

--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -29,7 +29,7 @@ static void handle_request_device(WGPURequestDeviceStatus status,
   UNUSED(userdata2)
   *(WGPUDevice *)userdata1 = device;
 }
-static void handle_buffer_map(WGPUBufferMapAsyncStatus status, 
+static void handle_buffer_map(WGPUMapAsyncStatus status, 
                               char const *message,
                               void *userdata1, void *userdata2) {
   UNUSED(message)

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -8,20 +8,25 @@
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
                                    WGPUAdapter adapter, char const *message,
-                                   void *userdata) {
+                                   void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
-  *(WGPUAdapter *)userdata = adapter;
+  UNUSED(userdata2)
+  *(WGPUAdapter *)userdata1 = adapter;
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
                                   WGPUDevice device, char const *message,
-                                  void *userdata) {
+                                  void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
-  *(WGPUDevice *)userdata = device;
+  UNUSED(userdata2)
+  *(WGPUDevice *)userdata1 = device;
 }
-static void handle_buffer_map(WGPUBufferMapAsyncStatus status, void *userdata) {
-  UNUSED(userdata)
+static void handle_buffer_map(WGPUBufferMapAsyncStatus status,
+                              char const * message,
+                              void *userdata1, void *userdata2) {
+  UNUSED(userdata1)
+  UNUSED(userdata2)
   printf(LOG_PREFIX " buffer_map status=%#.8x\n", status);
 }
 
@@ -38,13 +43,19 @@ int main(int argc, char *argv[]) {
   assert(instance);
 
   WGPUAdapter adapter = NULL;
-  wgpuInstanceRequestAdapter(instance, NULL, handle_request_adapter,
-                             (void *)&adapter);
+  wgpuInstanceRequestAdapter(instance, NULL,
+                             (const WGPURequestAdapterCallbackInfo){
+                                 .callback = handle_request_adapter,
+                                 .userdata1 = &adapter
+                             });
   assert(adapter);
 
   WGPUDevice device = NULL;
-  wgpuAdapterRequestDevice(adapter, NULL, handle_request_device,
-                           (void *)&device);
+  wgpuAdapterRequestDevice(adapter, NULL,
+                           (const WGPURequestDeviceCallbackInfo){ 
+                               .callback = handle_request_device,
+                               .userdata1 = &device
+                           });
   assert(device);
 
   WGPUQueue queue = wgpuDeviceGetQueue(device);
@@ -139,7 +150,9 @@ int main(int argc, char *argv[]) {
   wgpuQueueSubmit(queue, 1, &command_buffer);
 
   wgpuBufferMapAsync(staging_buffer, WGPUMapMode_Read, 0, numbers_size,
-                     handle_buffer_map, NULL);
+                     (const WGPUBufferMapCallbackInfo){
+                         .callback = handle_buffer_map
+                     });
   wgpuDevicePoll(device, true, NULL);
 
   uint32_t *buf =

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -7,7 +7,7 @@
 #define LOG_PREFIX "[compute]"
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
-                                   WGPUAdapter adapter, char const *message,
+                                   WGPUAdapter adapter, WGPUStringView message,
                                    void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
@@ -15,7 +15,7 @@ static void handle_request_adapter(WGPURequestAdapterStatus status,
   *(WGPUAdapter *)userdata1 = adapter;
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
-                                  WGPUDevice device, char const *message,
+                                  WGPUDevice device, WGPUStringView message,
                                   void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
@@ -23,7 +23,7 @@ static void handle_request_device(WGPURequestDeviceStatus status,
   *(WGPUDevice *)userdata1 = device;
 }
 static void handle_buffer_map(WGPUMapAsyncStatus status,
-                              char const * message,
+                              WGPUStringView message,
                               void *userdata1, void *userdata2) {
   UNUSED(userdata1)
   UNUSED(userdata2)
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
 
   WGPUBuffer staging_buffer = wgpuDeviceCreateBuffer(
       device, &(const WGPUBufferDescriptor){
-                  .label = "staging_buffer",
+                  .label = {"staging_buffer", WGPU_STRLEN},
                   .usage = WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst,
                   .size = numbers_size,
                   .mappedAtCreation = false,
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
 
   WGPUBuffer storage_buffer = wgpuDeviceCreateBuffer(
       device, &(const WGPUBufferDescriptor){
-                  .label = "storage_buffer",
+                  .label = {"storage_buffer", WGPU_STRLEN},
                   .usage = WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst |
                            WGPUBufferUsage_CopySrc,
                   .size = numbers_size,
@@ -86,11 +86,11 @@ int main(int argc, char *argv[]) {
 
   WGPUComputePipeline compute_pipeline = wgpuDeviceCreateComputePipeline(
       device, &(const WGPUComputePipelineDescriptor){
-                  .label = "compute_pipeline",
+                  .label = {"compute_pipeline", WGPU_STRLEN},
                   .compute =
                       (const WGPUProgrammableStageDescriptor){
                           .module = shader_module,
-                          .entryPoint = "main",
+                          .entryPoint = {"main", WGPU_STRLEN},
                       },
               });
   assert(compute_pipeline);
@@ -101,7 +101,7 @@ int main(int argc, char *argv[]) {
 
   WGPUBindGroup bind_group = wgpuDeviceCreateBindGroup(
       device, &(const WGPUBindGroupDescriptor){
-                  .label = "bind_group",
+                  .label = {"bind_group", WGPU_STRLEN},
                   .layout = bind_group_layout,
                   .entryCount = 1,
                   .entries =
@@ -118,14 +118,14 @@ int main(int argc, char *argv[]) {
 
   WGPUCommandEncoder command_encoder = wgpuDeviceCreateCommandEncoder(
       device, &(const WGPUCommandEncoderDescriptor){
-                  .label = "command_encoder",
+                  .label = {"command_encoder", WGPU_STRLEN},
               });
   assert(command_encoder);
 
   WGPUComputePassEncoder compute_pass_encoder =
       wgpuCommandEncoderBeginComputePass(command_encoder,
                                          &(const WGPUComputePassDescriptor){
-                                             .label = "compute_pass",
+                                             .label = {"compute_pass", WGPU_STRLEN},
                                          });
   assert(compute_pass_encoder);
 
@@ -142,7 +142,7 @@ int main(int argc, char *argv[]) {
 
   WGPUCommandBuffer command_buffer = wgpuCommandEncoderFinish(
       command_encoder, &(const WGPUCommandBufferDescriptor){
-                           .label = "command_buffer",
+                           .label = {"command_buffer", WGPU_STRLEN},
                        });
   assert(command_buffer);
 

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -22,7 +22,7 @@ static void handle_request_device(WGPURequestDeviceStatus status,
   UNUSED(userdata2)
   *(WGPUDevice *)userdata1 = device;
 }
-static void handle_buffer_map(WGPUBufferMapAsyncStatus status,
+static void handle_buffer_map(WGPUMapAsyncStatus status,
                               char const * message,
                               void *userdata1, void *userdata2) {
   UNUSED(userdata1)

--- a/examples/enumerate_adapters/main.c
+++ b/examples/enumerate_adapters/main.c
@@ -26,16 +26,17 @@ int main(int argc, char *argv[]) {
     wgpuAdapterGetInfo(adapter, &info);
     printf("WGPUAdapter: %d\n", i);
     printf("WGPUAdapterInfo {\n"
-           "\tvendor: %s\n"
-           "\tarchitecture: %s\n"
-           "\tdevice: %s\n"
-           "\tdescription: %s\n"
+           "\tvendor: %.*s\n"
+           "\tarchitecture: %.*s\n"
+           "\tdevice: %.*s\n"
+           "\tdescription: %.*s\n"
            "\tbackendType: %#.8x\n"
            "\tadapterType: %#.8x\n"
            "\tvendorID: %" PRIu32 "\n"
            "\tdeviceID: %" PRIu32 "\n"
            "}\n",
-           info.vendor, info.architecture, info.device, info.description,
+           (int) info.vendor.length, info.vendor.data, (int) info.architecture.length, info.architecture.data,
+           (int) info.device.length, info.device.data, (int) info.description.length, info.description.data,
            info.backendType, info.adapterType, info.vendorID, info.deviceID);
 
     wgpuAdapterInfoFreeMembers(info);

--- a/examples/framework/framework.c
+++ b/examples/framework/framework.c
@@ -1,6 +1,6 @@
 #include "framework.h"
 
-static void log_callback(WGPULogLevel level, char const *message,
+static void log_callback(WGPULogLevel level, WGPUStringView message,
                          void *userdata) {
   UNUSED(userdata)
   char *level_str;
@@ -23,7 +23,7 @@ static void log_callback(WGPULogLevel level, char const *message,
   default:
     level_str = "unknown_level";
   }
-  fprintf(stderr, "[wgpu] [%s] %s\n", level_str, message);
+  fprintf(stderr, "[wgpu] [%s] %.*s\n", level_str, (int) message.length, message.data);
 }
 
 void frmwrk_setup_logging(WGPULogLevel level) {
@@ -64,7 +64,7 @@ WGPUShaderModule frmwrk_load_shader_module(WGPUDevice device,
 
   shader_module = wgpuDeviceCreateShaderModule(
       device, &(const WGPUShaderModuleDescriptor){
-                  .label = name,
+                  .label = {name, WGPU_STRLEN},
                   .nextInChain =
                       (const WGPUChainedStruct *)&(
                           const WGPUShaderSourceWGSL){
@@ -72,7 +72,7 @@ WGPUShaderModule frmwrk_load_shader_module(WGPUDevice device,
                               (const WGPUChainedStruct){
                                   .sType = WGPUSType_ShaderSourceWGSL,
                               },
-                          .code = buf,
+                          .code = {buf, WGPU_STRLEN},
                       },
               });
 
@@ -92,7 +92,7 @@ WGPUBuffer frmwrk_device_create_buffer_init(
   assert(descriptor);
   if (descriptor->content_size == 0) {
     return wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
-                                              .label = descriptor->label,
+                                              .label = {descriptor->label, WGPU_STRLEN},
                                               .size = 0,
                                               .usage = descriptor->usage,
                                               .mappedAtCreation = false,
@@ -105,7 +105,7 @@ WGPUBuffer frmwrk_device_create_buffer_init(
       MAX((unpadded_size + align_mask) & ~align_mask, COPY_BUFFER_ALIGNMENT);
   WGPUBuffer buffer =
       wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
-                                         .label = descriptor->label,
+                                         .label = {descriptor->label, WGPU_STRLEN},
                                          .size = padded_size,
                                          .usage = descriptor->usage,
                                          .mappedAtCreation = true,
@@ -168,10 +168,10 @@ void frmwrk_print_global_report(WGPUGlobalReport report) {
 void frmwrk_print_adapter_info(WGPUAdapter adapter) {
   struct WGPUAdapterInfo info = {0};
   wgpuAdapterGetInfo(adapter, &info);
-  printf("description: %s\n", info.description);
-  printf("vendor: %s\n", info.vendor);
-  printf("architecture: %s\n", info.architecture);
-  printf("device: %s\n", info.device);
+  printf("description: %.*s\n", (int) info.description.length, info.description.data);
+  printf("vendor: %.*s\n", (int) info.vendor.length, info.vendor.data);
+  printf("architecture: %.*s\n", (int) info.architecture.length, info.architecture.data);
+  printf("device: %.*s\n", (int) info.device.length, info.device.data);
   printf("backend type: %u\n", info.backendType);
   printf("adapter type: %u\n", info.adapterType);
   printf("vendorID: %x\n", info.vendorID);

--- a/examples/framework/framework.c
+++ b/examples/framework/framework.c
@@ -67,10 +67,10 @@ WGPUShaderModule frmwrk_load_shader_module(WGPUDevice device,
                   .label = name,
                   .nextInChain =
                       (const WGPUChainedStruct *)&(
-                          const WGPUShaderModuleWGSLDescriptor){
+                          const WGPUShaderSourceWGSL){
                           .chain =
                               (const WGPUChainedStruct){
-                                  .sType = WGPUSType_ShaderModuleWGSLDescriptor,
+                                  .sType = WGPUSType_ShaderSourceWGSL,
                               },
                           .code = buf,
                       },

--- a/examples/framework/framework.h
+++ b/examples/framework/framework.h
@@ -12,7 +12,7 @@
 
 typedef struct frmwrk_buffer_init_descriptor {
   WGPU_NULLABLE char const *label;
-  WGPUBufferUsageFlags usage;
+  WGPUBufferUsage usage;
   void *content;
   size_t content_size;
 } frmwrk_buffer_init_descriptor;

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -233,16 +233,13 @@ int main(int argc, char *argv[]) {
   WGPUSurfaceCapabilities surface_capabilities = {0};
   wgpuSurfaceGetCapabilities(demo.surface, demo.adapter, &surface_capabilities);
 
-  size_t adapter_feature_count =
-      wgpuAdapterEnumerateFeatures(demo.adapter, NULL);
-  WGPUFeatureName *adapter_features = (WGPUFeatureName *)malloc(
-      sizeof(WGPUFeatureName) * adapter_feature_count);
-  wgpuAdapterEnumerateFeatures(demo.adapter, adapter_features);
+  WGPUSupportedFeatures adapter_features = {0};
+  wgpuAdapterGetFeatures(demo.adapter, &adapter_features);
 
   bool adapter_has_required_features = false;
   bool adapter_has_optional_features = false;
-  for (size_t i = 0; i < adapter_feature_count; i++) {
-    switch ((uint32_t)adapter_features[i]) {
+  for (size_t i = 0; i < adapter_features.featureCount; i++) {
+    switch ((uint32_t)adapter_features.features[i]) {
     case WGPUNativeFeature_TextureBindingArray:
       adapter_has_required_features = true;
       break;
@@ -253,7 +250,7 @@ int main(int argc, char *argv[]) {
   }
   assert(
           adapter_has_required_features /* Adapter must support WGPUNativeFeature_TextureBindingArray feature for this example */);
-  free(adapter_features);
+  wgpuSupportedFeaturesFreeMembers(adapter_features);
 
   WGPUFeatureName required_device_features[2] = {
       (WGPUFeatureName)WGPUNativeFeature_TextureBindingArray,

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -149,7 +149,7 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceSourceromMetalLayer){
+                    const WGPUSurfaceSourceMetalLayer){
                     .chain =
                         (const WGPUChainedStruct){
                             .sType = WGPUSType_SurfaceSourceMetalLayer,

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -27,9 +27,10 @@ struct demo {
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
                                    WGPUAdapter adapter, char const *message,
-                                   void *userdata) {
+                                   void *userdata1, void *userdata2) {
+  UNUSED(userdata2)
   if (status == WGPURequestAdapterStatus_Success) {
-    struct demo *demo = userdata;
+    struct demo *demo = userdata1;
     demo->adapter = adapter;
   } else {
     printf(LOG_PREFIX " request_adapter status=%#.8x message=%s\n", status,
@@ -38,9 +39,10 @@ static void handle_request_adapter(WGPURequestAdapterStatus status,
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
                                   WGPUDevice device, char const *message,
-                                  void *userdata) {
+                                  void *userdata1, void *userdata2) {
+  UNUSED(userdata2)
   if (status == WGPURequestDeviceStatus_Success) {
-    struct demo *demo = userdata;
+    struct demo *demo = userdata1;
     demo->device = device;
   } else {
     printf(LOG_PREFIX " request_device status=%#.8x message=%s\n", status,
@@ -147,10 +149,10 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceDescriptorFromMetalLayer){
+                    const WGPUSurfaceSourceromMetalLayer){
                     .chain =
                         (const WGPUChainedStruct){
-                            .sType = WGPUSType_SurfaceDescriptorFromMetalLayer,
+                            .sType = WGPUSType_SurfaceSourceMetalLayer,
                         },
                     .layer = metal_layer,
                 },
@@ -165,10 +167,10 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceDescriptorFromXlibWindow){
+                    const WGPUSurfaceSourceXlibWindow){
                     .chain =
                         (const WGPUChainedStruct){
-                            .sType = WGPUSType_SurfaceDescriptorFromXlibWindow,
+                            .sType = WGPUSType_SurfaceSourceXlibWindow,
                         },
                     .display = x11_display,
                     .window = x11_window,
@@ -183,11 +185,11 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceDescriptorFromWaylandSurface){
+                    const WGPUSurfaceSourceWaylandSurface){
                     .chain =
                         (const WGPUChainedStruct){
                             .sType =
-                                WGPUSType_SurfaceDescriptorFromWaylandSurface,
+                                WGPUSType_SurfaceSourceWaylandSurface,
                         },
                     .display = wayland_display,
                     .surface = wayland_surface,
@@ -203,10 +205,10 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceDescriptorFromWindowsHWND){
+                    const WGPUSurfaceSourceWindowsHWND){
                     .chain =
                         (const WGPUChainedStruct){
-                            .sType = WGPUSType_SurfaceDescriptorFromWindowsHWND,
+                            .sType = WGPUSType_SurfaceSourceWindowsHWND,
                         },
                     .hinstance = hinstance,
                     .hwnd = hwnd,
@@ -222,7 +224,10 @@ int main(int argc, char *argv[]) {
                              &(const WGPURequestAdapterOptions){
                                  .compatibleSurface = demo.surface,
                              },
-                             handle_request_adapter, &demo);
+                             (const WGPURequestAdapterCallbackInfo){
+                                 .callback = handle_request_adapter,
+                                 .userdata1 = &demo
+                             });
   assert(demo.adapter);
 
   WGPUSurfaceCapabilities surface_capabilities = {0};
@@ -260,13 +265,15 @@ int main(int argc, char *argv[]) {
     required_device_feature_count++;
   }
 
-  wgpuAdapterRequestDevice(
-      demo.adapter,
-      &(const WGPUDeviceDescriptor){
-          .requiredFeatureCount = required_device_feature_count,
-          .requiredFeatures = required_device_features,
-      },
-      handle_request_device, &demo);
+  wgpuAdapterRequestDevice(demo.adapter,
+                           &(const WGPUDeviceDescriptor){
+                               .requiredFeatureCount = required_device_feature_count,
+                               .requiredFeatures = required_device_features,
+                           }, 
+                           (const WGPURequestDeviceCallbackInfo){ 
+                               .callback = handle_request_device,
+                               .userdata1 = &demo
+                           });
   assert(demo.device);
 
   WGPUQueue queue = wgpuDeviceGetQueue(demo.device);
@@ -648,8 +655,9 @@ int main(int argc, char *argv[]) {
     WGPUSurfaceTexture surface_texture;
     wgpuSurfaceGetCurrentTexture(demo.surface, &surface_texture);
     switch (surface_texture.status) {
-    case WGPUSurfaceGetCurrentTextureStatus_Success:
-      // All good, could check for `surface_texture.suboptimal` here.
+    case WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal:
+    case WGPUSurfaceGetCurrentTextureStatus_SuccessSuboptimal:
+      // All good, could handle suboptimal here
       break;
     case WGPUSurfaceGetCurrentTextureStatus_Timeout:
     case WGPUSurfaceGetCurrentTextureStatus_Outdated:

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -26,27 +26,27 @@ struct demo {
 };
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
-                                   WGPUAdapter adapter, char const *message,
+                                   WGPUAdapter adapter, WGPUStringView message,
                                    void *userdata1, void *userdata2) {
   UNUSED(userdata2)
   if (status == WGPURequestAdapterStatus_Success) {
     struct demo *demo = userdata1;
     demo->adapter = adapter;
   } else {
-    printf(LOG_PREFIX " request_adapter status=%#.8x message=%s\n", status,
-           message);
+    printf(LOG_PREFIX " request_adapter status=%#.8x message=%.*s\n", status,
+           (int) message.length, message.data);
   }
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
-                                  WGPUDevice device, char const *message,
+                                  WGPUDevice device, WGPUStringView message,
                                   void *userdata1, void *userdata2) {
   UNUSED(userdata2)
   if (status == WGPURequestDeviceStatus_Success) {
     struct demo *demo = userdata1;
     demo->device = device;
   } else {
-    printf(LOG_PREFIX " request_device status=%#.8x message=%s\n", status,
-           message);
+    printf(LOG_PREFIX " request_device status=%#.8x message=%.*s\n", status,
+           (int) message.length, message.data);
   }
 }
 static void handle_glfw_framebuffer_size(GLFWwindow *window, int width,
@@ -368,25 +368,25 @@ int main(int argc, char *argv[]) {
   WGPUTexture red_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
-                       .label = "red",
+                       .label = {"red", WGPU_STRLEN},
                    });
   assert(red_texture);
   WGPUTexture green_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
-                       .label = "green",
+                       .label = {"green", WGPU_STRLEN},
                    });
   assert(green_texture);
   WGPUTexture blue_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
-                       .label = "blue",
+                       .label = {"blue", WGPU_STRLEN},
                    });
   assert(blue_texture);
   WGPUTexture white_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
-                       .label = "white",
+                       .label = {"white", WGPU_STRLEN},
                    });
   assert(white_texture);
 
@@ -516,7 +516,7 @@ int main(int argc, char *argv[]) {
   };
   WGPUBindGroupLayout bind_group_layout = wgpuDeviceCreateBindGroupLayout(
       demo.device, &(const WGPUBindGroupLayoutDescriptor){
-                       .label = "bind group layout",
+                       .label = {"bind group layout", WGPU_STRLEN},
                        .entryCount = sizeof(bind_group_layout_entries) /
                                      sizeof(bind_group_layout_entries[0]),
                        .entries = bind_group_layout_entries,
@@ -582,7 +582,7 @@ int main(int argc, char *argv[]) {
   WGPUBindGroup bind_group = wgpuDeviceCreateBindGroup(
       demo.device, &(const WGPUBindGroupDescriptor){
                        .layout = bind_group_layout,
-                       .label = "bind group",
+                       .label = {"bind group", WGPU_STRLEN},
                        .entryCount = sizeof(bind_group_entries) /
                                      sizeof(bind_group_entries[0]),
                        .entries = bind_group_entries,
@@ -591,7 +591,7 @@ int main(int argc, char *argv[]) {
 
   WGPUPipelineLayout pipeline_layout = wgpuDeviceCreatePipelineLayout(
       demo.device, &(const WGPUPipelineLayoutDescriptor){
-                       .label = "main",
+                       .label = {"main", WGPU_STRLEN},
                        .bindGroupLayoutCount = 1,
                        .bindGroupLayouts =
                            (const WGPUBindGroupLayout[]){
@@ -607,7 +607,7 @@ int main(int argc, char *argv[]) {
           .vertex =
               (const WGPUVertexState){
                   .module = base_shader_module,
-                  .entryPoint = "vert_main",
+                  .entryPoint = {"vert_main", WGPU_STRLEN},
                   .bufferCount = 1,
                   .buffers =
                       (const WGPUVertexBufferLayout[]){
@@ -623,7 +623,7 @@ int main(int argc, char *argv[]) {
           .fragment =
               &(const WGPUFragmentState){
                   .module = fragment_shader_module,
-                  .entryPoint = fragment_entry_point,
+                  .entryPoint = {fragment_entry_point, WGPU_STRLEN},
                   .targetCount = 1,
                   .targets =
                       (const WGPUColorTargetState[]){
@@ -688,7 +688,7 @@ int main(int argc, char *argv[]) {
 
     WGPUCommandEncoder command_encoder = wgpuDeviceCreateCommandEncoder(
         demo.device, &(const WGPUCommandEncoderDescriptor){
-                         .label = "command_encoder",
+                         .label = {"command_encoder", WGPU_STRLEN},
                      });
     assert(command_encoder);
 
@@ -696,7 +696,7 @@ int main(int argc, char *argv[]) {
         wgpuCommandEncoderBeginRenderPass(
             command_encoder,
             &(const WGPURenderPassDescriptor){
-                .label = "render_pass_encoder",
+                .label = {"render_pass_encoder", WGPU_STRLEN},
                 .colorAttachmentCount = 1,
                 .colorAttachments =
                     (const WGPURenderPassColorAttachment[]){
@@ -740,7 +740,7 @@ int main(int argc, char *argv[]) {
 
     WGPUCommandBuffer command_buffer = wgpuCommandEncoderFinish(
         command_encoder, &(const WGPUCommandBufferDescriptor){
-                             .label = "command_buffer",
+                             .label = {"command_buffer", WGPU_STRLEN},
                          });
     assert(command_buffer);
 

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceSourceromMetalLayer){
+                    const WGPUSurfaceSourceMetalLayer){
                     .chain =
                         (const WGPUChainedStruct){
                             .sType = WGPUSType_SurfaceSourceMetalLayer,

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -26,27 +26,27 @@ struct demo {
 };
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
-                                   WGPUAdapter adapter, char const *message,
+                                   WGPUAdapter adapter, WGPUStringView message,
                                    void *userdata1, void *userdata2) {
   UNUSED(userdata2)
   if (status == WGPURequestAdapterStatus_Success) {
     struct demo *demo = userdata1;
     demo->adapter = adapter;
   } else {
-    printf(LOG_PREFIX " request_adapter status=%#.8x message=%s\n", status,
-           message);
+    printf(LOG_PREFIX " request_adapter status=%#.8x message=%.*s\n", status,
+           (int) message.length, message.data);
   }
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
-                                  WGPUDevice device, char const *message,
+                                  WGPUDevice device, WGPUStringView message,
                                   void *userdata1, void *userdata2) {
   UNUSED(userdata2)
   if (status == WGPURequestDeviceStatus_Success) {
     struct demo *demo = userdata1;
     demo->device = device;
   } else {
-    printf(LOG_PREFIX " request_device status=%#.8x message=%s\n", status,
-           message);
+    printf(LOG_PREFIX " request_device status=%#.8x message=%.*s\n", status,
+           (int) message.length, message.data);
   }
 }
 static void handle_glfw_key(GLFWwindow *window, int key, int scancode,
@@ -211,7 +211,7 @@ int main(int argc, char *argv[]) {
 
   WGPUPipelineLayout pipeline_layout = wgpuDeviceCreatePipelineLayout(
       demo.device, &(const WGPUPipelineLayoutDescriptor){
-                       .label = "pipeline_layout",
+                       .label = {"pipeline_layout", WGPU_STRLEN},
                    });
   assert(pipeline_layout);
 
@@ -221,17 +221,17 @@ int main(int argc, char *argv[]) {
   WGPURenderPipeline render_pipeline = wgpuDeviceCreateRenderPipeline(
       demo.device,
       &(const WGPURenderPipelineDescriptor){
-          .label = "render_pipeline",
+          .label = {"render_pipeline", WGPU_STRLEN},
           .layout = pipeline_layout,
           .vertex =
               (const WGPUVertexState){
                   .module = shader_module,
-                  .entryPoint = "vs_main",
+                  .entryPoint = {"vs_main", WGPU_STRLEN},
               },
           .fragment =
               &(const WGPUFragmentState){
                   .module = shader_module,
-                  .entryPoint = "fs_main",
+                  .entryPoint = {"fs_main", WGPU_STRLEN},
                   .targetCount = 1,
                   .targets =
                       (const WGPUColorTargetState[]){
@@ -312,7 +312,7 @@ int main(int argc, char *argv[]) {
 
     WGPUCommandEncoder command_encoder = wgpuDeviceCreateCommandEncoder(
         demo.device, &(const WGPUCommandEncoderDescriptor){
-                         .label = "command_encoder",
+                         .label = {"command_encoder", WGPU_STRLEN},
                      });
     assert(command_encoder);
 
@@ -320,7 +320,7 @@ int main(int argc, char *argv[]) {
         wgpuCommandEncoderBeginRenderPass(
             command_encoder,
             &(const WGPURenderPassDescriptor){
-                .label = "render_pass_encoder",
+                .label = {"render_pass_encoder", WGPU_STRLEN},
                 .colorAttachmentCount = 1,
                 .colorAttachments =
                     (const WGPURenderPassColorAttachment[]){
@@ -348,7 +348,7 @@ int main(int argc, char *argv[]) {
 
     WGPUCommandBuffer command_buffer = wgpuCommandEncoderFinish(
         command_encoder, &(const WGPUCommandBufferDescriptor){
-                             .label = "command_buffer",
+                             .label = {"command_buffer", WGPU_STRLEN},
                          });
     assert(command_buffer);
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -66,30 +66,26 @@ typedef enum WGPULogLevel {
     WGPULogLevel_Force32 = 0x7FFFFFFF
 } WGPULogLevel;
 
-typedef enum WGPUInstanceBackend {
-    WGPUInstanceBackend_All = 0x00000000,
-    WGPUInstanceBackend_Vulkan = 1 << 0,
-    WGPUInstanceBackend_GL = 1 << 1,
-    WGPUInstanceBackend_Metal = 1 << 2,
-    WGPUInstanceBackend_DX12 = 1 << 3,
-    WGPUInstanceBackend_DX11 = 1 << 4,
-    WGPUInstanceBackend_BrowserWebGPU = 1 << 5,
-    WGPUInstanceBackend_Primary = WGPUInstanceBackend_Vulkan | WGPUInstanceBackend_Metal |
-        WGPUInstanceBackend_DX12 |
-        WGPUInstanceBackend_BrowserWebGPU,
-    WGPUInstanceBackend_Secondary = WGPUInstanceBackend_GL | WGPUInstanceBackend_DX11,
-    WGPUInstanceBackend_Force32 = 0x7FFFFFFF
-} WGPUInstanceBackend;
-typedef WGPUFlags WGPUInstanceBackendFlags;
+typedef WGPUFlags WGPUInstanceBackend;
+static const WGPUInstanceBackend WGPUInstanceBackend_All = 0x00000000;
+static const WGPUInstanceBackend WGPUInstanceBackend_Vulkan = 1 << 0;
+static const WGPUInstanceBackend WGPUInstanceBackend_GL = 1 << 1;
+static const WGPUInstanceBackend WGPUInstanceBackend_Metal = 1 << 2;
+static const WGPUInstanceBackend WGPUInstanceBackend_DX12 = 1 << 3;
+static const WGPUInstanceBackend WGPUInstanceBackend_DX11 = 1 << 4;
+static const WGPUInstanceBackend WGPUInstanceBackend_BrowserWebGPU = 1 << 5;
+// Vulkan, Metal, DX12 and BrowserWebGPU
+static const WGPUInstanceBackend WGPUInstanceBackend_Primary = (1 << 0) | (1 << 2) | (1 << 3) | (1 << 5);
+// GL and DX11
+static const WGPUInstanceBackend WGPUInstanceBackend_Secondary = (1 << 1) | (1 << 4);
+static const WGPUInstanceBackend WGPUInstanceBackend_Force32 = 0x7FFFFFFF;
 
-typedef enum WGPUInstanceFlag {
-    WGPUInstanceFlag_Default = 0x00000000,
-    WGPUInstanceFlag_Debug = 1 << 0,
-    WGPUInstanceFlag_Validation = 1 << 1,
-    WGPUInstanceFlag_DiscardHalLabels = 1 << 2,
-    WGPUInstanceFlag_Force32 = 0x7FFFFFFF
-} WGPUInstanceFlag;
-typedef WGPUFlags WGPUInstanceFlags;
+typedef WGPUFlags WGPUInstanceFlag;
+static const WGPUInstanceFlag WGPUInstanceFlag_Default = 0x00000000;
+static const WGPUInstanceFlag WGPUInstanceFlag_Debug = 1 << 0;
+static const WGPUInstanceFlag WGPUInstanceFlag_Validation = 1 << 1;
+static const WGPUInstanceFlag WGPUInstanceFlag_DiscardHalLabels = 1 << 2;
+static const WGPUInstanceFlag WGPUInstanceFlag_Force32 = 0x7FFFFFFF;
 
 typedef enum WGPUDx12Compiler {
     WGPUDx12Compiler_Undefined = 0x00000000,
@@ -122,8 +118,8 @@ typedef enum WGPUNativeQueryType {
 
 typedef struct WGPUInstanceExtras {
     WGPUChainedStruct chain;
-    WGPUInstanceBackendFlags backends;
-    WGPUInstanceFlags flags;
+    WGPUInstanceBackend backends;
+    WGPUInstanceFlag flags;
     WGPUDx12Compiler dx12ShaderCompiler;
     WGPUGles3MinorVersion gles3MinorVersion;
     const char * dxilPath;
@@ -220,7 +216,7 @@ typedef struct WGPUGlobalReport {
 
 typedef struct WGPUInstanceEnumerateAdapterOptions {
     WGPUChainedStruct const * nextInChain;
-    WGPUInstanceBackendFlags backends;
+    WGPUInstanceBackend backends;
 } WGPUInstanceEnumerateAdapterOptions;
 
 typedef struct WGPUBindGroupEntryExtras {

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -151,7 +151,7 @@ typedef struct WGPUSupportedLimitsExtras {
 } WGPUSupportedLimitsExtras;
 
 typedef struct WGPUPushConstantRange {
-    WGPUShaderStageFlags stages;
+    WGPUShaderStage stages;
     uint32_t start;
     uint32_t end;
 } WGPUPushConstantRange;
@@ -281,7 +281,7 @@ void wgpuSetLogLevel(WGPULogLevel level);
 
 uint32_t wgpuGetVersion(void);
 
-void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void const * data);
+void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStage stages, uint32_t offset, uint32_t sizeBytes, void const * data);
 
 void wgpuRenderPassEncoderMultiDrawIndirect(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);
 void wgpuRenderPassEncoderMultiDrawIndexedIndirect(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -122,13 +122,13 @@ typedef struct WGPUInstanceExtras {
     WGPUInstanceFlag flags;
     WGPUDx12Compiler dx12ShaderCompiler;
     WGPUGles3MinorVersion gles3MinorVersion;
-    const char * dxilPath;
-    const char * dxcPath;
+    WGPUStringView dxilPath;
+    WGPUStringView dxcPath;
 } WGPUInstanceExtras;
 
 typedef struct WGPUDeviceExtras {
     WGPUChainedStruct chain;
-    const char * tracePath;
+    WGPUStringView tracePath;
 } WGPUDeviceExtras;
 
 typedef struct WGPUNativeLimits {
@@ -166,14 +166,14 @@ typedef struct WGPUWrappedSubmissionIndex {
 } WGPUWrappedSubmissionIndex;
 
 typedef struct WGPUShaderDefine {
-    char const * name;
-    char const * value;
+    WGPUStringView name;
+    WGPUStringView value;
 } WGPUShaderDefine;
 
 typedef struct WGPUShaderModuleGLSLDescriptor {
     WGPUChainedStruct chain;
     WGPUShaderStage stage;
-    char const * code;
+    WGPUStringView code;
     uint32_t defineCount;
     WGPUShaderDefine * defines;
 } WGPUShaderModuleGLSLDescriptor;
@@ -245,7 +245,7 @@ typedef struct WGPUSurfaceConfigurationExtras {
     uint32_t desiredMaximumFrameLatency;
 } WGPUSurfaceConfigurationExtras WGPU_STRUCTURE_ATTRIBUTE;
 
-typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void * userdata);
+typedef void (*WGPULogCallback)(WGPULogLevel level, WGPUStringView message, void * userdata);
 
 typedef enum WGPUNativeTextureFormat {
     // From Features::TEXTURE_FORMAT_16BIT_NORM

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -6,10 +6,9 @@
 typedef enum WGPUNativeSType {
     // Start at 0003 since that's allocated range for wgpu-native
     WGPUSType_DeviceExtras = 0x00030001,
-    WGPUSType_RequiredLimitsExtras = 0x00030002,
+    WGPUSType_NativeLimits = 0x00030002,
     WGPUSType_PipelineLayoutExtras = 0x00030003,
     WGPUSType_ShaderModuleGLSLDescriptor = 0x00030004,
-    WGPUSType_SupportedLimitsExtras = 0x00030005,
     WGPUSType_InstanceExtras = 0x00030006,
     WGPUSType_BindGroupEntryExtras = 0x00030007,
     WGPUSType_BindGroupLayoutEntryExtras = 0x00030008,
@@ -132,19 +131,11 @@ typedef struct WGPUDeviceExtras {
 } WGPUDeviceExtras;
 
 typedef struct WGPUNativeLimits {
+    /** This struct chain is used as mutable in some places and immutable in others. */
+    WGPUChainedStructOut * nextInChain;
     uint32_t maxPushConstantSize;
     uint32_t maxNonSamplerBindings;
 } WGPUNativeLimits;
-
-typedef struct WGPURequiredLimitsExtras {
-    WGPUChainedStruct chain;
-    WGPUNativeLimits limits;
-} WGPURequiredLimitsExtras;
-
-typedef struct WGPUSupportedLimitsExtras {
-    WGPUChainedStructOut chain;
-    WGPUNativeLimits limits;
-} WGPUSupportedLimitsExtras;
 
 typedef struct WGPUPushConstantRange {
     WGPUShaderStage stages;

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -135,7 +135,7 @@ typedef struct WGPUDeviceExtras {
 
 typedef struct WGPUNativeLimits {
     /** This struct chain is used as mutable in some places and immutable in others. */
-    WGPUChainedStructOut * nextInChain;
+    WGPUChainedStructOut chain;
     uint32_t maxPushConstantSize;
     uint32_t maxNonSamplerBindings;
 } WGPUNativeLimits;
@@ -173,7 +173,7 @@ typedef struct WGPUShaderModuleGLSLDescriptor {
 } WGPUShaderModuleGLSLDescriptor;
 
 typedef struct WGPUShaderModuleDescriptorSpirV {
-    char const * label;
+    WGPUStringView label;
     uint32_t sourceSize;
     uint32_t const * source;
 } WGPUShaderModuleDescriptorSpirV;

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -293,7 +293,7 @@ pub fn map_instance_descriptor(
             backends: map_instance_backend_flags(extras.backends as native::WGPUInstanceBackend),
             dx12_shader_compiler,
             gles_minor_version: map_gles3_minor_version(extras.gles3MinorVersion),
-            flags: match extras.flags as native::WGPUInstanceFlag {
+            flags: match extras.flags {
                 native::WGPUInstanceFlag_Default => wgt::InstanceFlags::default(),
                 flags => map_instance_flags(flags),
             },

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -385,10 +385,7 @@ pub unsafe fn map_pipeline_layout_descriptor<'a>(
 }
 
 #[inline]
-pub fn write_limits_struct(
-    wgt_limits: wgt::Limits,
-    limits: &mut native::WGPULimits,
-) {
+pub fn write_limits_struct(wgt_limits: wgt::Limits, limits: &mut native::WGPULimits) {
     limits.maxTextureDimension1D = wgt_limits.max_texture_dimension_1d;
     limits.maxTextureDimension2D = wgt_limits.max_texture_dimension_2d;
     limits.maxTextureDimension3D = wgt_limits.max_texture_dimension_3d;

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -94,19 +94,23 @@ map_enum_with_undefined!(
     WGPUBlendFactor,
     wgt::BlendFactor,
     "Unknown blend factor",
-    Zero: Zero,
-    One: One,
-    Src: Src,
-    OneMinusSrc: OneMinusSrc,
-    SrcAlpha: SrcAlpha,
-    OneMinusSrcAlpha: OneMinusSrcAlpha,
-    Dst: Dst,
-    OneMinusDst: OneMinusDst,
-    DstAlpha: DstAlpha,
-    OneMinusDstAlpha: OneMinusDstAlpha,
-    SrcAlphaSaturated: SrcAlphaSaturated,
-    Constant: Constant,
-    OneMinusConstant: OneMinusConstant
+    Zero,
+    One,
+    Src,
+    OneMinusSrc,
+    SrcAlpha,
+    OneMinusSrcAlpha,
+    Dst,
+    OneMinusDst,
+    DstAlpha,
+    OneMinusDstAlpha,
+    SrcAlphaSaturated,
+    Constant,
+    OneMinusConstant,
+    Src1,
+    OneMinusSrc1,
+    Src1Alpha,
+    OneMinusSrc1Alpha
 );
 map_enum_with_undefined!(
     map_blend_operation,
@@ -1101,7 +1105,9 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::FLOAT32_FILTERABLE) {
         temp.push(native::WGPUFeatureName_Float32Filterable);
     }
-
+    if features.contains(wgt::Features::DUAL_SOURCE_BLENDING) {
+        temp.push(native::WGPUFeatureName_DualSourceBlending);
+    }
     // wgpu-rs only features
     if features.contains(wgt::Features::PUSH_CONSTANTS) {
         temp.push(native::WGPUNativeFeature_PushConstants);
@@ -1227,7 +1233,10 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUFeatureName_ShaderF16 => Some(Features::SHADER_F16),
         native::WGPUFeatureName_RG11B10UfloatRenderable => Some(Features::RG11B10UFLOAT_RENDERABLE),
         native::WGPUFeatureName_BGRA8UnormStorage => Some(Features::BGRA8UNORM_STORAGE),
+        // TODO: WGPUFeatureName_ClipDistances
+        // TODO: WGPUFeatureName_Float32Blendable
         native::WGPUFeatureName_Float32Filterable => Some(Features::FLOAT32_FILTERABLE),
+        native::WGPUFeatureName_DualSourceBlending => Some(Features::DUAL_SOURCE_BLENDING),
 
         // wgpu-rs only features
         native::WGPUNativeFeature_PushConstants => Some(Features::PUSH_CONSTANTS),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1008,21 +1008,13 @@ pub unsafe extern "C" fn wgpuBufferMapAsync(
         callback: Some(wgc::resource::BufferMapCallback::from_rust(Box::new(
             move |result: resource::BufferAccessResult| {
                 let (status, message) = match result {
-                    Ok(()) => (native::WGPUBufferMapAsyncStatus_Success, CString::default()),
+                    Ok(()) => (native::WGPUMapAsyncStatus_Success, CString::default()),
                     Err(cause) => {
                         let code = match cause {
-                            resource::BufferAccessError::Device(_) => {
-                                native::WGPUBufferMapAsyncStatus_DeviceLost
+                            resource::BufferAccessError::MapAborted => {
+                                native::WGPUMapAsyncStatus_Aborted
                             }
-                            resource::BufferAccessError::MapAlreadyPending => {
-                                native::WGPUBufferMapAsyncStatus_MappingAlreadyPending
-                            }
-                            resource::BufferAccessError::InvalidBufferId(_)
-                            | resource::BufferAccessError::DestroyedResource(_) => {
-                                native::WGPUBufferMapAsyncStatus_DestroyedBeforeCallback
-                            }
-                            _ => native::WGPUBufferMapAsyncStatus_ValidationError, // TODO: WGPUBufferMapAsyncStatus_OffsetOutOfRange
-                                                                                   // TODO: WGPUBufferMapAsyncStatus_SizeOutOfRange
+                            _ => native::WGPUMapAsyncStatus_Error,
                         };
 
                         (code, CString::new(format_error(&cause)).unwrap())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -650,15 +650,17 @@ pub unsafe extern "C" fn wgpuCreateInstance(
 ) -> native::WGPUInstance {
     let instance_desc = match descriptor {
         Some(descriptor) => {
-            if descriptor.features.timedWaitAnyEnable != 0 || descriptor.features.timedWaitAnyMaxCount > 0 {
+            if descriptor.features.timedWaitAnyEnable != 0
+                || descriptor.features.timedWaitAnyMaxCount > 0
+            {
                 panic!("Unsupported timed WaitAny features specified");
             }
 
             follow_chain!(map_instance_descriptor(
-                    (descriptor),
-                    WGPUSType_InstanceExtras => native::WGPUInstanceExtras
-                ))
-        },
+                (descriptor),
+                WGPUSType_InstanceExtras => native::WGPUInstanceExtras
+            ))
+        }
         None => wgt::InstanceDescriptor::default(),
     };
 
@@ -676,7 +678,7 @@ pub unsafe extern "C" fn wgpuGetInstanceFeatures(
         nextInChain: std::ptr::null_mut(),
         // WaitAny is currently completely unsupported, so...
         timedWaitAnyEnable: false as native::WGPUBool,
-        timedWaitAnyMaxCount: 0
+        timedWaitAnyMaxCount: 0,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4357,7 +4357,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModuleSpirV(
     let descriptor = descriptor.expect("invalid descriptor");
 
     let desc = wgc::pipeline::ShaderModuleDescriptor {
-        label: ptr_into_label(descriptor.label),
+        label: string_view_into_label(descriptor.label),
         shader_bound_checks: unsafe { wgt::ShaderBoundChecks::unchecked() },
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -715,7 +715,7 @@ fn return_features(native: &mut native::WGPUSupportedFeatures, features: wgt::Fe
 #[no_mangle]
 pub unsafe extern "C" fn wgpuAdapterGetLimits(
     adapter: native::WGPUAdapter,
-    limits: Option<&mut native::WGPUSupportedLimits>,
+    limits: Option<&mut native::WGPULimits>,
 ) -> native::WGPUBool {
     let (adapter_id, context) = {
         let adapter = adapter.as_ref().expect("invalid adapter");
@@ -2572,7 +2572,7 @@ pub unsafe extern "C" fn wgpuSupportedFeaturesFreeMembers(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuDeviceGetLimits(
     device: native::WGPUDevice,
-    limits: Option<&mut native::WGPUSupportedLimits>,
+    limits: Option<&mut native::WGPULimits>,
 ) -> native::WGPUBool {
     let (device_id, context) = {
         let device = device.as_ref().expect("invalid device");

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,7 +1,6 @@
-use crate::{map_enum, native};
+use crate::{map_enum, native, utils};
 use log::{Level, LevelFilter, Metadata, Record};
 use parking_lot::RwLock;
-use std::ffi::CString;
 
 #[no_mangle]
 pub extern "C" fn wgpuGetVersion() -> std::os::raw::c_uint {
@@ -40,7 +39,6 @@ impl log::Log for Logger {
 
         if let Some(callback) = logger.callback {
             let msg = record.args().to_string();
-            let msg_c = CString::new(msg).unwrap();
             let level = match record.level() {
                 Level::Error => native::WGPULogLevel_Error,
                 Level::Warn => native::WGPULogLevel_Warn,
@@ -50,7 +48,7 @@ impl log::Log for Logger {
             };
 
             unsafe {
-                callback(level, msg_c.as_ptr(), logger.userdata);
+                callback(level, utils::str_into_string_view(&msg), logger.userdata);
             }
 
             // We do not use std::mem::forget(msg_c), so Rust will reclaim the memory

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -2,7 +2,6 @@ use crate::native;
 
 #[no_mangle]
 pub extern "C" fn wgpuGetProcAddress(
-    _device: native::WGPUDevice,
     _proc_name: *const ::std::os::raw::c_char,
 ) -> native::WGPUProc {
     unimplemented!();
@@ -73,9 +72,8 @@ pub extern "C" fn wgpuComputePipelineSetLabel(
 pub extern "C" fn wgpuDeviceCreateComputePipelineAsync(
     _device: native::WGPUDevice,
     _descriptor: *const native::WGPUComputePipelineDescriptor,
-    _callback: native::WGPUDeviceCreateComputePipelineAsyncCallback,
-    _userdata: *mut ::std::os::raw::c_void,
-) {
+    _callback: native::WGPUCreateComputePipelineAsyncCallbackInfo,
+) -> native::WGPUFuture {
     unimplemented!();
 }
 
@@ -83,9 +81,8 @@ pub extern "C" fn wgpuDeviceCreateComputePipelineAsync(
 pub extern "C" fn wgpuDeviceCreateRenderPipelineAsync(
     _device: native::WGPUDevice,
     _descriptor: *const native::WGPURenderPipelineDescriptor,
-    _callback: native::WGPUDeviceCreateRenderPipelineAsyncCallback,
-    _userdata: *mut ::std::os::raw::c_void,
-) {
+    _callback: native::WGPUCreateRenderPipelineAsyncCallbackInfo,
+) -> native::WGPUFuture {
     unimplemented!();
 }
 
@@ -177,9 +174,8 @@ pub extern "C" fn wgpuSamplerSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuShaderModuleGetCompilationInfo(
     _shader_module: native::WGPUShaderModule,
-    _callback: native::WGPUShaderModuleGetCompilationInfoCallback,
-    _userdata: *mut ::std::os::raw::c_void,
-) {
+    _callback: native::WGPUCompilationInfoCallbackInfo,
+) -> native::WGPUFuture {
     unimplemented!();
 }
 
@@ -212,5 +208,15 @@ pub extern "C" fn wgpuTextureViewSetLabel(
     _texture_view: native::WGPUTextureView,
     _label: *const ::std::os::raw::c_char,
 ) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuInstanceWaitAny(
+    _instance: native::WGPUInstance,
+    _future_count: usize,
+    _futures: *mut native::WGPUFutureWaitInfo,
+    _timeout_ns: u64,
+) -> native::WGPUWaitStatus {
     unimplemented!();
 }

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -1,16 +1,14 @@
 use crate::native;
 
 #[no_mangle]
-pub extern "C" fn wgpuGetProcAddress(
-    _proc_name: *const ::std::os::raw::c_char,
-) -> native::WGPUProc {
+pub extern "C" fn wgpuGetProcAddress(_proc_name: native::WGPUStringView) -> native::WGPUProc {
     unimplemented!();
 }
 
 #[no_mangle]
 pub extern "C" fn wgpuBindGroupSetLabel(
     _bind_group: native::WGPUBindGroup,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -18,7 +16,7 @@ pub extern "C" fn wgpuBindGroupSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuBindGroupLayoutSetLabel(
     _bind_group_layout: native::WGPUBindGroupLayout,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -29,17 +27,14 @@ pub extern "C" fn wgpuBufferGetMapState(_buffer: native::WGPUBuffer) -> native::
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuBufferSetLabel(
-    _buffer: native::WGPUBuffer,
-    _label: *const ::std::os::raw::c_char,
-) {
+pub extern "C" fn wgpuBufferSetLabel(_buffer: native::WGPUBuffer, _label: native::WGPUStringView) {
     unimplemented!();
 }
 
 #[no_mangle]
 pub extern "C" fn wgpuCommandBufferSetLabel(
     _command_buffer: native::WGPUCommandBuffer,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -47,7 +42,7 @@ pub extern "C" fn wgpuCommandBufferSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuCommandEncoderSetLabel(
     _command_encoder: native::WGPUCommandEncoder,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -55,7 +50,7 @@ pub extern "C" fn wgpuCommandEncoderSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuComputePassEncoderSetLabel(
     _compute_pass_encoder: native::WGPUComputePassEncoder,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -63,7 +58,7 @@ pub extern "C" fn wgpuComputePassEncoderSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuComputePipelineSetLabel(
     _compute_pipeline: native::WGPUComputePipeline,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -87,10 +82,7 @@ pub extern "C" fn wgpuDeviceCreateRenderPipelineAsync(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuDeviceSetLabel(
-    _device: native::WGPUDevice,
-    _label: *const ::std::os::raw::c_char,
-) {
+pub extern "C" fn wgpuDeviceSetLabel(_device: native::WGPUDevice, _label: native::WGPUStringView) {
     unimplemented!();
 }
 
@@ -110,7 +102,7 @@ pub extern "C" fn wgpuInstanceProcessEvents(_instance: native::WGPUInstance) {
 #[no_mangle]
 pub extern "C" fn wgpuPipelineLayoutSetLabel(
     _pipeline_layout: native::WGPUPipelineLayout,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -118,23 +110,20 @@ pub extern "C" fn wgpuPipelineLayoutSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuQuerySetSetLabel(
     _query_set: native::WGPUQuerySet,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuQueueSetLabel(
-    _queue: native::WGPUQueue,
-    _label: *const ::std::os::raw::c_char,
-) {
+pub extern "C" fn wgpuQueueSetLabel(_queue: native::WGPUQueue, _label: native::WGPUStringView) {
     unimplemented!();
 }
 
 #[no_mangle]
 pub extern "C" fn wgpuRenderBundleSetLabel(
     _render_bundle: native::WGPURenderBundle,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -142,7 +131,7 @@ pub extern "C" fn wgpuRenderBundleSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuRenderBundleEncoderSetLabel(
     _render_bundle_encoder: native::WGPURenderBundleEncoder,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -150,7 +139,7 @@ pub extern "C" fn wgpuRenderBundleEncoderSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuRenderPassEncoderSetLabel(
     _render_pass_encoder: native::WGPURenderPassEncoder,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -158,7 +147,7 @@ pub extern "C" fn wgpuRenderPassEncoderSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuRenderPipelineSetLabel(
     _render_pipeline: native::WGPURenderPipeline,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -166,7 +155,7 @@ pub extern "C" fn wgpuRenderPipelineSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuSamplerSetLabel(
     _sampler: native::WGPUSampler,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -182,7 +171,7 @@ pub extern "C" fn wgpuShaderModuleGetCompilationInfo(
 #[no_mangle]
 pub extern "C" fn wgpuShaderModuleSetLabel(
     _shader_module: native::WGPUShaderModule,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -190,7 +179,7 @@ pub extern "C" fn wgpuShaderModuleSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuSurfaceSetLabel(
     _surface: native::WGPUSurface,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -198,7 +187,7 @@ pub extern "C" fn wgpuSurfaceSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuTextureSetLabel(
     _texture: native::WGPUTexture,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -206,7 +195,7 @@ pub extern "C" fn wgpuTextureSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuTextureViewSetLabel(
     _texture_view: native::WGPUTextureView,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -278,14 +278,12 @@ pub unsafe fn string_view_into_str<'a>(string_view: native::WGPUStringView) -> O
             _ => panic!("Null address to WGPUStringView!"),
         }
     } else {
-        unsafe {
-            let bytes = match string_view.length {
-                crate::conv::WGPU_STRLEN => CStr::from_ptr(string_view.data).to_bytes(),
-                _ => make_slice(string_view.data as *const u8, string_view.length),
-            };
+        let bytes = match string_view.length {
+            crate::conv::WGPU_STRLEN => CStr::from_ptr(string_view.data).to_bytes(),
+            _ => make_slice(string_view.data as *const u8, string_view.length),
+        };
 
-            Some(std::str::from_utf8_unchecked(bytes))
-        }
+        Some(std::str::from_utf8_unchecked(bytes))
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -166,7 +166,7 @@ macro_rules! follow_chain {
             $(
                 let mut $stype: Option<&$ty> = None;
             )*
-            let mut chain_opt: Option<&$crate::native::WGPUChainedStruct> = $base1.nextInChain.as_ref();
+            let mut chain_opt: Option<&$crate::native::WGPUChainedStruct> = ($base1.nextInChain as *const $crate::native::WGPUChainedStruct).as_ref();
             while let Some(next_in_chain) = chain_opt {
                 match next_in_chain.sType {
                     $(


### PR DESCRIPTION
This goes up to https://github.com/webgpu-native/webgpu-headers/commit/6f549cc3409663303b06f50483b9ebf9d1cf19dd
Things I *didn't* do:

* I didn't update the library to make sure "instance dropped" callback error codes are guaranteed to happen, like they seem to be in Dawn.

List of changes (roughly in order of header commits):

* Various enum and struct renames
* Updated callbacks to use the new `*CallbackInfo` structs and 2-userdata system. Also updated functions to return `WGPUFuture`, though the `WGPUFuture` thing is just stubbed out at the moment as I don't think wgpu-core has the necessary functionality for it. `wgpuInstanceWaitAny` is `unimplemented!()`
* `DepthClipControl` merged into `PrimitiveState`, related code simplified.
* Updated `depthWriteEnabled` to use an optional bool, mostly matters due to added validation.
* Add TODOs for missing features (sliced 3D compressed textures)
* `*Reference()` became `*AddRef()`
* Added `unorm10-10-10-2` vertex format
* Usage field in `TextureViewDescriptor`, just used for validation as wgpu-core doesn't allow specifying it anyways.
* Removed `maxInterStageShaderComponents`
* Added `clang_macro_fallback()` to bindgen config, since the headers switched to using `UINT32_MAX` etc. `UINT64_MAX` still doesn't work so I had to manually define those.
* Renamed flags enums. Added a conversion helper function to convert them from u64 -> u32 for mapping. (means added direct dependency on bitflags crate)
* Removed device argument from (unimplemented) `wgpuGetProcAddress`
* Suboptimal surface texture acquisition moved to enum return value, was easy since wgpu-core already returns it like that.
* "Undefined" present mode added, it just selects FIFO.
* `*EnumerateFeatures()` has been replaced with `*GetFeatures()`.
* All strings are now passed as `WGPUStringView`.