### PR TITLE
expose SUBGROUP, SUBGROUP_VERTEX, SUBGROUP_BARRIER native features

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -53,6 +53,9 @@ typedef enum WGPUNativeFeature {
     WGPUNativeFeature_ShaderI16 = 0x0003001E,
     WGPUNativeFeature_ShaderPrimitiveIndex = 0x0003001F,
     WGPUNativeFeature_ShaderEarlyDepthTest = 0x00030020,
+    WGPUNativeFeature_Subgroup = 0x00030021,
+    WGPUNativeFeature_SubgroupVertex = 0x00030022,
+    WGPUNativeFeature_SubgroupBarrier = 0x00030023,
     WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1217,6 +1217,15 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::SHADER_EARLY_DEPTH_TEST) {
         temp.push(native::WGPUNativeFeature_ShaderEarlyDepthTest);
     }
+    if features.contains(wgt::Features::SUBGROUP) {
+        temp.push(native::WGPUNativeFeature_Subgroup);
+    }
+    if features.contains(wgt::Features::SUBGROUP_VERTEX) {
+        temp.push(native::WGPUNativeFeature_SubgroupVertex);
+    }
+    if features.contains(wgt::Features::SUBGROUP_BARRIER) {
+        temp.push(native::WGPUNativeFeature_SubgroupBarrier);
+    }
 
     temp
 }
@@ -1273,6 +1282,9 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUNativeFeature_ShaderF64 => Some(Features::SHADER_F64),
         native::WGPUNativeFeature_ShaderPrimitiveIndex => Some(Features::SHADER_PRIMITIVE_INDEX),
         native::WGPUNativeFeature_ShaderEarlyDepthTest => Some(Features::SHADER_EARLY_DEPTH_TEST),
+        native::WGPUNativeFeature_Subgroup => Some(Features::SUBGROUP),
+        native::WGPUNativeFeature_SubgroupVertex => Some(Features::SUBGROUP_VERTEX),
+        native::WGPUNativeFeature_SubgroupBarrier => Some(Features::SUBGROUP_BARRIER),
         // fallback, probably not available in wgpu-core
         _ => None,
     }


### PR DESCRIPTION
Simply pass these constants thru

Test Plan

use the following shader

```
@compute
@workgroup_size(32)
fn main(
    @builtin(global_invocation_id) global_id: vec3<u32>,
    @builtin(subgroup_size) subgroup_size: u32,
    @builtin(subgroup_invocation_id) subgroup_invocation_id: u32,
    ) {
    let x = subgroup_size;
    let id = subgroup_invocation_id;

    // requires SUBGROUP
    subgroupAny(true);
    subgroupBallot(true);
    subgroupMax(5);
    
    // requires SUBGROUP_BARRIER
    subgroupBarrier();
}


@vertex
fn vertex_main() -> @builtin(position) vec4<f32> {
    // requires SUBGROUP_VERTEX
    subgroupAny(true);
    
    // Not allowed even with SubgroupBarrier & SubgroupVertex
    // subgroupBarrier();
    
    return vec4<f32>(0.0, 0.0, 0.0, 0.0);
}
```

use a main.c that compiles requires all the SUBGROUP features and loads this shader.  Verify that removing various features causes expected shader complication errors