### PR TITLE
Complete Timestamp Query feature implementation

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -31,8 +31,6 @@ typedef enum WGPUNativeFeature {
     WGPUNativeFeature_PartiallyBoundBindingArray = 0x0003000A,
     WGPUNativeFeature_TextureFormat16bitNorm = 0x0003000B,
     WGPUNativeFeature_TextureCompressionAstcHdr = 0x0003000C,
-    // TODO: requires wgpu.h api change
-    // WGPUNativeFeature_TimestampQueryInsidePasses = 0x0003000D,
     WGPUNativeFeature_MappablePrimaryBuffers = 0x0003000E,
     WGPUNativeFeature_BufferBindingArray = 0x0003000F,
     WGPUNativeFeature_UniformBufferAndStorageTextureArrayNonUniformIndexing = 0x00030010,
@@ -56,6 +54,8 @@ typedef enum WGPUNativeFeature {
     WGPUNativeFeature_Subgroup = 0x00030021,
     WGPUNativeFeature_SubgroupVertex = 0x00030022,
     WGPUNativeFeature_SubgroupBarrier = 0x00030023,
+    WGPUNativeFeature_TimestampQueryInsideEncoders = 0x00030024,
+    WGPUNativeFeature_TimestampQueryInsidePasses = 0x00030025,
     WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 
@@ -296,6 +296,9 @@ void wgpuComputePassEncoderBeginPipelineStatisticsQuery(WGPUComputePassEncoder c
 void wgpuComputePassEncoderEndPipelineStatisticsQuery(WGPUComputePassEncoder computePassEncoder);
 void wgpuRenderPassEncoderBeginPipelineStatisticsQuery(WGPURenderPassEncoder renderPassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
 void wgpuRenderPassEncoderEndPipelineStatisticsQuery(WGPURenderPassEncoder renderPassEncoder);
+
+void wgpuComputePassEncoderWriteTimestamp(WGPUComputePassEncoder computePassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
+void wgpuRenderPassEncoderWriteTimestamp(WGPURenderPassEncoder renderPassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1153,10 +1153,12 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::TEXTURE_COMPRESSION_ASTC_HDR) {
         temp.push(native::WGPUNativeFeature_TextureCompressionAstcHdr);
     }
-    // TODO: requires wgpu.h api change
-    // if features.contains(wgt::Features::TIMESTAMP_QUERY_INSIDE_PASSES) {
-    //     temp.push(native::WGPUNativeFeature_TimestampQueryInsidePasses);
-    // }
+    if features.contains(wgt::Features::TIMESTAMP_QUERY_INSIDE_PASSES) {
+        temp.push(native::WGPUNativeFeature_TimestampQueryInsidePasses);
+    }
+    if features.contains(wgt::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS) {
+        temp.push(native::WGPUNativeFeature_TimestampQueryInsideEncoders);
+    }
     if features.contains(wgt::Features::MAPPABLE_PRIMARY_BUFFERS) {
         temp.push(native::WGPUNativeFeature_MappablePrimaryBuffers);
     }
@@ -1261,8 +1263,8 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUNativeFeature_PartiallyBoundBindingArray => Some(Features::PARTIALLY_BOUND_BINDING_ARRAY),
         native::WGPUNativeFeature_TextureFormat16bitNorm => Some(Features::TEXTURE_FORMAT_16BIT_NORM),
         native::WGPUNativeFeature_TextureCompressionAstcHdr => Some(Features::TEXTURE_COMPRESSION_ASTC_HDR),
-        // TODO: requires wgpu.h api change
-        // native::WGPUNativeFeature_TimestampQueryInsidePasses => Some(Features::TIMESTAMP_QUERY_INSIDE_PASSES),
+        native::WGPUNativeFeature_TimestampQueryInsidePasses => Some(Features::TIMESTAMP_QUERY_INSIDE_PASSES),
+        native::WGPUNativeFeature_TimestampQueryInsideEncoders => Some(Features::TIMESTAMP_QUERY_INSIDE_ENCODERS),
         native::WGPUNativeFeature_MappablePrimaryBuffers => Some(Features::MAPPABLE_PRIMARY_BUFFERS),
         native::WGPUNativeFeature_BufferBindingArray => Some(Features::BUFFER_BINDING_ARRAY),
         native::WGPUNativeFeature_UniformBufferAndStorageTextureArrayNonUniformIndexing => Some(Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4442,3 +4442,45 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderEndPipelineStatisticsQuery(
         ),
     }
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuComputePassEncoderWriteTimestamp(
+    pass: native::WGPUComputePassEncoder,
+    query_set: native::WGPUQuerySet,
+    query_index: u32,
+) {
+    let pass = pass.as_ref().expect("invalid compute pass");
+    let query_set_id = query_set.as_ref().expect("invalid query set").id;
+    let encoder = pass.encoder.as_mut().unwrap();
+
+    match encoder.write_timestamp(&pass.context, query_set_id, query_index) {
+        Ok(()) => (),
+        Err(cause) => handle_error(
+            &pass.error_sink,
+            cause,
+            None,
+            "wgpuComputePassEncoderWriteTimestamp",
+        ),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuRenderPassEncoderWriteTimestamp(
+    pass: native::WGPURenderPassEncoder,
+    query_set: native::WGPUQuerySet,
+    query_index: u32,
+) {
+    let pass = pass.as_ref().expect("invalid render pass");
+    let query_set_id = query_set.as_ref().expect("invalid query set").id;
+    let encoder = pass.encoder.as_mut().unwrap();
+
+    match encoder.write_timestamp(&pass.context, query_set_id, query_index) {
+        Ok(()) => (),
+        Err(cause) => handle_error(
+            &pass.error_sink,
+            cause,
+            None,
+            "wgpuRenderPassEncoderWriteTimestamp",
+        ),
+    }
+}


### PR DESCRIPTION
Expose the two subfeatures as native features.  If these feature definitions move to upstream webgpu.h in the future, it should be a trivial change to change from a native to standard feature.

## Test Plan
Verify timestamp writes work in the following cases/apis:
✅Compute pipeline creation `timestampWrites` (`WGPUFeature_TimestampQuery`)
✅wgpuCommandEncoderWriteTimestamp (`WGPUNativeFeature_TimestampQueryInsideEncoders`)
✅wgpuComputePassEncoderWriteTimestamp (`WGPUNativeFeature_TimestampQueryInsidePasses`)

output
```
query time: 7872 ns
copy time: 7168 ns
inter pass time: 2080 ns
```

modified `examples/compute/main.c`
```
// [...]

static const uint32_t ENCODER_QUERY_START = 0;
static const uint32_t ENCODER_QUERY_END = 1;
static const uint32_t COMPUTE_PASS_QUERY_START = 2;
static const uint32_t COMPUTE_PASS_QUERY_END = 3;
static const uint32_t INTER_PASS_QUERY_START = 4;
static const uint32_t INTER_PASS_QUERY_END = 5;
static const uint32_t QUERY_COUNT = 6;

int main(int argc, char *argv[]) {

// [...]

  WGPUQuerySet query_set = wgpuDeviceCreateQuerySet(device, &(const WGPUQuerySetDescriptor){
    .label = "query_set",
    .type = WGPUQueryType_Timestamp,
    .count = QUERY_COUNT,
  });
  assert(query_set);
  
  uint64_t query_buffer_size = QUERY_COUNT * sizeof(uint64_t);
  WGPUBuffer query_buffer = wgpuDeviceCreateBuffer(
      device, &(const WGPUBufferDescriptor){
                  .label = "query_buffer",
                  .usage = WGPUBufferUsage_QueryResolve | WGPUBufferUsage_CopySrc,
                  .size = query_buffer_size,
                  .mappedAtCreation = false,
              });
  assert(query_buffer);

  uint64_t storage_buffer_size = numbers_size;
  WGPUBuffer storage_buffer = wgpuDeviceCreateBuffer(
      device, &(const WGPUBufferDescriptor){
                  .label = "storage_buffer",
                  .usage = WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst |
                           WGPUBufferUsage_CopySrc,
                  .size = storage_buffer_size,
                  .mappedAtCreation = false,
              });
  assert(storage_buffer);

  uint64_t staging_buffer_size = storage_buffer_size + query_buffer_size;
  WGPUBuffer staging_buffer = wgpuDeviceCreateBuffer(
      device, &(const WGPUBufferDescriptor){
                  .label = "staging_buffer",
                  .usage = WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst,
                  .size = staging_buffer_size,
                  .mappedAtCreation = false,
              });
  assert(staging_buffer);

// [...]

  WGPUCommandEncoder command_encoder = wgpuDeviceCreateCommandEncoder(
      device, &(const WGPUCommandEncoderDescriptor){
                  .label = "command_encoder",
              });
  assert(command_encoder);

  WGPUComputePassTimestampWrites timestamp_writes = {
    .querySet = query_set,
    .beginningOfPassWriteIndex = COMPUTE_PASS_QUERY_START,
    .endOfPassWriteIndex = COMPUTE_PASS_QUERY_END,
  };
  WGPUComputePassEncoder compute_pass_encoder =
      wgpuCommandEncoderBeginComputePass(command_encoder,
                                         &(const WGPUComputePassDescriptor){
                                             .label = "compute_pass",
                                             .timestampWrites = &timestamp_writes,
                                         });
  assert(compute_pass_encoder);
  
  wgpuComputePassEncoderWriteTimestamp(compute_pass_encoder, query_set, INTER_PASS_QUERY_START);

  wgpuComputePassEncoderSetPipeline(compute_pass_encoder, compute_pipeline);
  wgpuComputePassEncoderSetBindGroup(compute_pass_encoder, 0, bind_group, 0,
                                     NULL);

  wgpuComputePassEncoderWriteTimestamp(compute_pass_encoder, query_set, INTER_PASS_QUERY_END);

  wgpuComputePassEncoderDispatchWorkgroups(compute_pass_encoder, numbers_length, 1, 1);

  wgpuComputePassEncoderEnd(compute_pass_encoder);
  wgpuComputePassEncoderRelease(compute_pass_encoder);
  
  wgpuCommandEncoderWriteTimestamp(command_encoder, query_set, ENCODER_QUERY_START);

  wgpuCommandEncoderCopyBufferToBuffer(command_encoder, storage_buffer, 0,
                                       staging_buffer, 0, numbers_size);
  
  wgpuCommandEncoderWriteTimestamp(command_encoder, query_set, ENCODER_QUERY_END);
  
  wgpuCommandEncoderResolveQuerySet(command_encoder, query_set, 0, QUERY_COUNT, query_buffer, 0);
  wgpuCommandEncoderCopyBufferToBuffer(command_encoder, query_buffer, 0,
      staging_buffer, numbers_size, query_buffer_size);

// [...]

  uint32_t *buf =
      (uint32_t *)wgpuBufferGetMappedRange(staging_buffer, 0, numbers_size);
  assert(buf);
  uint64_t *query_buf = (uint64_t *)wgpuBufferGetMappedRange(staging_buffer, numbers_size, query_buffer_size);
  assert(query_buf);

  printf("times: [%d, %d, %d, %d]\n", buf[0], buf[1], buf[2], buf[3]);
  printf("compute pass time: %ld ns\n", query_buf[COMPUTE_PASS_QUERY_END] - query_buf[COMPUTE_PASS_QUERY_START]);
  printf("inter pass time: %ld ns\n", query_buf[INTER_PASS_QUERY_END] - query_buf[INTER_PASS_QUERY_START]);
  printf("copy time: %ld ns\n", query_buf[ENCODER_QUERY_END] - query_buf[ENCODER_QUERY_START]);

// [...]
}
```