### PR TITLE
Expose SPIRV_SHADER_PASSTHROUGH native feature.

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -43,7 +43,7 @@ typedef enum WGPUNativeFeature {
     // WGPUNativeFeature_PolygonModePoint = 0x00030014,
     // WGPUNativeFeature_ConservativeRasterization = 0x00030015,
     // WGPUNativeFeature_ClearTexture = 0x00030016,
-    // WGPUNativeFeature_SpirvShaderPassthrough = 0x00030017,
+    WGPUNativeFeature_SpirvShaderPassthrough = 0x00030017,
     // WGPUNativeFeature_Multiview = 0x00030018,
     WGPUNativeFeature_VertexAttribute64bit = 0x00030019,
     WGPUNativeFeature_TextureFormatNv12 = 0x0003001A,
@@ -182,6 +182,12 @@ typedef struct WGPUShaderModuleGLSLDescriptor {
     WGPUShaderDefine * defines;
 } WGPUShaderModuleGLSLDescriptor;
 
+typedef struct WGPUShaderModuleDescriptorSpirV {
+    char const * label;
+    uint32_t sourceSize;
+    uint32_t const * source;
+} WGPUShaderModuleDescriptorSpirV;
+
 typedef struct WGPURegistryReport {
    size_t numAllocated;
    size_t numKeptFromUser;
@@ -274,6 +280,7 @@ WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, size_t commandCount
 
 // Returns true if the queue is empty, or false if there are more queue submissions still in flight.
 WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUWrappedSubmissionIndex const * wrappedSubmissionIndex);
+WGPUShaderModule wgpuDeviceCreateShaderModuleSpirV(WGPUDevice device, WGPUShaderModuleDescriptorSpirV const * descriptor);
 
 void wgpuSetLogCallback(WGPULogCallback callback, void * userdata);
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1187,9 +1187,9 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     // if features.contains(wgt::Features::CLEAR_TEXTURE) {
     //     temp.push(native::WGPUNativeFeature_ClearTexture);
     // }
-    // if features.contains(wgt::Features::SPIRV_SHADER_PASSTHROUGH) {
-    //     temp.push(native::WGPUNativeFeature_SpirvShaderPassthrough);
-    // }
+    if features.contains(wgt::Features::SPIRV_SHADER_PASSTHROUGH) {
+        temp.push(native::WGPUNativeFeature_SpirvShaderPassthrough);
+    }
     // if features.contains(wgt::Features::MULTIVIEW) {
     //     temp.push(native::WGPUNativeFeature_Multiview);
     // }
@@ -1264,7 +1264,7 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         // native::WGPUNativeFeature_PolygonModePoint => Some(Features::POLYGON_MODE_POINT),
         // native::WGPUNativeFeature_ConservativeRasterization => Some(Features::CONSERVATIVE_RASTERIZATION),
         // native::WGPUNativeFeature_ClearTexture => Some(Features::CLEAR_TEXTURE),
-        // native::WGPUNativeFeature_SpirvShaderPassthrough => Some(Features::SPIRV_SHADER_PASSTHROUGH),
+        native::WGPUNativeFeature_SpirvShaderPassthrough => Some(Features::SPIRV_SHADER_PASSTHROUGH),
         // native::WGPUNativeFeature_Multiview => Some(Features::MULTIVIEW),
         native::WGPUNativeFeature_VertexAttribute64bit => Some(Features::VERTEX_ATTRIBUTE_64BIT),
         native::WGPUNativeFeature_TextureFormatNv12 => Some(Features::TEXTURE_FORMAT_NV12),


### PR DESCRIPTION
I needed this feature in my project, so i decided to add the bindings.

I don't write rust, so i just copied the existing code for `wgpuDeviceCreateShaderModule` and edited it as needed. The wiki was missing info about the generating glue code but i figure out that modifying `wgpu.h` was enough to generate what was needed. I tested the code on my C++ project by replacing a wgsl grid shader with glsl and didn't encounter any problems. Hopefully, i haven't forgotten anything.