### PR TITLE
Upgrade to latest webgpu headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,6 +1025,7 @@ name = "wgpu-native"
 version = "0.0.0"
 dependencies = [
  "bindgen",
+ "bitflags 2.6.0",
  "log",
  "naga",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,20 +129,6 @@ name = "bytemuck"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "cexpr"
@@ -507,6 +493,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "naga"
 version = "22.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2b15a2b24b69e105ebdbb5e8a859e2df75e441c1#2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -904,6 +891,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "22.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2b15a2b24b69e105ebdbb5e8a859e2df75e441c1#2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -929,6 +917,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "22.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2b15a2b24b69e105ebdbb5e8a859e2df75e441c1#2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -936,6 +925,7 @@ dependencies = [
  "bit-set",
  "bitflags 2.6.0",
  "block",
+ "bytemuck",
  "cfg_aliases",
  "core-graphics-types",
  "glow",
@@ -989,6 +979,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "22.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=2b15a2b24b69e105ebdbb5e8a859e2df75e441c1#2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bindgen"
@@ -79,23 +79,23 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
 name = "bit-set"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -126,9 +126,23 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "cexpr"
@@ -173,37 +187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "com"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
-dependencies = [
- "com_macros",
-]
-
-[[package]]
-name = "com_macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
-dependencies = [
- "com_macros_support",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "com_macros_support"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,16 +211,6 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "libc",
-]
-
-[[package]]
-name = "d3d12"
-version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v22.1.0#5c5c8b1d4d2d965fbd10b290ee26f4e7eb158d7c"
-dependencies = [
- "bitflags 2.6.0",
- "libloading",
- "winapi",
 ]
 
 [[package]]
@@ -285,7 +258,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -313,9 +286,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "glow"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -353,14 +326,13 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd4240fc91d3433d5e5b0fc5b67672d771850dc19bbee03c1381e19322803d7"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
 dependencies = [
  "log",
  "presser",
  "thiserror",
- "winapi",
  "windows",
 ]
 
@@ -372,7 +344,7 @@ checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
  "bitflags 2.6.0",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -395,19 +367,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hassle-rs"
-version = "0.11.0"
+name = "hashbrown"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
-dependencies = [
- "bitflags 2.6.0",
- "com",
- "libc",
- "libloading",
- "thiserror",
- "widestring",
- "winapi",
-]
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hexf-parse"
@@ -417,12 +380,12 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -443,9 +406,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -469,9 +432,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libloading"
@@ -543,8 +506,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "naga"
-version = "22.1.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v22.1.0#5c5c8b1d4d2d965fbd10b290ee26f4e7eb158d7c"
+version = "22.0.0"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -594,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "parking_lot"
@@ -639,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "pp-rs"
@@ -665,14 +627,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -706,18 +668,18 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -727,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -738,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "renderdoc-sys"
@@ -762,22 +724,22 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
@@ -812,20 +774,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -843,41 +794,41 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"
@@ -887,9 +838,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -898,24 +849,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -923,28 +874,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -952,8 +903,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "22.1.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v22.1.0#5c5c8b1d4d2d965fbd10b290ee26f4e7eb158d7c"
+version = "22.0.0"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -979,7 +929,6 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v22.1.0#5c5c8b1d4d2d965fbd10b290ee26f4e7eb158d7c"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -989,13 +938,11 @@ dependencies = [
  "block",
  "cfg_aliases",
  "core-graphics-types",
- "d3d12",
  "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hassle-rs",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -1017,7 +964,8 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "winapi",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -1041,35 +989,12 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v22.1.0#5c5c8b1d4d2d965fbd10b290ee26f4e7eb158d7c"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",
  "serde",
  "web-sys",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -1081,16 +1006,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core",
  "windows-targets",
@@ -1098,10 +1017,55 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets",
 ]
 
@@ -1180,9 +1144,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a77ee7c0de333dcc6da69b177380a0b81e0dacfa4f7344c465a36871ee601"
+checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
 
 [[package]]
 name = "zerocopy"
@@ -1201,5 +1165,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "cexpr"
@@ -392,9 +392,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -493,7 +493,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "naga"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=2b15a2b24b69e105ebdbb5e8a859e2df75e441c1#2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
+source = "git+https://github.com/gfx-rs/wgpu?rev=947fcdf77ce9eed9927950181c595a0fe93fb0b3#947fcdf77ce9eed9927950181c595a0fe93fb0b3"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -825,9 +825,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -874,15 +874,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=2b15a2b24b69e105ebdbb5e8a859e2df75e441c1#2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
+source = "git+https://github.com/gfx-rs/wgpu?rev=947fcdf77ce9eed9927950181c595a0fe93fb0b3#947fcdf77ce9eed9927950181c595a0fe93fb0b3"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -917,7 +917,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=2b15a2b24b69e105ebdbb5e8a859e2df75e441c1#2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
+source = "git+https://github.com/gfx-rs/wgpu?rev=947fcdf77ce9eed9927950181c595a0fe93fb0b3#947fcdf77ce9eed9927950181c595a0fe93fb0b3"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=2b15a2b24b69e105ebdbb5e8a859e2df75e441c1#2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
+source = "git+https://github.com/gfx-rs/wgpu?rev=947fcdf77ce9eed9927950181c595a0fe93fb0b3#947fcdf77ce9eed9927950181c595a0fe93fb0b3"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,8 +492,8 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "naga"
-version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=947fcdf77ce9eed9927950181c595a0fe93fb0b3#947fcdf77ce9eed9927950181c595a0fe93fb0b3"
+version = "23.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v23.0.0#08c9d8c397a4d3943c53d66c077c85236ff11f46"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -711,18 +711,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -781,18 +781,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -890,8 +890,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=947fcdf77ce9eed9927950181c595a0fe93fb0b3#947fcdf77ce9eed9927950181c595a0fe93fb0b3"
+version = "23.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v23.0.0#08c9d8c397a4d3943c53d66c077c85236ff11f46"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -916,8 +916,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=947fcdf77ce9eed9927950181c595a0fe93fb0b3#947fcdf77ce9eed9927950181c595a0fe93fb0b3"
+version = "23.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v23.0.0#08c9d8c397a4d3943c53d66c077c85236ff11f46"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -978,8 +978,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=947fcdf77ce9eed9927950181c595a0fe93fb0b3#947fcdf77ce9eed9927950181c595a0fe93fb0b3"
+version = "23.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v23.0.0#08c9d8c397a4d3943c53d66c077c85236ff11f46"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,23 +22,19 @@ resolver = "2"
 
 [workspace.dependencies.wgc]
 package = "wgpu-core"
-git = "https://github.com/gfx-rs/wgpu"
-tag = "v22.1.0"
+path = "../wgpu/wgpu-core"
 
 [workspace.dependencies.wgt]
 package = "wgpu-types"
-git = "https://github.com/gfx-rs/wgpu"
-tag = "v22.1.0"
+path = "../wgpu/wgpu-types"
 
 [workspace.dependencies.hal]
 package = "wgpu-hal"
-git = "https://github.com/gfx-rs/wgpu"
-tag = "v22.1.0"
+path = "../wgpu/wgpu-hal"
 
 [workspace.dependencies.naga]
 package = "naga"
-git = "https://github.com/gfx-rs/wgpu"
-tag = "v22.1.0"
+path = "../wgpu/naga"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
@@ -134,9 +130,8 @@ hal = { workspace = true, features = ["renderdoc"] }
 
 [target.'cfg(windows)'.dependencies]
 hal = { workspace = true, features = [
-	"dxc_shader_compiler",
+	"dx12",
 	"renderdoc",
-	"windows_rs",
 ] }
 
 [dependencies.wgt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ log = "0.4"
 thiserror = "1"
 parking_lot = "0.12"
 smallvec = "1"
+bitflags = "2.6.0"
 
 [build-dependencies]
 bindgen = "0.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,19 +22,23 @@ resolver = "2"
 
 [workspace.dependencies.wgc]
 package = "wgpu-core"
-path = "../wgpu/wgpu-core"
+git = "https://github.com/gfx-rs/wgpu"
+rev = "2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
 
 [workspace.dependencies.wgt]
 package = "wgpu-types"
-path = "../wgpu/wgpu-types"
+git = "https://github.com/gfx-rs/wgpu"
+rev = "2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
 
 [workspace.dependencies.hal]
 package = "wgpu-hal"
-path = "../wgpu/wgpu-hal"
+git = "https://github.com/gfx-rs/wgpu"
+rev = "2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
 
 [workspace.dependencies.naga]
 package = "naga"
-path = "../wgpu/naga"
+git = "https://github.com/gfx-rs/wgpu"
+rev = "2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ log = "0.4"
 thiserror = "1"
 parking_lot = "0.12"
 smallvec = "1"
-bitflags = "2.6.0"
+bitflags = "2"
 
 [build-dependencies]
 bindgen = "0.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,22 +23,22 @@ resolver = "2"
 [workspace.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
+rev = "947fcdf77ce9eed9927950181c595a0fe93fb0b3"
 
 [workspace.dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
+rev = "947fcdf77ce9eed9927950181c595a0fe93fb0b3"
 
 [workspace.dependencies.hal]
 package = "wgpu-hal"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
+rev = "947fcdf77ce9eed9927950181c595a0fe93fb0b3"
 
 [workspace.dependencies.naga]
 package = "naga"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "2b15a2b24b69e105ebdbb5e8a859e2df75e441c1"
+rev = "947fcdf77ce9eed9927950181c595a0fe93fb0b3"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,22 +23,22 @@ resolver = "2"
 [workspace.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "947fcdf77ce9eed9927950181c595a0fe93fb0b3"
+tag = "v23.0.0"
 
 [workspace.dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "947fcdf77ce9eed9927950181c595a0fe93fb0b3"
+tag = "v23.0.0"
 
 [workspace.dependencies.hal]
 package = "wgpu-hal"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "947fcdf77ce9eed9927950181c595a0fe93fb0b3"
+tag = "v23.0.0"
 
 [workspace.dependencies.naga]
 package = "naga"
 git = "https://github.com/gfx-rs/wgpu"
-rev = "947fcdf77ce9eed9927950181c595a0fe93fb0b3"
+tag = "v23.0.0"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,8 @@ fn main() {
         .prepend_enum_name(false)
         .size_t_is_usize(true)
         .ignore_functions()
-        .layout_tests(true);
+        .layout_tests(true)
+        .clang_macro_fallback();
 
     for (old_name, new_name) in types_to_rename {
         let line = format!("pub type {old_name} = *const crate::{new_name};");

--- a/examples/capture/CMakeLists.txt
+++ b/examples/capture/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${CMAKE_SOURCE_DIR}/../ffi/webgpu-headers)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32 Propsys RuntimeObject)
 elseif(UNIX AND NOT APPLE)
     set(OS_LIBRARIES "-lm -ldl")
 elseif(APPLE)

--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -14,7 +14,7 @@ const size_t IMAGE_HEIGHT = 200;
 const size_t COPY_BYTES_PER_ROW_ALIGNMENT = 256;
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
-                                   WGPUAdapter adapter, char const *message,
+                                   WGPUAdapter adapter, WGPUStringView message,
                                    void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
@@ -22,7 +22,7 @@ static void handle_request_adapter(WGPURequestAdapterStatus status,
   *(WGPUAdapter *)userdata1 = adapter;
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
-                                  WGPUDevice device, char const *message,
+                                  WGPUDevice device, WGPUStringView message,
                                   void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
@@ -30,7 +30,7 @@ static void handle_request_device(WGPURequestDeviceStatus status,
   *(WGPUDevice *)userdata1 = device;
 }
 static void handle_buffer_map(WGPUMapAsyncStatus status, 
-                              char const *message,
+                              WGPUStringView message,
                               void *userdata1, void *userdata2) {
   UNUSED(message)
   UNUSED(userdata1)
@@ -99,7 +99,7 @@ int main(int argc, char *argv[]) {
 
   WGPUBuffer output_buffer = wgpuDeviceCreateBuffer(
       device, &(const WGPUBufferDescriptor){
-                  .label = "output_buffer",
+                  .label = {"output_buffer", WGPU_STRLEN},
                   .size = buffer_size,
                   .usage = WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst,
                   .mappedAtCreation = false,
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
   WGPUTexture texture = wgpuDeviceCreateTexture(
       device,
       &(const WGPUTextureDescriptor){
-          .label = "texture",
+          .label = {"texture", WGPU_STRLEN},
           .size = texture_extent,
           .mipLevelCount = 1,
           .sampleCount = 1,
@@ -129,13 +129,13 @@ int main(int argc, char *argv[]) {
 
   WGPUCommandEncoder command_encoder = wgpuDeviceCreateCommandEncoder(
       device, &(const WGPUCommandEncoderDescriptor){
-                  .label = "command_encoder",
+                  .label = {"command_encoder", WGPU_STRLEN},
               });
   assert(command_encoder);
 
   WGPURenderPassEncoder render_pass_encoder = wgpuCommandEncoderBeginRenderPass(
       command_encoder, &(const WGPURenderPassDescriptor){
-                           .label = "rende_pass_encoder",
+                           .label = {"rende_pass_encoder", WGPU_STRLEN},
                            .colorAttachmentCount = 1,
                            .colorAttachments =
                                (const WGPURenderPassColorAttachment[]){
@@ -180,7 +180,7 @@ int main(int argc, char *argv[]) {
 
   WGPUCommandBuffer command_buffer = wgpuCommandEncoderFinish(
       command_encoder, &(const WGPUCommandBufferDescriptor){
-                           .label = "command_buffer",
+                           .label = {"command_buffer", WGPU_STRLEN},
                        });
   assert(command_buffer);
 

--- a/examples/capture/main.c
+++ b/examples/capture/main.c
@@ -29,7 +29,7 @@ static void handle_request_device(WGPURequestDeviceStatus status,
   UNUSED(userdata2)
   *(WGPUDevice *)userdata1 = device;
 }
-static void handle_buffer_map(WGPUBufferMapAsyncStatus status, 
+static void handle_buffer_map(WGPUMapAsyncStatus status, 
                               char const *message,
                               void *userdata1, void *userdata2) {
   UNUSED(message)

--- a/examples/compute/CMakeLists.txt
+++ b/examples/compute/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(${CMAKE_SOURCE_DIR}/../ffi/webgpu-headers)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32 Propsys RuntimeObject)
 elseif(UNIX AND NOT APPLE)
     set(OS_LIBRARIES "-lm -ldl")
 elseif(APPLE)

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -8,20 +8,25 @@
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
                                    WGPUAdapter adapter, char const *message,
-                                   void *userdata) {
+                                   void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
-  *(WGPUAdapter *)userdata = adapter;
+  UNUSED(userdata2)
+  *(WGPUAdapter *)userdata1 = adapter;
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
                                   WGPUDevice device, char const *message,
-                                  void *userdata) {
+                                  void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
-  *(WGPUDevice *)userdata = device;
+  UNUSED(userdata2)
+  *(WGPUDevice *)userdata1 = device;
 }
-static void handle_buffer_map(WGPUBufferMapAsyncStatus status, void *userdata) {
-  UNUSED(userdata)
+static void handle_buffer_map(WGPUBufferMapAsyncStatus status,
+                              char const * message,
+                              void *userdata1, void *userdata2) {
+  UNUSED(userdata1)
+  UNUSED(userdata2)
   printf(LOG_PREFIX " buffer_map status=%#.8x\n", status);
 }
 
@@ -38,13 +43,19 @@ int main(int argc, char *argv[]) {
   assert(instance);
 
   WGPUAdapter adapter = NULL;
-  wgpuInstanceRequestAdapter(instance, NULL, handle_request_adapter,
-                             (void *)&adapter);
+  wgpuInstanceRequestAdapter(instance, NULL,
+                             (const WGPURequestAdapterCallbackInfo){
+                                 .callback = handle_request_adapter,
+                                 .userdata1 = &adapter
+                             });
   assert(adapter);
 
   WGPUDevice device = NULL;
-  wgpuAdapterRequestDevice(adapter, NULL, handle_request_device,
-                           (void *)&device);
+  wgpuAdapterRequestDevice(adapter, NULL,
+                           (const WGPURequestDeviceCallbackInfo){ 
+                               .callback = handle_request_device,
+                               .userdata1 = &device
+                           });
   assert(device);
 
   WGPUQueue queue = wgpuDeviceGetQueue(device);
@@ -139,7 +150,9 @@ int main(int argc, char *argv[]) {
   wgpuQueueSubmit(queue, 1, &command_buffer);
 
   wgpuBufferMapAsync(staging_buffer, WGPUMapMode_Read, 0, numbers_size,
-                     handle_buffer_map, NULL);
+                     (const WGPUBufferMapCallbackInfo){
+                         .callback = handle_buffer_map
+                     });
   wgpuDevicePoll(device, true, NULL);
 
   uint32_t *buf =

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -7,7 +7,7 @@
 #define LOG_PREFIX "[compute]"
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
-                                   WGPUAdapter adapter, char const *message,
+                                   WGPUAdapter adapter, WGPUStringView message,
                                    void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
@@ -15,7 +15,7 @@ static void handle_request_adapter(WGPURequestAdapterStatus status,
   *(WGPUAdapter *)userdata1 = adapter;
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
-                                  WGPUDevice device, char const *message,
+                                  WGPUDevice device, WGPUStringView message,
                                   void *userdata1, void *userdata2) {
   UNUSED(status)
   UNUSED(message)
@@ -23,7 +23,7 @@ static void handle_request_device(WGPURequestDeviceStatus status,
   *(WGPUDevice *)userdata1 = device;
 }
 static void handle_buffer_map(WGPUMapAsyncStatus status,
-                              char const * message,
+                              WGPUStringView message,
                               void *userdata1, void *userdata2) {
   UNUSED(userdata1)
   UNUSED(userdata2)
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
 
   WGPUBuffer staging_buffer = wgpuDeviceCreateBuffer(
       device, &(const WGPUBufferDescriptor){
-                  .label = "staging_buffer",
+                  .label = {"staging_buffer", WGPU_STRLEN},
                   .usage = WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst,
                   .size = numbers_size,
                   .mappedAtCreation = false,
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
 
   WGPUBuffer storage_buffer = wgpuDeviceCreateBuffer(
       device, &(const WGPUBufferDescriptor){
-                  .label = "storage_buffer",
+                  .label = {"storage_buffer", WGPU_STRLEN},
                   .usage = WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst |
                            WGPUBufferUsage_CopySrc,
                   .size = numbers_size,
@@ -86,11 +86,11 @@ int main(int argc, char *argv[]) {
 
   WGPUComputePipeline compute_pipeline = wgpuDeviceCreateComputePipeline(
       device, &(const WGPUComputePipelineDescriptor){
-                  .label = "compute_pipeline",
+                  .label = {"compute_pipeline", WGPU_STRLEN},
                   .compute =
                       (const WGPUProgrammableStageDescriptor){
                           .module = shader_module,
-                          .entryPoint = "main",
+                          .entryPoint = {"main", WGPU_STRLEN},
                       },
               });
   assert(compute_pipeline);
@@ -101,7 +101,7 @@ int main(int argc, char *argv[]) {
 
   WGPUBindGroup bind_group = wgpuDeviceCreateBindGroup(
       device, &(const WGPUBindGroupDescriptor){
-                  .label = "bind_group",
+                  .label = {"bind_group", WGPU_STRLEN},
                   .layout = bind_group_layout,
                   .entryCount = 1,
                   .entries =
@@ -118,14 +118,14 @@ int main(int argc, char *argv[]) {
 
   WGPUCommandEncoder command_encoder = wgpuDeviceCreateCommandEncoder(
       device, &(const WGPUCommandEncoderDescriptor){
-                  .label = "command_encoder",
+                  .label = {"command_encoder", WGPU_STRLEN},
               });
   assert(command_encoder);
 
   WGPUComputePassEncoder compute_pass_encoder =
       wgpuCommandEncoderBeginComputePass(command_encoder,
                                          &(const WGPUComputePassDescriptor){
-                                             .label = "compute_pass",
+                                             .label = {"compute_pass", WGPU_STRLEN},
                                          });
   assert(compute_pass_encoder);
 
@@ -142,7 +142,7 @@ int main(int argc, char *argv[]) {
 
   WGPUCommandBuffer command_buffer = wgpuCommandEncoderFinish(
       command_encoder, &(const WGPUCommandBufferDescriptor){
-                           .label = "command_buffer",
+                           .label = {"command_buffer", WGPU_STRLEN},
                        });
   assert(command_buffer);
 

--- a/examples/compute/main.c
+++ b/examples/compute/main.c
@@ -22,7 +22,7 @@ static void handle_request_device(WGPURequestDeviceStatus status,
   UNUSED(userdata2)
   *(WGPUDevice *)userdata1 = device;
 }
-static void handle_buffer_map(WGPUBufferMapAsyncStatus status,
+static void handle_buffer_map(WGPUMapAsyncStatus status,
                               char const * message,
                               void *userdata1, void *userdata2) {
   UNUSED(userdata1)

--- a/examples/enumerate_adapters/CMakeLists.txt
+++ b/examples/enumerate_adapters/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(${CMAKE_SOURCE_DIR}/../ffi/webgpu-headers)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32 Propsys RuntimeObject)
 elseif(UNIX AND NOT APPLE)
     set(OS_LIBRARIES "-lm -ldl")
 elseif(APPLE)

--- a/examples/enumerate_adapters/main.c
+++ b/examples/enumerate_adapters/main.c
@@ -26,16 +26,17 @@ int main(int argc, char *argv[]) {
     wgpuAdapterGetInfo(adapter, &info);
     printf("WGPUAdapter: %d\n", i);
     printf("WGPUAdapterInfo {\n"
-           "\tvendor: %s\n"
-           "\tarchitecture: %s\n"
-           "\tdevice: %s\n"
-           "\tdescription: %s\n"
+           "\tvendor: %.*s\n"
+           "\tarchitecture: %.*s\n"
+           "\tdevice: %.*s\n"
+           "\tdescription: %.*s\n"
            "\tbackendType: %#.8x\n"
            "\tadapterType: %#.8x\n"
            "\tvendorID: %" PRIu32 "\n"
            "\tdeviceID: %" PRIu32 "\n"
            "}\n",
-           info.vendor, info.architecture, info.device, info.description,
+           (int) info.vendor.length, info.vendor.data, (int) info.architecture.length, info.architecture.data,
+           (int) info.device.length, info.device.data, (int) info.description.length, info.description.data,
            info.backendType, info.adapterType, info.vendorID, info.deviceID);
 
     wgpuAdapterInfoFreeMembers(info);

--- a/examples/framework/framework.c
+++ b/examples/framework/framework.c
@@ -121,7 +121,6 @@ WGPUBuffer frmwrk_device_create_buffer_init(
   printf("%snumAllocated=%zu\n", prefix, report.numAllocated);                 \
   printf("%snumKeptFromUser=%zu\n", prefix, report.numKeptFromUser);           \
   printf("%snumReleasedFromUser=%zu\n", prefix, report.numReleasedFromUser);   \
-  printf("%snumError=%zu\n", prefix, report.numError);                         \
   printf("%selementSize=%zu\n", prefix, report.elementSize)
 
 #define print_hub_report(report, prefix)                                       \
@@ -136,6 +135,7 @@ WGPUBuffer frmwrk_device_create_buffer_init(
   print_registry_report(report.renderBundles, prefix "renderBundles.");        \
   print_registry_report(report.renderPipelines, prefix "renderPipelines.");    \
   print_registry_report(report.computePipelines, prefix "computePipelines.");  \
+  print_registry_report(report.pipelineCaches, prefix "pipelineCaches.");      \
   print_registry_report(report.querySets, prefix "querySets.");                \
   print_registry_report(report.textures, prefix "textures.");                  \
   print_registry_report(report.textureViews, prefix "textureViews.");          \
@@ -144,24 +144,7 @@ WGPUBuffer frmwrk_device_create_buffer_init(
 void frmwrk_print_global_report(WGPUGlobalReport report) {
   printf("struct WGPUGlobalReport {\n");
   print_registry_report(report.surfaces, "\tsurfaces.");
-
-  switch (report.backendType) {
-  case WGPUBackendType_D3D12:
-    print_hub_report(report.dx12, "\tdx12.");
-    break;
-  case WGPUBackendType_Metal:
-    print_hub_report(report.metal, "\tmetal.");
-    break;
-  case WGPUBackendType_Vulkan:
-    print_hub_report(report.vulkan, "\tvulkan.");
-    break;
-  case WGPUBackendType_OpenGL:
-    print_hub_report(report.gl, "\tgl.");
-    break;
-  default:
-    printf("[framework] frmwrk_print_global_report: invalid backend type: %d",
-           report.backendType);
-  }
+  print_hub_report(report.hub, "\thub.");
   printf("}\n");
 }
 

--- a/examples/framework/framework.c
+++ b/examples/framework/framework.c
@@ -1,6 +1,6 @@
 #include "framework.h"
 
-static void log_callback(WGPULogLevel level, char const *message,
+static void log_callback(WGPULogLevel level, WGPUStringView message,
                          void *userdata) {
   UNUSED(userdata)
   char *level_str;
@@ -23,7 +23,7 @@ static void log_callback(WGPULogLevel level, char const *message,
   default:
     level_str = "unknown_level";
   }
-  fprintf(stderr, "[wgpu] [%s] %s\n", level_str, message);
+  fprintf(stderr, "[wgpu] [%s] %.*s\n", level_str, (int) message.length, message.data);
 }
 
 void frmwrk_setup_logging(WGPULogLevel level) {
@@ -64,7 +64,7 @@ WGPUShaderModule frmwrk_load_shader_module(WGPUDevice device,
 
   shader_module = wgpuDeviceCreateShaderModule(
       device, &(const WGPUShaderModuleDescriptor){
-                  .label = name,
+                  .label = {name, WGPU_STRLEN},
                   .nextInChain =
                       (const WGPUChainedStruct *)&(
                           const WGPUShaderSourceWGSL){
@@ -72,7 +72,7 @@ WGPUShaderModule frmwrk_load_shader_module(WGPUDevice device,
                               (const WGPUChainedStruct){
                                   .sType = WGPUSType_ShaderSourceWGSL,
                               },
-                          .code = buf,
+                          .code = {buf, WGPU_STRLEN},
                       },
               });
 
@@ -92,7 +92,7 @@ WGPUBuffer frmwrk_device_create_buffer_init(
   assert(descriptor);
   if (descriptor->content_size == 0) {
     return wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
-                                              .label = descriptor->label,
+                                              .label = {descriptor->label, WGPU_STRLEN},
                                               .size = 0,
                                               .usage = descriptor->usage,
                                               .mappedAtCreation = false,
@@ -105,7 +105,7 @@ WGPUBuffer frmwrk_device_create_buffer_init(
       MAX((unpadded_size + align_mask) & ~align_mask, COPY_BUFFER_ALIGNMENT);
   WGPUBuffer buffer =
       wgpuDeviceCreateBuffer(device, &(WGPUBufferDescriptor){
-                                         .label = descriptor->label,
+                                         .label = {descriptor->label, WGPU_STRLEN},
                                          .size = padded_size,
                                          .usage = descriptor->usage,
                                          .mappedAtCreation = true,
@@ -168,10 +168,10 @@ void frmwrk_print_global_report(WGPUGlobalReport report) {
 void frmwrk_print_adapter_info(WGPUAdapter adapter) {
   struct WGPUAdapterInfo info = {0};
   wgpuAdapterGetInfo(adapter, &info);
-  printf("description: %s\n", info.description);
-  printf("vendor: %s\n", info.vendor);
-  printf("architecture: %s\n", info.architecture);
-  printf("device: %s\n", info.device);
+  printf("description: %.*s\n", (int) info.description.length, info.description.data);
+  printf("vendor: %.*s\n", (int) info.vendor.length, info.vendor.data);
+  printf("architecture: %.*s\n", (int) info.architecture.length, info.architecture.data);
+  printf("device: %.*s\n", (int) info.device.length, info.device.data);
   printf("backend type: %u\n", info.backendType);
   printf("adapter type: %u\n", info.adapterType);
   printf("vendorID: %x\n", info.vendorID);

--- a/examples/framework/framework.c
+++ b/examples/framework/framework.c
@@ -67,10 +67,10 @@ WGPUShaderModule frmwrk_load_shader_module(WGPUDevice device,
                   .label = name,
                   .nextInChain =
                       (const WGPUChainedStruct *)&(
-                          const WGPUShaderModuleWGSLDescriptor){
+                          const WGPUShaderSourceWGSL){
                           .chain =
                               (const WGPUChainedStruct){
-                                  .sType = WGPUSType_ShaderModuleWGSLDescriptor,
+                                  .sType = WGPUSType_ShaderSourceWGSL,
                               },
                           .code = buf,
                       },

--- a/examples/framework/framework.h
+++ b/examples/framework/framework.h
@@ -12,7 +12,7 @@
 
 typedef struct frmwrk_buffer_init_descriptor {
   WGPU_NULLABLE char const *label;
-  WGPUBufferUsageFlags usage;
+  WGPUBufferUsage usage;
   void *content;
   size_t content_size;
 } frmwrk_buffer_init_descriptor;

--- a/examples/push_constants/CMakeLists.txt
+++ b/examples/push_constants/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(${CMAKE_SOURCE_DIR}/../ffi/webgpu-headers)
 include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32 Propsys RuntimeObject)
 elseif(UNIX AND NOT APPLE)
     set(OS_LIBRARIES "-lm -ldl")
 elseif(APPLE)

--- a/examples/texture_arrays/CMakeLists.txt
+++ b/examples/texture_arrays/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)
     add_definitions(-DGLFW_EXPOSE_NATIVE_WIN32)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32 Propsys RuntimeObject)
 elseif(UNIX AND NOT APPLE)
     add_definitions(-DGLFW_EXPOSE_NATIVE_X11)
     add_definitions(-DGLFW_EXPOSE_NATIVE_WAYLAND)

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -233,16 +233,13 @@ int main(int argc, char *argv[]) {
   WGPUSurfaceCapabilities surface_capabilities = {0};
   wgpuSurfaceGetCapabilities(demo.surface, demo.adapter, &surface_capabilities);
 
-  size_t adapter_feature_count =
-      wgpuAdapterEnumerateFeatures(demo.adapter, NULL);
-  WGPUFeatureName *adapter_features = (WGPUFeatureName *)malloc(
-      sizeof(WGPUFeatureName) * adapter_feature_count);
-  wgpuAdapterEnumerateFeatures(demo.adapter, adapter_features);
+  WGPUSupportedFeatures adapter_features = {0};
+  wgpuAdapterGetFeatures(demo.adapter, &adapter_features);
 
   bool adapter_has_required_features = false;
   bool adapter_has_optional_features = false;
-  for (size_t i = 0; i < adapter_feature_count; i++) {
-    switch ((uint32_t)adapter_features[i]) {
+  for (size_t i = 0; i < adapter_features.featureCount; i++) {
+    switch ((uint32_t)adapter_features.features[i]) {
     case WGPUNativeFeature_TextureBindingArray:
       adapter_has_required_features = true;
       break;
@@ -253,7 +250,7 @@ int main(int argc, char *argv[]) {
   }
   assert(
           adapter_has_required_features /* Adapter must support WGPUNativeFeature_TextureBindingArray feature for this example */);
-  free(adapter_features);
+  wgpuSupportedFeaturesFreeMembers(adapter_features);
 
   WGPUFeatureName required_device_features[2] = {
       (WGPUFeatureName)WGPUNativeFeature_TextureBindingArray,

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -149,7 +149,7 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceSourceromMetalLayer){
+                    const WGPUSurfaceSourceMetalLayer){
                     .chain =
                         (const WGPUChainedStruct){
                             .sType = WGPUSType_SurfaceSourceMetalLayer,

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -27,9 +27,10 @@ struct demo {
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
                                    WGPUAdapter adapter, char const *message,
-                                   void *userdata) {
+                                   void *userdata1, void *userdata2) {
+  UNUSED(userdata2)
   if (status == WGPURequestAdapterStatus_Success) {
-    struct demo *demo = userdata;
+    struct demo *demo = userdata1;
     demo->adapter = adapter;
   } else {
     printf(LOG_PREFIX " request_adapter status=%#.8x message=%s\n", status,
@@ -38,9 +39,10 @@ static void handle_request_adapter(WGPURequestAdapterStatus status,
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
                                   WGPUDevice device, char const *message,
-                                  void *userdata) {
+                                  void *userdata1, void *userdata2) {
+  UNUSED(userdata2)
   if (status == WGPURequestDeviceStatus_Success) {
-    struct demo *demo = userdata;
+    struct demo *demo = userdata1;
     demo->device = device;
   } else {
     printf(LOG_PREFIX " request_device status=%#.8x message=%s\n", status,
@@ -147,10 +149,10 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceDescriptorFromMetalLayer){
+                    const WGPUSurfaceSourceromMetalLayer){
                     .chain =
                         (const WGPUChainedStruct){
-                            .sType = WGPUSType_SurfaceDescriptorFromMetalLayer,
+                            .sType = WGPUSType_SurfaceSourceMetalLayer,
                         },
                     .layer = metal_layer,
                 },
@@ -165,10 +167,10 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceDescriptorFromXlibWindow){
+                    const WGPUSurfaceSourceXlibWindow){
                     .chain =
                         (const WGPUChainedStruct){
-                            .sType = WGPUSType_SurfaceDescriptorFromXlibWindow,
+                            .sType = WGPUSType_SurfaceSourceXlibWindow,
                         },
                     .display = x11_display,
                     .window = x11_window,
@@ -183,11 +185,11 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceDescriptorFromWaylandSurface){
+                    const WGPUSurfaceSourceWaylandSurface){
                     .chain =
                         (const WGPUChainedStruct){
                             .sType =
-                                WGPUSType_SurfaceDescriptorFromWaylandSurface,
+                                WGPUSType_SurfaceSourceWaylandSurface,
                         },
                     .display = wayland_display,
                     .surface = wayland_surface,
@@ -203,10 +205,10 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceDescriptorFromWindowsHWND){
+                    const WGPUSurfaceSourceWindowsHWND){
                     .chain =
                         (const WGPUChainedStruct){
-                            .sType = WGPUSType_SurfaceDescriptorFromWindowsHWND,
+                            .sType = WGPUSType_SurfaceSourceWindowsHWND,
                         },
                     .hinstance = hinstance,
                     .hwnd = hwnd,
@@ -222,7 +224,10 @@ int main(int argc, char *argv[]) {
                              &(const WGPURequestAdapterOptions){
                                  .compatibleSurface = demo.surface,
                              },
-                             handle_request_adapter, &demo);
+                             (const WGPURequestAdapterCallbackInfo){
+                                 .callback = handle_request_adapter,
+                                 .userdata1 = &demo
+                             });
   assert(demo.adapter);
 
   WGPUSurfaceCapabilities surface_capabilities = {0};
@@ -260,13 +265,15 @@ int main(int argc, char *argv[]) {
     required_device_feature_count++;
   }
 
-  wgpuAdapterRequestDevice(
-      demo.adapter,
-      &(const WGPUDeviceDescriptor){
-          .requiredFeatureCount = required_device_feature_count,
-          .requiredFeatures = required_device_features,
-      },
-      handle_request_device, &demo);
+  wgpuAdapterRequestDevice(demo.adapter,
+                           &(const WGPUDeviceDescriptor){
+                               .requiredFeatureCount = required_device_feature_count,
+                               .requiredFeatures = required_device_features,
+                           }, 
+                           (const WGPURequestDeviceCallbackInfo){ 
+                               .callback = handle_request_device,
+                               .userdata1 = &demo
+                           });
   assert(demo.device);
 
   WGPUQueue queue = wgpuDeviceGetQueue(demo.device);
@@ -648,8 +655,9 @@ int main(int argc, char *argv[]) {
     WGPUSurfaceTexture surface_texture;
     wgpuSurfaceGetCurrentTexture(demo.surface, &surface_texture);
     switch (surface_texture.status) {
-    case WGPUSurfaceGetCurrentTextureStatus_Success:
-      // All good, could check for `surface_texture.suboptimal` here.
+    case WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal:
+    case WGPUSurfaceGetCurrentTextureStatus_SuccessSuboptimal:
+      // All good, could handle suboptimal here
       break;
     case WGPUSurfaceGetCurrentTextureStatus_Timeout:
     case WGPUSurfaceGetCurrentTextureStatus_Outdated:

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -26,27 +26,27 @@ struct demo {
 };
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
-                                   WGPUAdapter adapter, char const *message,
+                                   WGPUAdapter adapter, WGPUStringView message,
                                    void *userdata1, void *userdata2) {
   UNUSED(userdata2)
   if (status == WGPURequestAdapterStatus_Success) {
     struct demo *demo = userdata1;
     demo->adapter = adapter;
   } else {
-    printf(LOG_PREFIX " request_adapter status=%#.8x message=%s\n", status,
-           message);
+    printf(LOG_PREFIX " request_adapter status=%#.8x message=%.*s\n", status,
+           (int) message.length, message.data);
   }
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
-                                  WGPUDevice device, char const *message,
+                                  WGPUDevice device, WGPUStringView message,
                                   void *userdata1, void *userdata2) {
   UNUSED(userdata2)
   if (status == WGPURequestDeviceStatus_Success) {
     struct demo *demo = userdata1;
     demo->device = device;
   } else {
-    printf(LOG_PREFIX " request_device status=%#.8x message=%s\n", status,
-           message);
+    printf(LOG_PREFIX " request_device status=%#.8x message=%.*s\n", status,
+           (int) message.length, message.data);
   }
 }
 static void handle_glfw_framebuffer_size(GLFWwindow *window, int width,
@@ -368,25 +368,25 @@ int main(int argc, char *argv[]) {
   WGPUTexture red_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
-                       .label = "red",
+                       .label = {"red", WGPU_STRLEN},
                    });
   assert(red_texture);
   WGPUTexture green_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
-                       .label = "green",
+                       .label = {"green", WGPU_STRLEN},
                    });
   assert(green_texture);
   WGPUTexture blue_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
-                       .label = "blue",
+                       .label = {"blue", WGPU_STRLEN},
                    });
   assert(blue_texture);
   WGPUTexture white_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
-                       .label = "white",
+                       .label = {"white", WGPU_STRLEN},
                    });
   assert(white_texture);
 
@@ -516,7 +516,7 @@ int main(int argc, char *argv[]) {
   };
   WGPUBindGroupLayout bind_group_layout = wgpuDeviceCreateBindGroupLayout(
       demo.device, &(const WGPUBindGroupLayoutDescriptor){
-                       .label = "bind group layout",
+                       .label = {"bind group layout", WGPU_STRLEN},
                        .entryCount = sizeof(bind_group_layout_entries) /
                                      sizeof(bind_group_layout_entries[0]),
                        .entries = bind_group_layout_entries,
@@ -582,7 +582,7 @@ int main(int argc, char *argv[]) {
   WGPUBindGroup bind_group = wgpuDeviceCreateBindGroup(
       demo.device, &(const WGPUBindGroupDescriptor){
                        .layout = bind_group_layout,
-                       .label = "bind group",
+                       .label = {"bind group", WGPU_STRLEN},
                        .entryCount = sizeof(bind_group_entries) /
                                      sizeof(bind_group_entries[0]),
                        .entries = bind_group_entries,
@@ -591,7 +591,7 @@ int main(int argc, char *argv[]) {
 
   WGPUPipelineLayout pipeline_layout = wgpuDeviceCreatePipelineLayout(
       demo.device, &(const WGPUPipelineLayoutDescriptor){
-                       .label = "main",
+                       .label = {"main", WGPU_STRLEN},
                        .bindGroupLayoutCount = 1,
                        .bindGroupLayouts =
                            (const WGPUBindGroupLayout[]){
@@ -607,7 +607,7 @@ int main(int argc, char *argv[]) {
           .vertex =
               (const WGPUVertexState){
                   .module = base_shader_module,
-                  .entryPoint = "vert_main",
+                  .entryPoint = {"vert_main", WGPU_STRLEN},
                   .bufferCount = 1,
                   .buffers =
                       (const WGPUVertexBufferLayout[]){
@@ -623,7 +623,7 @@ int main(int argc, char *argv[]) {
           .fragment =
               &(const WGPUFragmentState){
                   .module = fragment_shader_module,
-                  .entryPoint = fragment_entry_point,
+                  .entryPoint = {fragment_entry_point, WGPU_STRLEN},
                   .targetCount = 1,
                   .targets =
                       (const WGPUColorTargetState[]){
@@ -688,7 +688,7 @@ int main(int argc, char *argv[]) {
 
     WGPUCommandEncoder command_encoder = wgpuDeviceCreateCommandEncoder(
         demo.device, &(const WGPUCommandEncoderDescriptor){
-                         .label = "command_encoder",
+                         .label = {"command_encoder", WGPU_STRLEN},
                      });
     assert(command_encoder);
 
@@ -696,7 +696,7 @@ int main(int argc, char *argv[]) {
         wgpuCommandEncoderBeginRenderPass(
             command_encoder,
             &(const WGPURenderPassDescriptor){
-                .label = "render_pass_encoder",
+                .label = {"render_pass_encoder", WGPU_STRLEN},
                 .colorAttachmentCount = 1,
                 .colorAttachments =
                     (const WGPURenderPassColorAttachment[]){
@@ -740,7 +740,7 @@ int main(int argc, char *argv[]) {
 
     WGPUCommandBuffer command_buffer = wgpuCommandEncoderFinish(
         command_encoder, &(const WGPUCommandBufferDescriptor){
-                             .label = "command_buffer",
+                             .label = {"command_buffer", WGPU_STRLEN},
                          });
     assert(command_buffer);
 

--- a/examples/triangle/CMakeLists.txt
+++ b/examples/triangle/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories(${CMAKE_SOURCE_DIR}/framework)
 
 if (WIN32)
     add_definitions(-DGLFW_EXPOSE_NATIVE_WIN32)
-    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32)
+    set(OS_LIBRARIES d3dcompiler ws2_32 userenv bcrypt ntdll opengl32 Propsys RuntimeObject)
 elseif(UNIX AND NOT APPLE)
     add_definitions(-DGLFW_EXPOSE_NATIVE_X11)
     add_definitions(-DGLFW_EXPOSE_NATIVE_WAYLAND)

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[]) {
         &(const WGPUSurfaceDescriptor){
             .nextInChain =
                 (const WGPUChainedStruct *)&(
-                    const WGPUSurfaceSourceromMetalLayer){
+                    const WGPUSurfaceSourceMetalLayer){
                     .chain =
                         (const WGPUChainedStruct){
                             .sType = WGPUSType_SurfaceSourceMetalLayer,

--- a/examples/triangle/main.c
+++ b/examples/triangle/main.c
@@ -26,27 +26,27 @@ struct demo {
 };
 
 static void handle_request_adapter(WGPURequestAdapterStatus status,
-                                   WGPUAdapter adapter, char const *message,
+                                   WGPUAdapter adapter, WGPUStringView message,
                                    void *userdata1, void *userdata2) {
   UNUSED(userdata2)
   if (status == WGPURequestAdapterStatus_Success) {
     struct demo *demo = userdata1;
     demo->adapter = adapter;
   } else {
-    printf(LOG_PREFIX " request_adapter status=%#.8x message=%s\n", status,
-           message);
+    printf(LOG_PREFIX " request_adapter status=%#.8x message=%.*s\n", status,
+           (int) message.length, message.data);
   }
 }
 static void handle_request_device(WGPURequestDeviceStatus status,
-                                  WGPUDevice device, char const *message,
+                                  WGPUDevice device, WGPUStringView message,
                                   void *userdata1, void *userdata2) {
   UNUSED(userdata2)
   if (status == WGPURequestDeviceStatus_Success) {
     struct demo *demo = userdata1;
     demo->device = device;
   } else {
-    printf(LOG_PREFIX " request_device status=%#.8x message=%s\n", status,
-           message);
+    printf(LOG_PREFIX " request_device status=%#.8x message=%.*s\n", status,
+           (int) message.length, message.data);
   }
 }
 static void handle_glfw_key(GLFWwindow *window, int key, int scancode,
@@ -211,7 +211,7 @@ int main(int argc, char *argv[]) {
 
   WGPUPipelineLayout pipeline_layout = wgpuDeviceCreatePipelineLayout(
       demo.device, &(const WGPUPipelineLayoutDescriptor){
-                       .label = "pipeline_layout",
+                       .label = {"pipeline_layout", WGPU_STRLEN},
                    });
   assert(pipeline_layout);
 
@@ -221,17 +221,17 @@ int main(int argc, char *argv[]) {
   WGPURenderPipeline render_pipeline = wgpuDeviceCreateRenderPipeline(
       demo.device,
       &(const WGPURenderPipelineDescriptor){
-          .label = "render_pipeline",
+          .label = {"render_pipeline", WGPU_STRLEN},
           .layout = pipeline_layout,
           .vertex =
               (const WGPUVertexState){
                   .module = shader_module,
-                  .entryPoint = "vs_main",
+                  .entryPoint = {"vs_main", WGPU_STRLEN},
               },
           .fragment =
               &(const WGPUFragmentState){
                   .module = shader_module,
-                  .entryPoint = "fs_main",
+                  .entryPoint = {"fs_main", WGPU_STRLEN},
                   .targetCount = 1,
                   .targets =
                       (const WGPUColorTargetState[]){
@@ -312,7 +312,7 @@ int main(int argc, char *argv[]) {
 
     WGPUCommandEncoder command_encoder = wgpuDeviceCreateCommandEncoder(
         demo.device, &(const WGPUCommandEncoderDescriptor){
-                         .label = "command_encoder",
+                         .label = {"command_encoder", WGPU_STRLEN},
                      });
     assert(command_encoder);
 
@@ -320,7 +320,7 @@ int main(int argc, char *argv[]) {
         wgpuCommandEncoderBeginRenderPass(
             command_encoder,
             &(const WGPURenderPassDescriptor){
-                .label = "render_pass_encoder",
+                .label = {"render_pass_encoder", WGPU_STRLEN},
                 .colorAttachmentCount = 1,
                 .colorAttachments =
                     (const WGPURenderPassColorAttachment[]){
@@ -348,7 +348,7 @@ int main(int argc, char *argv[]) {
 
     WGPUCommandBuffer command_buffer = wgpuCommandEncoderFinish(
         command_encoder, &(const WGPUCommandBufferDescriptor){
-                             .label = "command_buffer",
+                             .label = {"command_buffer", WGPU_STRLEN},
                          });
     assert(command_buffer);
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -66,30 +66,26 @@ typedef enum WGPULogLevel {
     WGPULogLevel_Force32 = 0x7FFFFFFF
 } WGPULogLevel;
 
-typedef enum WGPUInstanceBackend {
-    WGPUInstanceBackend_All = 0x00000000,
-    WGPUInstanceBackend_Vulkan = 1 << 0,
-    WGPUInstanceBackend_GL = 1 << 1,
-    WGPUInstanceBackend_Metal = 1 << 2,
-    WGPUInstanceBackend_DX12 = 1 << 3,
-    WGPUInstanceBackend_DX11 = 1 << 4,
-    WGPUInstanceBackend_BrowserWebGPU = 1 << 5,
-    WGPUInstanceBackend_Primary = WGPUInstanceBackend_Vulkan | WGPUInstanceBackend_Metal |
-        WGPUInstanceBackend_DX12 |
-        WGPUInstanceBackend_BrowserWebGPU,
-    WGPUInstanceBackend_Secondary = WGPUInstanceBackend_GL | WGPUInstanceBackend_DX11,
-    WGPUInstanceBackend_Force32 = 0x7FFFFFFF
-} WGPUInstanceBackend;
-typedef WGPUFlags WGPUInstanceBackendFlags;
+typedef WGPUFlags WGPUInstanceBackend;
+static const WGPUInstanceBackend WGPUInstanceBackend_All = 0x00000000;
+static const WGPUInstanceBackend WGPUInstanceBackend_Vulkan = 1 << 0;
+static const WGPUInstanceBackend WGPUInstanceBackend_GL = 1 << 1;
+static const WGPUInstanceBackend WGPUInstanceBackend_Metal = 1 << 2;
+static const WGPUInstanceBackend WGPUInstanceBackend_DX12 = 1 << 3;
+static const WGPUInstanceBackend WGPUInstanceBackend_DX11 = 1 << 4;
+static const WGPUInstanceBackend WGPUInstanceBackend_BrowserWebGPU = 1 << 5;
+// Vulkan, Metal, DX12 and BrowserWebGPU
+static const WGPUInstanceBackend WGPUInstanceBackend_Primary = (1 << 0) | (1 << 2) | (1 << 3) | (1 << 5);
+// GL and DX11
+static const WGPUInstanceBackend WGPUInstanceBackend_Secondary = (1 << 1) | (1 << 4);
+static const WGPUInstanceBackend WGPUInstanceBackend_Force32 = 0x7FFFFFFF;
 
-typedef enum WGPUInstanceFlag {
-    WGPUInstanceFlag_Default = 0x00000000,
-    WGPUInstanceFlag_Debug = 1 << 0,
-    WGPUInstanceFlag_Validation = 1 << 1,
-    WGPUInstanceFlag_DiscardHalLabels = 1 << 2,
-    WGPUInstanceFlag_Force32 = 0x7FFFFFFF
-} WGPUInstanceFlag;
-typedef WGPUFlags WGPUInstanceFlags;
+typedef WGPUFlags WGPUInstanceFlag;
+static const WGPUInstanceFlag WGPUInstanceFlag_Default = 0x00000000;
+static const WGPUInstanceFlag WGPUInstanceFlag_Debug = 1 << 0;
+static const WGPUInstanceFlag WGPUInstanceFlag_Validation = 1 << 1;
+static const WGPUInstanceFlag WGPUInstanceFlag_DiscardHalLabels = 1 << 2;
+static const WGPUInstanceFlag WGPUInstanceFlag_Force32 = 0x7FFFFFFF;
 
 typedef enum WGPUDx12Compiler {
     WGPUDx12Compiler_Undefined = 0x00000000,
@@ -122,8 +118,8 @@ typedef enum WGPUNativeQueryType {
 
 typedef struct WGPUInstanceExtras {
     WGPUChainedStruct chain;
-    WGPUInstanceBackendFlags backends;
-    WGPUInstanceFlags flags;
+    WGPUInstanceBackend backends;
+    WGPUInstanceFlag flags;
     WGPUDx12Compiler dx12ShaderCompiler;
     WGPUGles3MinorVersion gles3MinorVersion;
     const char * dxilPath;
@@ -220,7 +216,7 @@ typedef struct WGPUGlobalReport {
 
 typedef struct WGPUInstanceEnumerateAdapterOptions {
     WGPUChainedStruct const * nextInChain;
-    WGPUInstanceBackendFlags backends;
+    WGPUInstanceBackend backends;
 } WGPUInstanceEnumerateAdapterOptions;
 
 typedef struct WGPUBindGroupEntryExtras {

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -151,7 +151,7 @@ typedef struct WGPUSupportedLimitsExtras {
 } WGPUSupportedLimitsExtras;
 
 typedef struct WGPUPushConstantRange {
-    WGPUShaderStageFlags stages;
+    WGPUShaderStage stages;
     uint32_t start;
     uint32_t end;
 } WGPUPushConstantRange;
@@ -281,7 +281,7 @@ void wgpuSetLogLevel(WGPULogLevel level);
 
 uint32_t wgpuGetVersion(void);
 
-void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void const * data);
+void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStage stages, uint32_t offset, uint32_t sizeBytes, void const * data);
 
 void wgpuRenderPassEncoderMultiDrawIndirect(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);
 void wgpuRenderPassEncoderMultiDrawIndexedIndirect(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -122,13 +122,13 @@ typedef struct WGPUInstanceExtras {
     WGPUInstanceFlag flags;
     WGPUDx12Compiler dx12ShaderCompiler;
     WGPUGles3MinorVersion gles3MinorVersion;
-    const char * dxilPath;
-    const char * dxcPath;
+    WGPUStringView dxilPath;
+    WGPUStringView dxcPath;
 } WGPUInstanceExtras;
 
 typedef struct WGPUDeviceExtras {
     WGPUChainedStruct chain;
-    const char * tracePath;
+    WGPUStringView tracePath;
 } WGPUDeviceExtras;
 
 typedef struct WGPUNativeLimits {
@@ -166,14 +166,14 @@ typedef struct WGPUWrappedSubmissionIndex {
 } WGPUWrappedSubmissionIndex;
 
 typedef struct WGPUShaderDefine {
-    char const * name;
-    char const * value;
+    WGPUStringView name;
+    WGPUStringView value;
 } WGPUShaderDefine;
 
 typedef struct WGPUShaderModuleGLSLDescriptor {
     WGPUChainedStruct chain;
     WGPUShaderStage stage;
-    char const * code;
+    WGPUStringView code;
     uint32_t defineCount;
     WGPUShaderDefine * defines;
 } WGPUShaderModuleGLSLDescriptor;
@@ -245,7 +245,7 @@ typedef struct WGPUSurfaceConfigurationExtras {
     uint32_t desiredMaximumFrameLatency;
 } WGPUSurfaceConfigurationExtras WGPU_STRUCTURE_ATTRIBUTE;
 
-typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void * userdata);
+typedef void (*WGPULogCallback)(WGPULogLevel level, WGPUStringView message, void * userdata);
 
 typedef enum WGPUNativeTextureFormat {
     // From Features::TEXTURE_FORMAT_16BIT_NORM

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -164,11 +164,6 @@ typedef struct WGPUPipelineLayoutExtras {
 
 typedef uint64_t WGPUSubmissionIndex;
 
-typedef struct WGPUWrappedSubmissionIndex {
-    WGPUQueue queue;
-    WGPUSubmissionIndex submissionIndex;
-} WGPUWrappedSubmissionIndex;
-
 typedef struct WGPUShaderDefine {
     char const * name;
     char const * value;
@@ -186,7 +181,6 @@ typedef struct WGPURegistryReport {
    size_t numAllocated;
    size_t numKeptFromUser;
    size_t numReleasedFromUser;
-   size_t numError;
    size_t elementSize;
 } WGPURegistryReport;
 
@@ -202,6 +196,7 @@ typedef struct WGPUHubReport {
     WGPURegistryReport renderBundles;
     WGPURegistryReport renderPipelines;
     WGPURegistryReport computePipelines;
+    WGPURegistryReport pipelineCaches;
     WGPURegistryReport querySets;
     WGPURegistryReport buffers;
     WGPURegistryReport textures;
@@ -211,11 +206,7 @@ typedef struct WGPUHubReport {
 
 typedef struct WGPUGlobalReport {
     WGPURegistryReport surfaces;
-    WGPUBackendType backendType;
-    WGPUHubReport vulkan;
-    WGPUHubReport metal;
-    WGPUHubReport dx12;
-    WGPUHubReport gl;
+    WGPUHubReport hub;
 } WGPUGlobalReport;
 
 typedef struct WGPUInstanceEnumerateAdapterOptions {
@@ -273,7 +264,7 @@ size_t wgpuInstanceEnumerateAdapters(WGPUInstance instance, WGPU_NULLABLE WGPUIn
 WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands);
 
 // Returns true if the queue is empty, or false if there are more queue submissions still in flight.
-WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUWrappedSubmissionIndex const * wrappedSubmissionIndex);
+WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUSubmissionIndex const * wrappedSubmissionIndex);
 
 void wgpuSetLogCallback(WGPULogCallback callback, void * userdata);
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -6,10 +6,9 @@
 typedef enum WGPUNativeSType {
     // Start at 0003 since that's allocated range for wgpu-native
     WGPUSType_DeviceExtras = 0x00030001,
-    WGPUSType_RequiredLimitsExtras = 0x00030002,
+    WGPUSType_NativeLimits = 0x00030002,
     WGPUSType_PipelineLayoutExtras = 0x00030003,
     WGPUSType_ShaderModuleGLSLDescriptor = 0x00030004,
-    WGPUSType_SupportedLimitsExtras = 0x00030005,
     WGPUSType_InstanceExtras = 0x00030006,
     WGPUSType_BindGroupEntryExtras = 0x00030007,
     WGPUSType_BindGroupLayoutEntryExtras = 0x00030008,
@@ -132,19 +131,11 @@ typedef struct WGPUDeviceExtras {
 } WGPUDeviceExtras;
 
 typedef struct WGPUNativeLimits {
+    /** This struct chain is used as mutable in some places and immutable in others. */
+    WGPUChainedStructOut * nextInChain;
     uint32_t maxPushConstantSize;
     uint32_t maxNonSamplerBindings;
 } WGPUNativeLimits;
-
-typedef struct WGPURequiredLimitsExtras {
-    WGPUChainedStruct chain;
-    WGPUNativeLimits limits;
-} WGPURequiredLimitsExtras;
-
-typedef struct WGPUSupportedLimitsExtras {
-    WGPUChainedStructOut chain;
-    WGPUNativeLimits limits;
-} WGPUSupportedLimitsExtras;
 
 typedef struct WGPUPushConstantRange {
     WGPUShaderStage stages;

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -135,7 +135,7 @@ typedef struct WGPUDeviceExtras {
 
 typedef struct WGPUNativeLimits {
     /** This struct chain is used as mutable in some places and immutable in others. */
-    WGPUChainedStructOut * nextInChain;
+    WGPUChainedStructOut chain;
     uint32_t maxPushConstantSize;
     uint32_t maxNonSamplerBindings;
 } WGPUNativeLimits;
@@ -173,7 +173,7 @@ typedef struct WGPUShaderModuleGLSLDescriptor {
 } WGPUShaderModuleGLSLDescriptor;
 
 typedef struct WGPUShaderModuleDescriptorSpirV {
-    char const * label;
+    WGPUStringView label;
     uint32_t sourceSize;
     uint32_t const * source;
 } WGPUShaderModuleDescriptorSpirV;

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -760,7 +760,7 @@ pub fn map_texture_format(value: native::WGPUTextureFormat) -> Option<wgt::Textu
         native::WGPUTextureFormat_BGRA8UnormSrgb => Some(wgt::TextureFormat::Bgra8UnormSrgb),
         native::WGPUTextureFormat_RGB10A2Uint => Some(wgt::TextureFormat::Rgb10a2Uint),
         native::WGPUTextureFormat_RGB10A2Unorm => Some(wgt::TextureFormat::Rgb10a2Unorm),
-        native::WGPUTextureFormat_RG11B10Ufloat => Some(wgt::TextureFormat::Rg11b10Float),
+        native::WGPUTextureFormat_RG11B10Ufloat => Some(wgt::TextureFormat::Rg11b10Ufloat),
         native::WGPUTextureFormat_RGB9E5Ufloat => Some(wgt::TextureFormat::Rgb9e5Ufloat),
         native::WGPUTextureFormat_RG32Float => Some(wgt::TextureFormat::Rg32Float),
         native::WGPUTextureFormat_RG32Uint => Some(wgt::TextureFormat::Rg32Uint),
@@ -877,7 +877,7 @@ pub fn to_native_texture_format(rs_type: wgt::TextureFormat) -> Option<native::W
         wgt::TextureFormat::Bgra8UnormSrgb => Some(native::WGPUTextureFormat_BGRA8UnormSrgb),
         wgt::TextureFormat::Rgb10a2Uint => Some(native::WGPUTextureFormat_RGB10A2Uint),
         wgt::TextureFormat::Rgb10a2Unorm => Some(native::WGPUTextureFormat_RGB10A2Unorm),
-        wgt::TextureFormat::Rg11b10Float => Some(native::WGPUTextureFormat_RG11B10Ufloat),
+        wgt::TextureFormat::Rg11b10Ufloat => Some(native::WGPUTextureFormat_RG11B10Ufloat),
         wgt::TextureFormat::Rgb9e5Ufloat => Some(native::WGPUTextureFormat_RGB9E5Ufloat),
         wgt::TextureFormat::Rg32Float => Some(native::WGPUTextureFormat_RG32Float),
         wgt::TextureFormat::Rg32Uint => Some(native::WGPUTextureFormat_RG32Uint),
@@ -993,7 +993,6 @@ pub fn map_storage_report(report: &wgc::registry::RegistryReport) -> native::WGP
         numAllocated: report.num_allocated,
         numKeptFromUser: report.num_kept_from_user,
         numReleasedFromUser: report.num_released_from_user,
-        numError: report.num_error,
         elementSize: report.element_size,
     }
 }
@@ -1012,6 +1011,7 @@ pub fn map_hub_report(report: &wgc::hub::HubReport) -> native::WGPUHubReport {
         renderBundles: map_storage_report(&report.render_bundles),
         renderPipelines: map_storage_report(&report.render_pipelines),
         computePipelines: map_storage_report(&report.compute_pipelines),
+        pipelineCaches: map_storage_report(&report.pipeline_caches),
         querySets: map_storage_report(&report.query_sets),
         buffers: map_storage_report(&report.buffers),
         textures: map_storage_report(&report.textures),
@@ -1026,41 +1026,7 @@ pub fn write_global_report(
     report: &wgc::global::GlobalReport,
 ) {
     native_report.surfaces = map_storage_report(&report.surfaces);
-
-    #[cfg(any(
-        all(
-            any(target_os = "ios", target_os = "macos"),
-            feature = "vulkan-portability"
-        ),
-        windows,
-        all(unix, not(target_os = "ios"), not(target_os = "macos"))
-    ))]
-    if let Some(ref vulkan) = report.vulkan {
-        native_report.vulkan = map_hub_report(vulkan);
-        native_report.backendType = native::WGPUBackendType_Vulkan;
-    }
-
-    #[cfg(all(any(target_os = "ios", target_os = "macos"), feature = "metal"))]
-    if let Some(ref metal) = report.metal {
-        native_report.metal = map_hub_report(metal);
-        native_report.backendType = native::WGPUBackendType_Metal;
-    }
-
-    #[cfg(all(target_os = "windows", feature = "dx12"))]
-    if let Some(ref dx12) = report.dx12 {
-        native_report.dx12 = map_hub_report(dx12);
-        native_report.backendType = native::WGPUBackendType_D3D12;
-    }
-
-    #[cfg(any(
-        feature = "angle",
-        target_os = "windows",
-        all(unix, not(target_os = "ios"), not(target_os = "macos"))
-    ))]
-    if let Some(ref gl) = report.gl {
-        native_report.gl = map_hub_report(gl);
-        native_report.backendType = native::WGPUBackendType_OpenGL;
-    }
+    native_report.hub = map_hub_report(&report.hub);
 }
 
 #[inline]

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -293,7 +293,7 @@ pub fn map_instance_descriptor(
             backends: map_instance_backend_flags(extras.backends as native::WGPUInstanceBackend),
             dx12_shader_compiler,
             gles_minor_version: map_gles3_minor_version(extras.gles3MinorVersion),
-            flags: match extras.flags as native::WGPUInstanceFlag {
+            flags: match extras.flags {
                 native::WGPUInstanceFlag_Default => wgt::InstanceFlags::default(),
                 flags => map_instance_flags(flags),
             },

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -385,10 +385,7 @@ pub unsafe fn map_pipeline_layout_descriptor<'a>(
 }
 
 #[inline]
-pub fn write_limits_struct(
-    wgt_limits: wgt::Limits,
-    limits: &mut native::WGPULimits,
-) {
+pub fn write_limits_struct(wgt_limits: wgt::Limits, limits: &mut native::WGPULimits) {
     limits.maxTextureDimension1D = wgt_limits.max_texture_dimension_1d;
     limits.maxTextureDimension2D = wgt_limits.max_texture_dimension_2d;
     limits.maxTextureDimension3D = wgt_limits.max_texture_dimension_3d;

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -94,19 +94,23 @@ map_enum_with_undefined!(
     WGPUBlendFactor,
     wgt::BlendFactor,
     "Unknown blend factor",
-    Zero: Zero,
-    One: One,
-    Src: Src,
-    OneMinusSrc: OneMinusSrc,
-    SrcAlpha: SrcAlpha,
-    OneMinusSrcAlpha: OneMinusSrcAlpha,
-    Dst: Dst,
-    OneMinusDst: OneMinusDst,
-    DstAlpha: DstAlpha,
-    OneMinusDstAlpha: OneMinusDstAlpha,
-    SrcAlphaSaturated: SrcAlphaSaturated,
-    Constant: Constant,
-    OneMinusConstant: OneMinusConstant
+    Zero,
+    One,
+    Src,
+    OneMinusSrc,
+    SrcAlpha,
+    OneMinusSrcAlpha,
+    Dst,
+    OneMinusDst,
+    DstAlpha,
+    OneMinusDstAlpha,
+    SrcAlphaSaturated,
+    Constant,
+    OneMinusConstant,
+    Src1,
+    OneMinusSrc1,
+    Src1Alpha,
+    OneMinusSrc1Alpha
 );
 map_enum_with_undefined!(
     map_blend_operation,
@@ -1101,7 +1105,9 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::FLOAT32_FILTERABLE) {
         temp.push(native::WGPUFeatureName_Float32Filterable);
     }
-
+    if features.contains(wgt::Features::DUAL_SOURCE_BLENDING) {
+        temp.push(native::WGPUFeatureName_DualSourceBlending);
+    }
     // wgpu-rs only features
     if features.contains(wgt::Features::PUSH_CONSTANTS) {
         temp.push(native::WGPUNativeFeature_PushConstants);
@@ -1227,7 +1233,10 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUFeatureName_ShaderF16 => Some(Features::SHADER_F16),
         native::WGPUFeatureName_RG11B10UfloatRenderable => Some(Features::RG11B10UFLOAT_RENDERABLE),
         native::WGPUFeatureName_BGRA8UnormStorage => Some(Features::BGRA8UNORM_STORAGE),
+        // TODO: WGPUFeatureName_ClipDistances
+        // TODO: WGPUFeatureName_Float32Blendable
         native::WGPUFeatureName_Float32Filterable => Some(Features::FLOAT32_FILTERABLE),
+        native::WGPUFeatureName_DualSourceBlending => Some(Features::DUAL_SOURCE_BLENDING),
 
         // wgpu-rs only features
         native::WGPUNativeFeature_PushConstants => Some(Features::PUSH_CONSTANTS),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -773,13 +773,7 @@ pub unsafe extern "C" fn wgpuAdapterRequestDevice(
     };
 
     let result =
-        context.adapter_request_device(
-            adapter_id,
-            &desc,
-            ptr_into_path(trace_str),
-            None,
-            None
-        );
+        context.adapter_request_device(adapter_id, &desc, ptr_into_path(trace_str), None, None);
     match result {
         Ok((device_id, queue_id)) => {
             let message = CString::default();
@@ -885,7 +879,7 @@ pub unsafe extern "C" fn wgpuBufferGetConstMappedRange(
         match size {
             conv::WGPU_WHOLE_MAP_SIZE => None,
             _ => Some(size as u64),
-        }
+        },
     ) {
         Ok((ptr, _)) => ptr,
         Err(err) => handle_error_fatal(err, "wgpuBufferGetConstMappedRange"),
@@ -911,7 +905,7 @@ pub unsafe extern "C" fn wgpuBufferGetMappedRange(
         match size {
             conv::WGPU_WHOLE_MAP_SIZE => None,
             _ => Some(size as u64),
-        }
+        },
     ) {
         Ok((ptr, _)) => ptr,
         Err(err) => handle_error_fatal(err, "wgpuBufferGetMappedRange"),
@@ -1209,7 +1203,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearBuffer(
             0 => panic!("invalid size"),
             conv::WGPU_WHOLE_SIZE => None,
             _ => Some(size),
-        }
+        },
     ) {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderClearBuffer");
     }
@@ -1241,7 +1235,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyBufferToBuffer(
         source_offset,
         destination_buffer_id,
         destination_offset,
-        size
+        size,
     ) {
         handle_error(
             error_sink,
@@ -1272,7 +1266,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyBufferToTexture(
         command_encoder_id,
         &conv::map_image_copy_buffer(source.expect("invalid source")),
         &conv::map_image_copy_texture(destination.expect("invalid destination")),
-        &conv::map_extent3d(copy_size.expect("invalid copy size"))
+        &conv::map_extent3d(copy_size.expect("invalid copy size")),
     ) {
         handle_error(
             error_sink,
@@ -1303,7 +1297,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyTextureToBuffer(
         command_encoder_id,
         &conv::map_image_copy_texture(source.expect("invalid source")),
         &conv::map_image_copy_buffer(destination.expect("invalid destination")),
-        &conv::map_extent3d(copy_size.expect("invalid copy size"))
+        &conv::map_extent3d(copy_size.expect("invalid copy size")),
     ) {
         handle_error(
             error_sink,
@@ -1334,7 +1328,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyTextureToTexture(
         command_encoder_id,
         &conv::map_image_copy_texture(source.expect("invalid source")),
         &conv::map_image_copy_texture(destination.expect("invalid destination")),
-        &conv::map_extent3d(copy_size.expect("invalid copy size"))
+        &conv::map_extent3d(copy_size.expect("invalid copy size")),
     ) {
         handle_error(
             error_sink,
@@ -1391,8 +1385,10 @@ pub unsafe extern "C" fn wgpuCommandEncoderInsertDebugMarker(
         )
     };
 
-    if let Err(cause) = context.command_encoder_insert_debug_marker(command_encoder_id, CStr::from_ptr(marker_label).to_str().unwrap())
-    {
+    if let Err(cause) = context.command_encoder_insert_debug_marker(
+        command_encoder_id,
+        CStr::from_ptr(marker_label).to_str().unwrap(),
+    ) {
         handle_error(
             error_sink,
             cause,
@@ -1415,8 +1411,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderPopDebugGroup(
         )
     };
 
-    if let Err(cause) = context.command_encoder_pop_debug_group(command_encoder_id)
-    {
+    if let Err(cause) = context.command_encoder_pop_debug_group(command_encoder_id) {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderPopDebugGroup");
     }
 }
@@ -1435,8 +1430,10 @@ pub unsafe extern "C" fn wgpuCommandEncoderPushDebugGroup(
         )
     };
 
-    if let Err(cause) = context.command_encoder_push_debug_group(command_encoder_id, CStr::from_ptr(group_label).to_str().unwrap())
-    {
+    if let Err(cause) = context.command_encoder_push_debug_group(
+        command_encoder_id,
+        CStr::from_ptr(group_label).to_str().unwrap(),
+    ) {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderPushDebugGroup");
     }
 }
@@ -1467,7 +1464,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderResolveQuerySet(
         first_query,
         query_count,
         destination_buffer_id,
-        destination_offset
+        destination_offset,
     ) {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderResolveQuerySet");
     }
@@ -1489,11 +1486,9 @@ pub unsafe extern "C" fn wgpuCommandEncoderWriteTimestamp(
     };
     let query_set_id = query_set.as_ref().expect("invalid query set").id;
 
-    if let Err(cause) = context.command_encoder_write_timestamp(
-        command_encoder_id,
-        query_set_id,
-        query_index
-    ) {
+    if let Err(cause) =
+        context.command_encoder_write_timestamp(command_encoder_id, query_set_id, query_index)
+    {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderWriteTimestamp");
     }
 }
@@ -1551,7 +1546,11 @@ pub unsafe extern "C" fn wgpuComputePassEncoderDispatchWorkgroupsIndirect(
 
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.compute_pass_dispatch_workgroups_indirect(encoder, indirect_buffer_id, indirect_offset) {
+    match pass.context.compute_pass_dispatch_workgroups_indirect(
+        encoder,
+        indirect_buffer_id,
+        indirect_offset,
+    ) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -1676,7 +1675,10 @@ pub unsafe extern "C" fn wgpuComputePassEncoderSetPipeline(
         .id;
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.compute_pass_set_pipeline(encoder, compute_pipeline_id) {
+    match pass
+        .context
+        .compute_pass_set_pipeline(encoder, compute_pipeline_id)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -1720,7 +1722,8 @@ pub unsafe extern "C" fn wgpuComputePipelineGetBindGroupLayout(
         (pipeline.id, &pipeline.context, &pipeline.error_sink)
     };
 
-    let (bind_group_layout_id, error) = context.compute_pipeline_get_bind_group_layout(pipeline_id, group_index, None);
+    let (bind_group_layout_id, error) =
+        context.compute_pipeline_get_bind_group_layout(pipeline_id, group_index, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -1781,8 +1784,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroup(
         layout: bind_group_layout_id,
         entries: Cow::Borrowed(&entries),
     };
-    let (bind_group_id, error) =
-        context.device_create_bind_group(device_id, &desc, None);
+    let (bind_group_id, error) = context.device_create_bind_group(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, desc.label, "wgpuDeviceCreateBindGroup");
     }
@@ -1852,8 +1854,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBuffer(
         mapped_at_creation: descriptor.mappedAtCreation != 0,
     };
 
-    let (buffer_id, error) =
-        context.device_create_buffer(device_id, &desc, None);
+    let (buffer_id, error) = context.device_create_buffer(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, desc.label, "wgpuDeviceCreateBuffer");
     }
@@ -1884,8 +1885,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateCommandEncoder(
         },
         None => wgt::CommandEncoderDescriptor::default(),
     };
-    let (command_encoder_id, error) =
-        context.device_create_command_encoder(device_id, &desc, None);
+    let (command_encoder_id, error) = context.device_create_command_encoder(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -1947,12 +1947,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateComputePipeline(
         cache: None,
     };
 
-    let (compute_pipeline_id, error) = context.device_create_compute_pipeline(
-        device_id,
-        &desc,
-        None,
-        None
-    );
+    let (compute_pipeline_id, error) =
+        context.device_create_compute_pipeline(device_id, &desc, None, None);
     if let Some(cause) = error {
         if let wgc::pipeline::CreateComputePipelineError::Internal(ref error) = cause {
             log::warn!(
@@ -1993,8 +1989,7 @@ pub unsafe extern "C" fn wgpuDeviceCreatePipelineLayout(
             (descriptor),
             WGPUSType_PipelineLayoutExtras => native::WGPUPipelineLayoutExtras)
     );
-    let (pipeline_layout_id, error) =
-        context.device_create_pipeline_layout(device_id, &desc, None);
+    let (pipeline_layout_id, error) = context.device_create_pipeline_layout(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -2027,8 +2022,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateQuerySet(
             WGPUSType_QuerySetDescriptorExtras => native::WGPUQuerySetDescriptorExtras)
     );
 
-    let (query_set_id, error) =
-        context.device_create_query_set(device_id, &desc, None);
+    let (query_set_id, error) = context.device_create_query_set(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, desc.label, "wgpuDeviceCreateQuerySet");
     }
@@ -2247,7 +2241,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
         cache: None,
     };
 
-    let (render_pipeline_id, error) = context.device_create_render_pipeline(device_id, &desc, None, None);
+    let (render_pipeline_id, error) =
+        context.device_create_render_pipeline(device_id, &desc, None, None);
     if let Some(cause) = error {
         if let wgc::pipeline::CreateRenderPipelineError::Internal { stage, ref error } = cause {
             log::error!("Shader translation error for stage {:?}: {}", stage, error);
@@ -2317,8 +2312,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateSampler(
         },
     };
 
-    let (sampler_id, error) =
-        context.device_create_sampler(device_id, &desc, None);
+    let (sampler_id, error) = context.device_create_sampler(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, desc.label, "wgpuDeviceCreateSampler");
     }
@@ -2367,7 +2361,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModule(
         }
     };
 
-    let (shader_module_id, error) = context.device_create_shader_module(device_id, &desc, source, None);
+    let (shader_module_id, error) =
+        context.device_create_shader_module(device_id, &desc, source, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -2412,8 +2407,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateTexture(
             .collect(),
     };
 
-    let (texture_id, error) =
-        context.device_create_texture(device_id, &desc, None);
+    let (texture_id, error) = context.device_create_texture(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, desc.label, "wgpuDeviceCreateTexture");
     }
@@ -2661,10 +2655,7 @@ pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
                 backend_type => panic!("invalid backend type: 0x{backend_type:08X}"),
             },
         ),
-        None => (
-            wgt::RequestAdapterOptions::default(),
-            wgt::Backends::all(),
-        ),
+        None => (wgt::RequestAdapterOptions::default(), wgt::Backends::all()),
     };
 
     match context.request_adapter(&desc, inputs, None) {
@@ -2707,8 +2698,9 @@ pub unsafe extern "C" fn wgpuInstanceEnumerateAdapters(
     let context = &instance.context;
 
     let inputs = match options {
-        Some(options) =>
-            map_instance_backend_flags(options.backends as native::WGPUInstanceBackend),
+        Some(options) => {
+            map_instance_backend_flags(options.backends as native::WGPUInstanceBackend)
+        }
         None => wgt::Backends::all(),
     };
 
@@ -2730,9 +2722,7 @@ pub unsafe extern "C" fn wgpuInstanceEnumerateAdapters(
     } else {
         // Drop all the adapters when only counting length.
 
-        result
-            .iter()
-            .for_each(|id| context.adapter_drop(*id));
+        result.iter().for_each(|id| context.adapter_drop(*id));
     }
 
     count
@@ -2859,7 +2849,7 @@ pub unsafe extern "C" fn wgpuQueueWriteBuffer(
         queue_id,
         buffer_id,
         buffer_offset,
-        make_slice(data, data_size)
+        make_slice(data, data_size),
     ) {
         handle_error(error_sink, cause, None, "wgpuQueueWriteBuffer");
     }
@@ -2884,7 +2874,7 @@ pub unsafe extern "C" fn wgpuQueueWriteTexture(
         &conv::map_image_copy_texture(destination.expect("invalid destination")),
         make_slice(data, data_size),
         &conv::map_texture_data_layout(data_layout.expect("invalid data layout")),
-        &conv::map_extent3d(write_size.expect("invalid write size"))
+        &conv::map_extent3d(write_size.expect("invalid write size")),
     ) {
         handle_error(error_sink, cause, None, "wgpuQueueWriteTexture");
     }
@@ -3193,7 +3183,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderBeginOcclusionQuery(
     let pass = pass.as_ref().expect("invalid render pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_begin_occlusion_query(encoder, query_index) {
+    match pass
+        .context
+        .render_pass_begin_occlusion_query(encoder, query_index)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3270,7 +3263,11 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDrawIndexedIndirect(
         .id;
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_draw_indexed_indirect(encoder, indirect_buffer_id, indirect_offset) {
+    match pass.context.render_pass_draw_indexed_indirect(
+        encoder,
+        indirect_buffer_id,
+        indirect_offset,
+    ) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3294,7 +3291,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDrawIndirect(
         .id;
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_draw_indirect(encoder, indirect_buffer_id, indirect_offset) {
+    match pass
+        .context
+        .render_pass_draw_indirect(encoder, indirect_buffer_id, indirect_offset)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3347,7 +3347,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderExecuteBundles(
         .collect::<SmallVec<[_; 4]>>();
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_execute_bundles(encoder, &bundle_ids) {
+    match pass
+        .context
+        .render_pass_execute_bundles(encoder, &bundle_ids)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3457,10 +3460,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetBlendConstant(
     let pass = pass.as_ref().expect("invalid render pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_set_blend_constant(
-        encoder,
-        conv::map_color(color.expect("invalid color")),
-    ) {
+    match pass
+        .context
+        .render_pass_set_blend_constant(encoder, conv::map_color(color.expect("invalid color")))
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3516,7 +3519,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetPipeline(
         .id;
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_set_pipeline(encoder, render_pipeline_id) {
+    match pass
+        .context
+        .render_pass_set_pipeline(encoder, render_pipeline_id)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3538,7 +3544,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetScissorRect(
     let pass = pass.as_ref().expect("invalid render pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_set_scissor_rect(encoder, x, y, width, height) {
+    match pass
+        .context
+        .render_pass_set_scissor_rect(encoder, x, y, width, height)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3557,7 +3566,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetStencilReference(
     let pass = pass.as_ref().expect("invalid render pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_set_stencil_reference(encoder, reference) {
+    match pass
+        .context
+        .render_pass_set_stencil_reference(encoder, reference)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3615,7 +3627,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetViewport(
     let pass = pass.as_ref().expect("invalid render pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_set_viewport(encoder, x, y, width, height, min_depth, max_depth) {
+    match pass
+        .context
+        .render_pass_set_viewport(encoder, x, y, width, height, min_depth, max_depth)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3662,7 +3677,8 @@ pub unsafe extern "C" fn wgpuRenderPipelineGetBindGroupLayout(
             &render_pipeline.error_sink,
         )
     };
-    let (bind_group_layout_id, error) = context.render_pipeline_get_bind_group_layout(render_pipeline_id, group_index, None);
+    let (bind_group_layout_id, error) =
+        context.render_pipeline_get_bind_group_layout(render_pipeline_id, group_index, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -3735,8 +3751,7 @@ pub unsafe extern "C" fn wgpuSurfaceConfigure(
         WGPUSType_SurfaceConfigurationExtras => native::WGPUSurfaceConfigurationExtras
     ));
 
-    match context.surface_configure(surface.id, device.id, &surface_config)
-    {
+    match context.surface_configure(surface.id, device.id, &surface_config) {
         Some(cause) => handle_error_fatal(cause, "wgpuSurfaceConfigure"),
         None => {
             let mut surface_data_guard = surface.data.lock();
@@ -3775,8 +3790,7 @@ pub unsafe extern "C" fn wgpuSurfaceGetCapabilities(
     let surface_id = surface.as_ref().expect("invalid surface").id;
     let capabilities = capabilities.expect("invalid return pointer \"capabilities\"");
 
-    let caps = match context.surface_get_capabilities(surface_id, adapter_id)
-    {
+    let caps = match context.surface_get_capabilities(surface_id, adapter_id) {
         Ok(caps) => caps,
         Err(wgc::instance::GetSurfaceSupportError::Unsupported) => {
             wgt::SurfaceCapabilities::default()
@@ -3857,8 +3871,7 @@ pub unsafe extern "C" fn wgpuSurfaceGetCurrentTexture(
         ),
     };
 
-    match context.surface_get_current_texture(surface.id, None)
-    {
+    match context.surface_get_current_texture(surface.id, None) {
         Ok(wgc::present::SurfaceOutput { status, texture_id }) => {
             surface
                 .has_surface_presented
@@ -3896,7 +3909,7 @@ pub unsafe extern "C" fn wgpuSurfaceGetCurrentTexture(
 pub unsafe extern "C" fn wgpuSurfacePresent(surface: native::WGPUSurface) {
     let surface = surface.as_ref().expect("invalid surface");
     let context = &surface.context;
-    
+
     match context.surface_present(surface.id) {
         Ok(_status) => surface
             .has_surface_presented
@@ -3991,8 +4004,7 @@ pub unsafe extern "C" fn wgpuTextureCreateView(
         None => wgc::resource::TextureViewDescriptor::default(),
     };
 
-    let (texture_view_id, error) =
-        context.texture_create_view(texture_id, &desc, None);
+    let (texture_view_id, error) = context.texture_create_view(texture_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, None, "wgpuTextureCreateView");
     }
@@ -4143,9 +4155,7 @@ pub unsafe extern "C" fn wgpuDevicePoll(
 
     let maintain = match wait {
         true => match submission_index {
-            Some(index) => {
-                wgt::Maintain::WaitForSubmissionIndex(*index)
-            }
+            Some(index) => wgt::Maintain::WaitForSubmissionIndex(*index),
             None => wgt::Maintain::Wait,
         },
         false => wgt::Maintain::Poll,
@@ -4197,7 +4207,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndirect(
     let buffer_id = buffer.as_ref().expect("invalid buffer").id;
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_multi_draw_indirect(encoder, buffer_id, offset, count) {
+    match pass
+        .context
+        .render_pass_multi_draw_indirect(encoder, buffer_id, offset, count)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4219,7 +4232,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndexedIndirect(
     let buffer_id = buffer.as_ref().expect("invalid buffer").id;
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_multi_draw_indexed_indirect(encoder, buffer_id, offset, count) {
+    match pass
+        .context
+        .render_pass_multi_draw_indexed_indirect(encoder, buffer_id, offset, count)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4304,7 +4320,11 @@ pub unsafe extern "C" fn wgpuComputePassEncoderBeginPipelineStatisticsQuery(
     let query_set_id = query_set.as_ref().expect("invalid query set").id;
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.compute_pass_begin_pipeline_statistics_query(encoder, query_set_id, query_index) {
+    match pass.context.compute_pass_begin_pipeline_statistics_query(
+        encoder,
+        query_set_id,
+        query_index,
+    ) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4322,7 +4342,10 @@ pub unsafe extern "C" fn wgpuComputePassEncoderEndPipelineStatisticsQuery(
     let pass = pass.as_ref().expect("invalid compute pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.compute_pass_end_pipeline_statistics_query(encoder) {
+    match pass
+        .context
+        .compute_pass_end_pipeline_statistics_query(encoder)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4343,7 +4366,11 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderBeginPipelineStatisticsQuery(
     let query_set_id = query_set.as_ref().expect("invalid query set").id;
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_begin_pipeline_statistics_query(encoder, query_set_id, query_index) {
+    match pass.context.render_pass_begin_pipeline_statistics_query(
+        encoder,
+        query_set_id,
+        query_index,
+    ) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4361,7 +4388,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderEndPipelineStatisticsQuery(
     let pass = pass.as_ref().expect("invalid render pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_end_pipeline_statistics_query(encoder) {
+    match pass
+        .context
+        .render_pass_end_pipeline_statistics_query(encoder)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1008,21 +1008,13 @@ pub unsafe extern "C" fn wgpuBufferMapAsync(
         callback: Some(wgc::resource::BufferMapCallback::from_rust(Box::new(
             move |result: resource::BufferAccessResult| {
                 let (status, message) = match result {
-                    Ok(()) => (native::WGPUBufferMapAsyncStatus_Success, CString::default()),
+                    Ok(()) => (native::WGPUMapAsyncStatus_Success, CString::default()),
                     Err(cause) => {
                         let code = match cause {
-                            resource::BufferAccessError::Device(_) => {
-                                native::WGPUBufferMapAsyncStatus_DeviceLost
+                            resource::BufferAccessError::MapAborted => {
+                                native::WGPUMapAsyncStatus_Aborted
                             }
-                            resource::BufferAccessError::MapAlreadyPending => {
-                                native::WGPUBufferMapAsyncStatus_MappingAlreadyPending
-                            }
-                            resource::BufferAccessError::InvalidBufferId(_)
-                            | resource::BufferAccessError::DestroyedResource(_) => {
-                                native::WGPUBufferMapAsyncStatus_DestroyedBeforeCallback
-                            }
-                            _ => native::WGPUBufferMapAsyncStatus_ValidationError, // TODO: WGPUBufferMapAsyncStatus_OffsetOutOfRange
-                                                                                   // TODO: WGPUBufferMapAsyncStatus_SizeOutOfRange
+                            _ => native::WGPUMapAsyncStatus_Error,
                         };
 
                         (code, CString::new(format_error(&cause)).unwrap())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ use utils::{
     get_base_device_limits_from_adapter_limits, make_slice, ptr_into_label, ptr_into_path,
 };
 use wgc::{
-    command::{bundle_ffi, DynComputePass, DynRenderPass},
-    gfx_select, id, resource, Label,
+    command::{bundle_ffi, ComputePass, RenderPass},
+    id, resource, Label,
 };
 
 pub mod conv;
@@ -48,7 +48,7 @@ impl Drop for WGPUAdapterImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.adapter_drop(self.id));
+            context.adapter_drop(self.id);
         }
     }
 }
@@ -61,7 +61,7 @@ impl Drop for WGPUBindGroupImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.bind_group_drop(self.id));
+            context.bind_group_drop(self.id);
         }
     }
 }
@@ -74,7 +74,7 @@ impl Drop for WGPUBindGroupLayoutImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.bind_group_layout_drop(self.id));
+            context.bind_group_layout_drop(self.id);
         }
     }
 }
@@ -93,7 +93,7 @@ impl Drop for WGPUBufferImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.buffer_drop(self.id, false));
+            context.buffer_drop(self.id);
         }
     }
 }
@@ -107,7 +107,7 @@ impl Drop for WGPUCommandBufferImpl {
     fn drop(&mut self) {
         if self.open.load(atomic::Ordering::SeqCst) && !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.command_buffer_drop(self.id));
+            context.command_buffer_drop(self.id);
         }
     }
 }
@@ -122,22 +122,15 @@ impl Drop for WGPUCommandEncoderImpl {
     fn drop(&mut self) {
         if self.open.load(atomic::Ordering::SeqCst) && !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.command_encoder_drop(self.id));
+            context.command_encoder_drop(self.id);
         }
     }
 }
 
 pub struct WGPUComputePassEncoderImpl {
     context: Arc<Context>,
-    encoder: *mut dyn DynComputePass,
+    encoder: Box<ComputePass>,
     error_sink: ErrorSink,
-}
-impl Drop for WGPUComputePassEncoderImpl {
-    fn drop(&mut self) {
-        if !thread::panicking() {
-            drop(unsafe { Box::from_raw(self.encoder) });
-        }
-    }
 }
 // ComputePassEncoder is thread-unsafe
 unsafe impl Send for WGPUComputePassEncoderImpl {}
@@ -152,7 +145,7 @@ impl Drop for WGPUComputePipelineImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.compute_pipeline_drop(self.id));
+            context.compute_pipeline_drop(self.id);
         }
     }
 }
@@ -165,7 +158,7 @@ impl Drop for QueueId {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.queue_drop(self.id));
+            context.queue_drop(self.id);
         }
     }
 }
@@ -181,12 +174,12 @@ impl Drop for WGPUDeviceImpl {
         if !thread::panicking() {
             let context = &self.context;
 
-            match gfx_select!(self.id => context.device_poll(self.id, wgt::Maintain::Wait)) {
+            match context.device_poll(self.id, wgt::Maintain::Wait) {
                 Ok(_) => (),
                 Err(err) => handle_error_fatal(err, "WGPUDeviceImpl::drop"),
             }
 
-            gfx_select!(self.id => context.device_drop(self.id));
+            context.device_drop(self.id);
         }
     }
 }
@@ -203,7 +196,7 @@ impl Drop for WGPUPipelineLayoutImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.pipeline_layout_drop(self.id));
+            context.pipeline_layout_drop(self.id);
         }
     }
 }
@@ -221,7 +214,7 @@ impl Drop for WGPUQuerySetImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.query_set_drop(self.id));
+            context.query_set_drop(self.id);
         }
     }
 }
@@ -239,7 +232,7 @@ impl Drop for WGPURenderBundleImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.render_bundle_drop(self.id));
+            context.render_bundle_drop(self.id);
         }
     }
 }
@@ -264,15 +257,8 @@ unsafe impl Sync for WGPURenderBundleEncoderImpl {}
 
 pub struct WGPURenderPassEncoderImpl {
     context: Arc<Context>,
-    encoder: *mut dyn DynRenderPass,
+    encoder: Box<RenderPass>,
     error_sink: ErrorSink,
-}
-impl Drop for WGPURenderPassEncoderImpl {
-    fn drop(&mut self) {
-        if !thread::panicking() {
-            drop(unsafe { Box::from_raw(self.encoder) });
-        }
-    }
 }
 // RenderPassEncodee is thread-unsafe
 unsafe impl Send for WGPURenderPassEncoderImpl {}
@@ -287,7 +273,7 @@ impl Drop for WGPURenderPipelineImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.render_pipeline_drop(self.id));
+            context.render_pipeline_drop(self.id);
         }
     }
 }
@@ -300,7 +286,7 @@ impl Drop for WGPUSamplerImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            gfx_select!(self.id => context.sampler_drop(self.id));
+            context.sampler_drop(self.id);
         }
     }
 }
@@ -314,7 +300,7 @@ impl Drop for WGPUShaderModuleImpl {
         if let Some(id) = self.id {
             if !thread::panicking() {
                 let context = &self.context;
-                gfx_select!(id => context.shader_module_drop(id));
+                context.shader_module_drop(id);
             }
         }
     }
@@ -369,7 +355,7 @@ impl Drop for WGPUTextureImpl {
             Some(surface_id) => {
                 if !self.has_surface_presented.load(atomic::Ordering::SeqCst) {
                     let context = &self.context;
-                    match gfx_select!(self.id => context.surface_texture_discard(surface_id)) {
+                    match context.surface_texture_discard(surface_id) {
                         Ok(_) => (),
                         Err(cause) => handle_error_fatal(cause, "wgpuTextureRelease"),
                     }
@@ -377,7 +363,7 @@ impl Drop for WGPUTextureImpl {
             }
             None => {
                 let context = &self.context;
-                gfx_select!(self.id => context.texture_drop(self.id, false));
+                context.texture_drop(self.id);
             }
         }
     }
@@ -391,7 +377,7 @@ impl Drop for WGPUTextureViewImpl {
     fn drop(&mut self) {
         if !thread::panicking() {
             let context = &self.context;
-            let _ = gfx_select!(self.id => context.texture_view_drop(self.id, false));
+            let _ = context.texture_view_drop(self.id);
         }
     }
 }
@@ -649,10 +635,7 @@ pub unsafe extern "C" fn wgpuAdapterEnumerateFeatures(
         let adapter = adapter.as_ref().expect("invalid adapter");
         (adapter.id, &adapter.context)
     };
-    let adapter_features = match gfx_select!(adapter_id => context.adapter_features(adapter_id)) {
-        Ok(features) => features,
-        Err(err) => handle_error_fatal(err, "wgpuAdapterEnumerateFeatures"),
-    };
+    let adapter_features = context.adapter_features(adapter_id);
 
     let temp = conv::features_to_native(adapter_features);
 
@@ -674,11 +657,8 @@ pub unsafe extern "C" fn wgpuAdapterGetLimits(
     };
     let limits = limits.expect("invalid return pointer \"limits\"");
 
-    let result = gfx_select!(adapter_id => context.adapter_limits(adapter_id));
-    match result {
-        Ok(wgt_limits) => conv::write_limits_struct(wgt_limits, limits),
-        Err(err) => handle_error_fatal(err, "wgpuAdapterGetLimits"),
-    }
+    let wgt_limits = context.adapter_limits(adapter_id);
+    conv::write_limits_struct(wgt_limits, limits);
 
     true as native::WGPUBool // indicates that we can fill WGPUChainedStructOut
 }
@@ -693,11 +673,7 @@ pub unsafe extern "C" fn wgpuAdapterGetInfo(
     let context = adapter.context.as_ref();
     let adapter_id = adapter.id;
 
-    let result = gfx_select!(adapter_id => context.adapter_get_info(adapter_id));
-    let result = match result {
-        Ok(info) => info,
-        Err(err) => handle_error_fatal(err, "wgpuAdapterGetInfo"),
-    };
+    let result = context.adapter_get_info(adapter_id);
 
     info.vendor = CString::new(result.driver).unwrap().into_raw();
     info.architecture = CString::default().into_raw(); // TODO(webgpu.h)
@@ -718,10 +694,7 @@ pub unsafe extern "C" fn wgpuAdapterHasFeature(
         let adapter = adapter.as_ref().expect("invalid adapter");
         (adapter.id, &adapter.context)
     };
-    let adapter_features = match gfx_select!(adapter_id => context.adapter_features(adapter_id)) {
-        Ok(features) => features,
-        Err(err) => handle_error_fatal(err, "wgpuAdapterHasFeature"),
-    };
+    let adapter_features = context.adapter_features(adapter_id);
 
     let feature = match conv::map_feature(feature) {
         Some(feature) => feature,
@@ -760,19 +733,7 @@ pub unsafe extern "C" fn wgpuAdapterRequestDevice(
     };
     let callback = callback.expect("invalid callback");
 
-    let adapter_limits = match gfx_select!(adapter_id => context.adapter_limits(adapter_id)) {
-        Ok(adapter_limits) => adapter_limits,
-        Err(cause) => {
-            let msg = CString::new(format_error(&cause)).unwrap();
-            callback(
-                native::WGPURequestDeviceStatus_Error,
-                std::ptr::null(),
-                msg.as_ptr(),
-                userdata,
-            );
-            return;
-        }
-    };
+    let adapter_limits = context.adapter_limits(adapter_id);
     let base_limits = get_base_device_limits_from_adapter_limits(&adapter_limits);
 
     let (desc, trace_str, device_lost_handler, error_callback) = match descriptor {
@@ -798,17 +759,16 @@ pub unsafe extern "C" fn wgpuAdapterRequestDevice(
         ),
     };
 
-    let (device_id, queue_id, err) = gfx_select!(adapter_id =>
+    let result =
         context.adapter_request_device(
             adapter_id,
             &desc,
             ptr_into_path(trace_str),
             None,
             None
-        )
-    );
-    match err {
-        None => {
+        );
+    match result {
+        Ok((device_id, queue_id)) => {
             let message = CString::default();
             let mut error_sink = ErrorSinkRaw::new(device_lost_handler);
             if let Some(error_callback) = error_callback {
@@ -830,7 +790,7 @@ pub unsafe extern "C" fn wgpuAdapterRequestDevice(
                 userdata,
             );
         }
-        Some(err) => {
+        Err(err) => {
             let message = CString::new(format_error(&err)).unwrap();
             callback(
                 native::WGPURequestDeviceStatus_Error,
@@ -892,7 +852,7 @@ pub unsafe extern "C" fn wgpuBufferDestroy(buffer: native::WGPUBuffer) {
         (buffer.id, &buffer.context)
     };
     // Per spec, no error to report. Even calling destroy multiple times is valid.
-    let _ = gfx_select!(buffer_id => context.buffer_destroy(buffer_id));
+    let _ = context.buffer_destroy(buffer_id);
 }
 
 #[no_mangle]
@@ -906,14 +866,14 @@ pub unsafe extern "C" fn wgpuBufferGetConstMappedRange(
         (buffer.id, &buffer.context)
     };
 
-    let buf = match gfx_select!(buffer_id => context.buffer_get_mapped_range(
+    let buf = match context.buffer_get_mapped_range(
         buffer_id,
         offset as wgt::BufferAddress,
         match size {
             conv::WGPU_WHOLE_MAP_SIZE => None,
             _ => Some(size as u64),
         }
-    )) {
+    ) {
         Ok((ptr, _)) => ptr,
         Err(err) => handle_error_fatal(err, "wgpuBufferGetConstMappedRange"),
     };
@@ -932,14 +892,14 @@ pub unsafe extern "C" fn wgpuBufferGetMappedRange(
         (buffer.id, &buffer.context)
     };
 
-    let buf = match gfx_select!(buffer_id => context.buffer_get_mapped_range(
+    let buf = match context.buffer_get_mapped_range(
         buffer_id,
         offset as wgt::BufferAddress,
         match size {
             conv::WGPU_WHOLE_MAP_SIZE => None,
             _ => Some(size as u64),
         }
-    )) {
+    ) {
         Ok((ptr, _)) => ptr,
         Err(err) => handle_error_fatal(err, "wgpuBufferGetMappedRange"),
     };
@@ -993,7 +953,7 @@ pub unsafe extern "C" fn wgpuBufferMapAsync(
                     Err(resource::BufferAccessError::MapAlreadyPending) => {
                         native::WGPUBufferMapAsyncStatus_MappingAlreadyPending
                     }
-                    Err(resource::BufferAccessError::InvalidBufferId(_))
+                    Err(resource::BufferAccessError::InvalidResource(_))
                     | Err(resource::BufferAccessError::DestroyedResource(_)) => {
                         native::WGPUBufferMapAsyncStatus_DestroyedBeforeCallback
                     }
@@ -1007,12 +967,12 @@ pub unsafe extern "C" fn wgpuBufferMapAsync(
         ))),
     };
 
-    if let Err(cause) = gfx_select!(buffer_id => context.buffer_map_async(
+    if let Err(cause) = context.buffer_map_async(
         buffer_id,
         offset as wgt::BufferAddress,
         Some(size as wgt::BufferAddress),
         operation,
-    )) {
+    ) {
         handle_error(error_sink, cause, None, "wgpuBufferMapAsync");
     };
 }
@@ -1024,7 +984,7 @@ pub unsafe extern "C" fn wgpuBufferUnmap(buffer: native::WGPUBuffer) {
         (buffer.id, &buffer.context, &buffer.error_sink)
     };
 
-    if let Err(cause) = gfx_select!(buffer_id => context.buffer_unmap(buffer_id)) {
+    if let Err(cause) = context.buffer_unmap(buffer_id) {
         handle_error(error_sink, cause, None, "wgpuBufferUnmap");
     }
 }
@@ -1093,7 +1053,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginComputePass(
         None => wgc::command::ComputePassDescriptor::default(),
     };
 
-    let (pass, err) = gfx_select!(command_encoder_id => context.command_encoder_create_compute_pass_dyn(command_encoder_id, &desc));
+    let (pass, err) = context.command_encoder_create_compute_pass(command_encoder_id, &desc);
     if let Some(cause) = err {
         handle_error(
             error_sink,
@@ -1104,7 +1064,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginComputePass(
     }
     Arc::into_raw(Arc::new(WGPUComputePassEncoderImpl {
         context: context.clone(),
-        encoder: Box::into_raw(pass),
+        encoder: Box::new(pass),
         error_sink: error_sink.clone(),
     }))
 }
@@ -1195,7 +1155,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
         occlusion_query_set: descriptor.occlusionQuerySet.as_ref().map(|v| v.id),
     };
 
-    let (pass, err) = gfx_select!(command_encoder_id => context.command_encoder_create_render_pass_dyn(command_encoder_id, &desc));
+    let (pass, err) = context.command_encoder_create_render_pass(command_encoder_id, &desc);
     if let Some(cause) = err {
         handle_error(
             error_sink,
@@ -1206,7 +1166,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
     }
     Arc::into_raw(Arc::new(WGPURenderPassEncoderImpl {
         context: context.clone(),
-        encoder: Box::into_raw(pass),
+        encoder: Box::new(pass),
         error_sink: error_sink.clone(),
     }))
 }
@@ -1228,7 +1188,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearBuffer(
     };
     let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
-    if let Err(cause) = gfx_select!(command_encoder_id => context.command_encoder_clear_buffer(
+    if let Err(cause) = context.command_encoder_clear_buffer(
         command_encoder_id,
         buffer_id,
         offset,
@@ -1237,7 +1197,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearBuffer(
             conv::WGPU_WHOLE_SIZE => None,
             _ => Some(size),
         }
-    )) {
+    ) {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderClearBuffer");
     }
 }
@@ -1262,14 +1222,14 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyBufferToBuffer(
     let source_buffer_id = source.as_ref().expect("invalid source").id;
     let destination_buffer_id = destination.as_ref().expect("invalid destination").id;
 
-    if let Err(cause) = gfx_select!(command_encoder_id => context.command_encoder_copy_buffer_to_buffer(
+    if let Err(cause) = context.command_encoder_copy_buffer_to_buffer(
         command_encoder_id,
         source_buffer_id,
         source_offset,
         destination_buffer_id,
         destination_offset,
         size
-    )) {
+    ) {
         handle_error(
             error_sink,
             cause,
@@ -1295,12 +1255,12 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyBufferToTexture(
         )
     };
 
-    if let Err(cause) = gfx_select!(command_encoder_id => context.command_encoder_copy_buffer_to_texture(
+    if let Err(cause) = context.command_encoder_copy_buffer_to_texture(
         command_encoder_id,
         &conv::map_image_copy_buffer(source.expect("invalid source")),
         &conv::map_image_copy_texture(destination.expect("invalid destination")),
         &conv::map_extent3d(copy_size.expect("invalid copy size"))
-    )) {
+    ) {
         handle_error(
             error_sink,
             cause,
@@ -1326,12 +1286,12 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyTextureToBuffer(
         )
     };
 
-    if let Err(cause) = gfx_select!(command_encoder_id => context.command_encoder_copy_texture_to_buffer(
+    if let Err(cause) = context.command_encoder_copy_texture_to_buffer(
         command_encoder_id,
         &conv::map_image_copy_texture(source.expect("invalid source")),
         &conv::map_image_copy_buffer(destination.expect("invalid destination")),
         &conv::map_extent3d(copy_size.expect("invalid copy size"))
-    )) {
+    ) {
         handle_error(
             error_sink,
             cause,
@@ -1357,12 +1317,12 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyTextureToTexture(
         )
     };
 
-    if let Err(cause) = gfx_select!(command_encoder_id => context.command_encoder_copy_texture_to_texture(
+    if let Err(cause) = context.command_encoder_copy_texture_to_texture(
         command_encoder_id,
         &conv::map_image_copy_texture(source.expect("invalid source")),
         &conv::map_image_copy_texture(destination.expect("invalid destination")),
         &conv::map_extent3d(copy_size.expect("invalid copy size"))
-    )) {
+    ) {
         handle_error(
             error_sink,
             cause,
@@ -1392,7 +1352,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderFinish(
         None => wgt::CommandBufferDescriptor::default(),
     };
 
-    let (command_buffer_id, error) = gfx_select!(command_encoder_id => context.command_encoder_finish(command_encoder_id, &desc));
+    let (command_buffer_id, error) = context.command_encoder_finish(command_encoder_id, &desc);
     if let Some(cause) = error {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderFinish");
     }
@@ -1418,7 +1378,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderInsertDebugMarker(
         )
     };
 
-    if let Err(cause) = gfx_select!(command_encoder_id => context.command_encoder_insert_debug_marker(command_encoder_id, CStr::from_ptr(marker_label).to_str().unwrap()))
+    if let Err(cause) = context.command_encoder_insert_debug_marker(command_encoder_id, CStr::from_ptr(marker_label).to_str().unwrap())
     {
         handle_error(
             error_sink,
@@ -1442,7 +1402,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderPopDebugGroup(
         )
     };
 
-    if let Err(cause) = gfx_select!(command_encoder_id => context.command_encoder_pop_debug_group(command_encoder_id))
+    if let Err(cause) = context.command_encoder_pop_debug_group(command_encoder_id)
     {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderPopDebugGroup");
     }
@@ -1462,7 +1422,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderPushDebugGroup(
         )
     };
 
-    if let Err(cause) = gfx_select!(command_encoder_id => context.command_encoder_push_debug_group(command_encoder_id, CStr::from_ptr(group_label).to_str().unwrap()))
+    if let Err(cause) = context.command_encoder_push_debug_group(command_encoder_id, CStr::from_ptr(group_label).to_str().unwrap())
     {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderPushDebugGroup");
     }
@@ -1488,14 +1448,14 @@ pub unsafe extern "C" fn wgpuCommandEncoderResolveQuerySet(
     let query_set_id = query_set.as_ref().expect("invalid query set").id;
     let destination_buffer_id = destination.as_ref().expect("invalid destination").id;
 
-    if let Err(cause) = gfx_select!(command_encoder_id => context.command_encoder_resolve_query_set(
+    if let Err(cause) = context.command_encoder_resolve_query_set(
         command_encoder_id,
         query_set_id,
         first_query,
         query_count,
         destination_buffer_id,
         destination_offset
-    )) {
+    ) {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderResolveQuerySet");
     }
 }
@@ -1516,11 +1476,11 @@ pub unsafe extern "C" fn wgpuCommandEncoderWriteTimestamp(
     };
     let query_set_id = query_set.as_ref().expect("invalid query set").id;
 
-    if let Err(cause) = gfx_select!(command_encoder_id => context.command_encoder_write_timestamp(
+    if let Err(cause) = context.command_encoder_write_timestamp(
         command_encoder_id,
         query_set_id,
         query_index
-    )) {
+    ) {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderWriteTimestamp");
     }
 }
@@ -1546,10 +1506,10 @@ pub unsafe extern "C" fn wgpuComputePassEncoderDispatchWorkgroups(
     workgroup_count_z: u32,
 ) {
     let pass = pass.as_ref().expect("invalid compute pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.dispatch_workgroups(
-        &pass.context,
+    match pass.context.compute_pass_dispatch_workgroups(
+        encoder,
         workgroup_count_x,
         workgroup_count_y,
         workgroup_count_z,
@@ -1576,9 +1536,9 @@ pub unsafe extern "C" fn wgpuComputePassEncoderDispatchWorkgroupsIndirect(
         .expect("invalid indirect buffer")
         .id;
 
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.dispatch_workgroups_indirect(&pass.context, indirect_buffer_id, indirect_offset) {
+    match pass.context.compute_pass_dispatch_workgroups_indirect(encoder, indirect_buffer_id, indirect_offset) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -1592,9 +1552,9 @@ pub unsafe extern "C" fn wgpuComputePassEncoderDispatchWorkgroupsIndirect(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuComputePassEncoderEnd(pass: native::WGPUComputePassEncoder) {
     let pass = pass.as_ref().expect("invalid compute pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.end(&pass.context) {
+    match pass.context.compute_pass_end(encoder) {
         Ok(()) => (),
         Err(cause) => handle_error(&pass.error_sink, cause, None, "wgpuComputePassEncoderEnd"),
     }
@@ -1606,10 +1566,10 @@ pub unsafe extern "C" fn wgpuComputePassEncoderInsertDebugMarker(
     marker_label: *const std::ffi::c_char,
 ) {
     let pass = pass.as_ref().expect("invalid compute pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.insert_debug_marker(
-        &pass.context,
+    match pass.context.compute_pass_insert_debug_marker(
+        encoder,
         CStr::from_ptr(marker_label).to_str().unwrap(),
         0,
     ) {
@@ -1626,9 +1586,9 @@ pub unsafe extern "C" fn wgpuComputePassEncoderInsertDebugMarker(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuComputePassEncoderPopDebugGroup(pass: native::WGPUComputePassEncoder) {
     let pass = pass.as_ref().expect("invalid compute pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.pop_debug_group(&pass.context) {
+    match pass.context.compute_pass_pop_debug_group(encoder) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -1645,10 +1605,10 @@ pub unsafe extern "C" fn wgpuComputePassEncoderPushDebugGroup(
     group_label: *const std::ffi::c_char,
 ) {
     let pass = pass.as_ref().expect("invalid compute pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.push_debug_group(
-        &pass.context,
+    match pass.context.compute_pass_push_debug_group(
+        encoder,
         CStr::from_ptr(group_label).to_str().unwrap(),
         0,
     ) {
@@ -1673,12 +1633,12 @@ pub unsafe extern "C" fn wgpuComputePassEncoderSetBindGroup(
     let pass = pass.as_ref().expect("invalid compute pass");
     //TODO: as per webgpu.h bindgroup is nullable
     let bind_group_id = bind_group.as_ref().expect("invalid bind group").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_bind_group(
-        &pass.context,
+    match pass.context.compute_pass_set_bind_group(
+        encoder,
         group_index,
-        bind_group_id,
+        Some(bind_group_id),
         make_slice(dynamic_offsets, dynamic_offset_count),
     ) {
         Ok(()) => (),
@@ -1701,9 +1661,9 @@ pub unsafe extern "C" fn wgpuComputePassEncoderSetPipeline(
         .as_ref()
         .expect("invalid compute pipeline")
         .id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_pipeline(&pass.context, compute_pipeline_id) {
+    match pass.context.compute_pass_set_pipeline(encoder, compute_pipeline_id) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -1747,7 +1707,7 @@ pub unsafe extern "C" fn wgpuComputePipelineGetBindGroupLayout(
         (pipeline.id, &pipeline.context, &pipeline.error_sink)
     };
 
-    let (bind_group_layout_id, error) = gfx_select!(pipeline_id => context.compute_pipeline_get_bind_group_layout(pipeline_id, group_index, None));
+    let (bind_group_layout_id, error) = context.compute_pipeline_get_bind_group_layout(pipeline_id, group_index, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -1809,7 +1769,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroup(
         entries: Cow::Borrowed(&entries),
     };
     let (bind_group_id, error) =
-        gfx_select!(device_id => context.device_create_bind_group(device_id, &desc, None));
+        context.device_create_bind_group(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, desc.label, "wgpuDeviceCreateBindGroup");
     }
@@ -1845,7 +1805,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBindGroupLayout(
         entries: Cow::Borrowed(&entries),
     };
     let (bind_group_layout_id, error) =
-        gfx_select!(device_id => context.device_create_bind_group_layout(device_id, &desc, None));
+        context.device_create_bind_group_layout(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -1880,7 +1840,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateBuffer(
     };
 
     let (buffer_id, error) =
-        gfx_select!(device_id => context.device_create_buffer(device_id, &desc, None));
+        context.device_create_buffer(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, desc.label, "wgpuDeviceCreateBuffer");
     }
@@ -1912,7 +1872,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateCommandEncoder(
         None => wgt::CommandEncoderDescriptor::default(),
     };
     let (command_encoder_id, error) =
-        gfx_select!(device_id => context.device_create_command_encoder(device_id, &desc, None));
+        context.device_create_command_encoder(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -1969,19 +1929,17 @@ pub unsafe extern "C" fn wgpuDeviceCreateComputePipeline(
             ),
             // TODO(wgpu.h)
             zero_initialize_workgroup_memory: false,
-            // TODO(wgpu.h)
-            vertex_pulling_transform: false,
         },
         // TODO(wgpu.h)
         cache: None,
     };
 
-    let (compute_pipeline_id, error) = gfx_select!(device_id => context.device_create_compute_pipeline(
+    let (compute_pipeline_id, error) = context.device_create_compute_pipeline(
         device_id,
         &desc,
         None,
         None
-    ));
+    );
     if let Some(cause) = error {
         if let wgc::pipeline::CreateComputePipelineError::Internal(ref error) = cause {
             log::warn!(
@@ -2023,7 +1981,7 @@ pub unsafe extern "C" fn wgpuDeviceCreatePipelineLayout(
             WGPUSType_PipelineLayoutExtras => native::WGPUPipelineLayoutExtras)
     );
     let (pipeline_layout_id, error) =
-        gfx_select!(device_id => context.device_create_pipeline_layout(device_id, &desc, None));
+        context.device_create_pipeline_layout(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -2057,7 +2015,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateQuerySet(
     );
 
     let (query_set_id, error) =
-        gfx_select!(device_id => context.device_create_query_set(device_id, &desc, None));
+        context.device_create_query_set(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, desc.label, "wgpuDeviceCreateQuerySet");
     }
@@ -2148,8 +2106,6 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
                 ),
                 // TODO(wgpu.h)
                 zero_initialize_workgroup_memory: false,
-                // TODO(wgpu.h)
-                vertex_pulling_transform: false,
             },
             buffers: Cow::Owned(
                 make_slice(descriptor.vertex.buffers, descriptor.vertex.bufferCount)
@@ -2250,8 +2206,6 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
                     ),
                     // TODO(wgpu.h)
                     zero_initialize_workgroup_memory: false,
-                    // TODO(wgpu.h)
-                    vertex_pulling_transform: false,
                 },
                 targets: Cow::Owned(
                     make_slice(fragment.targets, fragment.targetCount)
@@ -2280,7 +2234,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
         cache: None,
     };
 
-    let (render_pipeline_id, error) = gfx_select!(device_id => context.device_create_render_pipeline(device_id, &desc, None, None));
+    let (render_pipeline_id, error) = context.device_create_render_pipeline(device_id, &desc, None, None);
     if let Some(cause) = error {
         if let wgc::pipeline::CreateRenderPipelineError::Internal { stage, ref error } = cause {
             log::error!("Shader translation error for stage {:?}: {}", stage, error);
@@ -2351,7 +2305,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateSampler(
     };
 
     let (sampler_id, error) =
-        gfx_select!(device_id => context.device_create_sampler(device_id, &desc, None));
+        context.device_create_sampler(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, desc.label, "wgpuDeviceCreateSampler");
     }
@@ -2400,7 +2354,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModule(
         }
     };
 
-    let (shader_module_id, error) = gfx_select!(device_id => context.device_create_shader_module(device_id, &desc, source, None));
+    let (shader_module_id, error) = context.device_create_shader_module(device_id, &desc, source, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -2446,7 +2400,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateTexture(
     };
 
     let (texture_id, error) =
-        gfx_select!(device_id => context.device_create_texture(device_id, &desc, None));
+        context.device_create_texture(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, desc.label, "wgpuDeviceCreateTexture");
     }
@@ -2482,10 +2436,7 @@ pub unsafe extern "C" fn wgpuDeviceEnumerateFeatures(
         let device = device.as_ref().expect("invalid device");
         (device.id, &device.context)
     };
-    let device_features = match gfx_select!(device_id => context.device_features(device_id)) {
-        Ok(features) => features,
-        Err(err) => handle_error_fatal(err, "wgpuDeviceEnumerateFeatures"),
-    };
+    let device_features = context.device_features(device_id);
 
     let temp = conv::features_to_native(device_features);
 
@@ -2507,11 +2458,8 @@ pub unsafe extern "C" fn wgpuDeviceGetLimits(
     };
     let limits = limits.expect("invalid return pointer \"limits\"");
 
-    let result = gfx_select!(device_id => context.device_limits(device_id));
-    match result {
-        Ok(wgt_limits) => conv::write_limits_struct(wgt_limits, limits),
-        Err(err) => handle_error_fatal(err, "wgpuDeviceGetLimits"),
-    }
+    let wgt_limits = context.device_limits(device_id);
+    conv::write_limits_struct(wgt_limits, limits);
 
     true as native::WGPUBool // indicates that we can fill WGPUChainedStructOut
 }
@@ -2538,10 +2486,7 @@ pub unsafe extern "C" fn wgpuDeviceHasFeature(
         let device = device.as_ref().expect("invalid device");
         (device.id, &device.context)
     };
-    let device_features = match gfx_select!(device_id => context.device_features(device_id)) {
-        Ok(features) => features,
-        Err(err) => handle_error_fatal(err, "wgpuDeviceHasFeature"),
-    };
+    let device_features = context.device_features(device_id);
 
     let feature = match conv::map_feature(feature) {
         Some(feature) => feature,
@@ -2682,37 +2627,34 @@ pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
                 force_fallback_adapter: options.forceFallbackAdapter != 0,
                 compatible_surface: options.compatibleSurface.as_ref().map(|surface| surface.id),
             },
-            wgc::instance::AdapterInputs::Mask(
-                match options.backendType {
-                    native::WGPUBackendType_Undefined => wgt::Backends::all(),
-                    native::WGPUBackendType_Null => wgt::Backends::empty(),
-                    native::WGPUBackendType_WebGPU => wgt::Backends::BROWSER_WEBGPU,
-                    native::WGPUBackendType_D3D12 => wgt::Backends::DX12,
-                    native::WGPUBackendType_Metal => wgt::Backends::METAL,
-                    native::WGPUBackendType_Vulkan => wgt::Backends::VULKAN,
-                    native::WGPUBackendType_OpenGL => wgt::Backends::GL,
-                    native::WGPUBackendType_OpenGLES => wgt::Backends::GL,
-                    native::WGPUBackendType_D3D11 => {
-                        callback(
-                            native::WGPURequestAdapterStatus_Error,
-                            std::ptr::null_mut(),
-                            "unsupported backend type: d3d11".as_ptr() as _,
-                            userdata,
-                        );
-                        return;
-                    }
-                    backend_type => panic!("invalid backend type: 0x{backend_type:08X}"),
-                },
-                |_| None,
-            ),
+            match options.backendType {
+                native::WGPUBackendType_Undefined => wgt::Backends::all(),
+                native::WGPUBackendType_Null => wgt::Backends::empty(),
+                native::WGPUBackendType_WebGPU => wgt::Backends::BROWSER_WEBGPU,
+                native::WGPUBackendType_D3D12 => wgt::Backends::DX12,
+                native::WGPUBackendType_Metal => wgt::Backends::METAL,
+                native::WGPUBackendType_Vulkan => wgt::Backends::VULKAN,
+                native::WGPUBackendType_OpenGL => wgt::Backends::GL,
+                native::WGPUBackendType_OpenGLES => wgt::Backends::GL,
+                native::WGPUBackendType_D3D11 => {
+                    callback(
+                        native::WGPURequestAdapterStatus_Error,
+                        std::ptr::null_mut(),
+                        "unsupported backend type: d3d11".as_ptr() as _,
+                        userdata,
+                    );
+                    return;
+                }
+                backend_type => panic!("invalid backend type: 0x{backend_type:08X}"),
+            },
         ),
         None => (
             wgt::RequestAdapterOptions::default(),
-            wgc::instance::AdapterInputs::Mask(wgt::Backends::all(), |_| None),
+            wgt::Backends::all(),
         ),
     };
 
-    match context.request_adapter(&desc, inputs) {
+    match context.request_adapter(&desc, inputs, None) {
         Ok(adapter_id) => {
             let message = CString::default();
             callback(
@@ -2731,9 +2673,6 @@ pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
                 match err {
                     wgc::instance::RequestAdapterError::NotFound => {
                         native::WGPURequestAdapterStatus_Unavailable
-                    }
-                    wgc::instance::RequestAdapterError::InvalidSurface(_) => {
-                        native::WGPURequestAdapterStatus_Error
                     }
                     _ => native::WGPURequestAdapterStatus_Unknown,
                 },
@@ -2755,11 +2694,9 @@ pub unsafe extern "C" fn wgpuInstanceEnumerateAdapters(
     let context = &instance.context;
 
     let inputs = match options {
-        Some(options) => wgc::instance::AdapterInputs::Mask(
+        Some(options) =>
             map_instance_backend_flags(options.backends as native::WGPUInstanceBackend),
-            |_| None,
-        ),
-        None => wgc::instance::AdapterInputs::Mask(wgt::Backends::all(), |_| None),
+        None => wgt::Backends::all(),
     };
 
     let result = context.enumerate_adapters(inputs);
@@ -2782,7 +2719,7 @@ pub unsafe extern "C" fn wgpuInstanceEnumerateAdapters(
 
         result
             .iter()
-            .for_each(|id| gfx_select!(id => context.adapter_drop(*id)));
+            .for_each(|id| context.adapter_drop(*id));
     }
 
     count
@@ -2863,11 +2800,7 @@ pub unsafe extern "C" fn wgpuQueueOnSubmittedWorkDone(
         callback(native::WGPUQueueWorkDoneStatus_Success, userdata.as_ptr());
     }));
 
-    if let Err(cause) =
-        gfx_select!(queue_id => context.queue_on_submitted_work_done(queue_id, closure))
-    {
-        handle_error_fatal(cause, "wgpuQueueOnSubmittedWorkDone");
-    };
+    context.queue_on_submitted_work_done(queue_id, closure);
 }
 
 #[no_mangle]
@@ -2890,8 +2823,8 @@ pub unsafe extern "C" fn wgpuQueueSubmit(
         })
         .collect::<SmallVec<[_; 4]>>();
 
-    if let Err(cause) = gfx_select!(queue_id => context.queue_submit(queue_id, &command_buffers)) {
-        handle_error_fatal(cause, "wgpuQueueSubmit");
+    if let Err(cause) = context.queue_submit(queue_id, &command_buffers) {
+        handle_error_fatal(cause.1, "wgpuQueueSubmit");
     }
 }
 
@@ -2909,12 +2842,12 @@ pub unsafe extern "C" fn wgpuQueueWriteBuffer(
     };
     let buffer_id = buffer.as_ref().expect("invalid buffer").id;
 
-    if let Err(cause) = gfx_select!(queue_id => context.queue_write_buffer(
+    if let Err(cause) = context.queue_write_buffer(
         queue_id,
         buffer_id,
         buffer_offset,
         make_slice(data, data_size)
-    )) {
+    ) {
         handle_error(error_sink, cause, None, "wgpuQueueWriteBuffer");
     }
 }
@@ -2933,13 +2866,13 @@ pub unsafe extern "C" fn wgpuQueueWriteTexture(
         (queue.queue.id, &queue.queue.context, &queue.error_sink)
     };
 
-    if let Err(cause) = gfx_select!(queue_id => context.queue_write_texture(
+    if let Err(cause) = context.queue_write_texture(
         queue_id,
         &conv::map_image_copy_texture(destination.expect("invalid destination")),
         make_slice(data, data_size),
         &conv::map_texture_data_layout(data_layout.expect("invalid data layout")),
         &conv::map_extent3d(write_size.expect("invalid write size"))
-    )) {
+    ) {
         handle_error(error_sink, cause, None, "wgpuQueueWriteTexture");
     }
 }
@@ -3074,7 +3007,7 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderFinish(
         None => wgt::RenderBundleDescriptor::default(),
     };
 
-    let (render_bundle_id, error) = gfx_select!(encoder.parent() => context.render_bundle_encoder_finish(*encoder, &desc, None));
+    let (render_bundle_id, error) = context.render_bundle_encoder_finish(*encoder, &desc, None);
     if let Some(cause) = error {
         handle_error_fatal(cause, "wgpuRenderBundleEncoderFinish");
     }
@@ -3141,7 +3074,7 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetBindGroup(
     bundle_ffi::wgpu_render_bundle_set_bind_group(
         encoder,
         group_index,
-        bind_group_id,
+        Some(bind_group_id),
         dynamic_offsets,
         dynamic_offset_count,
     );
@@ -3245,9 +3178,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderBeginOcclusionQuery(
     query_index: u32,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.begin_occlusion_query(&pass.context, query_index) {
+    match pass.context.render_pass_begin_occlusion_query(encoder, query_index) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3267,10 +3200,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDraw(
     first_instance: u32,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.draw(
-        &pass.context,
+    match pass.context.render_pass_draw(
+        encoder,
         vertex_count,
         instance_count,
         first_vertex,
@@ -3291,10 +3224,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDrawIndexed(
     first_instance: u32,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.draw_indexed(
-        &pass.context,
+    match pass.context.render_pass_draw_indexed(
+        encoder,
         index_count,
         instance_count,
         first_index,
@@ -3322,9 +3255,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDrawIndexedIndirect(
         .as_ref()
         .expect("invalid indirect buffer")
         .id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.draw_indexed_indirect(&pass.context, indirect_buffer_id, indirect_offset) {
+    match pass.context.render_pass_draw_indexed_indirect(encoder, indirect_buffer_id, indirect_offset) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3346,9 +3279,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDrawIndirect(
         .as_ref()
         .expect("invalid indirect buffer")
         .id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.draw_indirect(&pass.context, indirect_buffer_id, indirect_offset) {
+    match pass.context.render_pass_draw_indirect(encoder, indirect_buffer_id, indirect_offset) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3362,9 +3295,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderDrawIndirect(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderPassEncoderEnd(pass: native::WGPURenderPassEncoder) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.end(&pass.context) {
+    match pass.context.render_pass_end(encoder) {
         Ok(()) => (),
         Err(cause) => handle_error(&pass.error_sink, cause, None, "wgpuRenderPassEncoderEnd"),
     }
@@ -3375,9 +3308,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderEndOcclusionQuery(
     pass: native::WGPURenderPassEncoder,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.end_occlusion_query(&pass.context) {
+    match pass.context.render_pass_end_occlusion_query(encoder) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3399,9 +3332,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderExecuteBundles(
         .iter()
         .map(|v| v.as_ref().expect("invalid render bundle").id)
         .collect::<SmallVec<[_; 4]>>();
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.execute_bundles(&pass.context, &bundle_ids) {
+    match pass.context.render_pass_execute_bundles(encoder, &bundle_ids) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3418,10 +3351,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderInsertDebugMarker(
     marker_label: *const std::ffi::c_char,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.insert_debug_marker(
-        &pass.context,
+    match pass.context.render_pass_insert_debug_marker(
+        encoder,
         CStr::from_ptr(marker_label).to_str().unwrap(),
         0,
     ) {
@@ -3438,9 +3371,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderInsertDebugMarker(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuRenderPassEncoderPopDebugGroup(pass: native::WGPURenderPassEncoder) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.pop_debug_group(&pass.context) {
+    match pass.context.render_pass_pop_debug_group(encoder) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3457,10 +3390,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderPushDebugGroup(
     group_label: *const std::ffi::c_char,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.push_debug_group(
-        &pass.context,
+    match pass.context.render_pass_push_debug_group(
+        encoder,
         CStr::from_ptr(group_label).to_str().unwrap(),
         0,
     ) {
@@ -3485,12 +3418,12 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetBindGroup(
     let pass = pass.as_ref().expect("invalid render pass");
     // TODO: as per webgpu.h bindgroup is nullable
     let bind_group_id = bind_group.as_ref().expect("invalid bind group").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_bind_group(
-        &pass.context,
+    match pass.context.render_pass_set_bind_group(
+        encoder,
         group_index,
-        bind_group_id,
+        Some(bind_group_id),
         make_slice(dynamic_offsets, dynamic_offset_count),
     ) {
         Ok(()) => (),
@@ -3509,10 +3442,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetBlendConstant(
     color: Option<&native::WGPUColor>,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_blend_constant(
-        &pass.context,
+    match pass.context.render_pass_set_blend_constant(
+        encoder,
         conv::map_color(color.expect("invalid color")),
     ) {
         Ok(()) => (),
@@ -3535,10 +3468,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetIndexBuffer(
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
     let buffer_id = buffer.as_ref().expect("invalid buffer").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_index_buffer(
-        &pass.context,
+    match pass.context.render_pass_set_index_buffer(
+        encoder,
         buffer_id,
         conv::map_index_format(index_format).expect("invalid index format"),
         offset,
@@ -3568,9 +3501,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetPipeline(
         .as_ref()
         .expect("invalid render pipeline")
         .id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_pipeline(&pass.context, render_pipeline_id) {
+    match pass.context.render_pass_set_pipeline(encoder, render_pipeline_id) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3590,9 +3523,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetScissorRect(
     height: u32,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_scissor_rect(&pass.context, x, y, width, height) {
+    match pass.context.render_pass_set_scissor_rect(encoder, x, y, width, height) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3609,9 +3542,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetStencilReference(
     reference: u32,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_stencil_reference(&pass.context, reference) {
+    match pass.context.render_pass_set_stencil_reference(encoder, reference) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3633,10 +3566,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetVertexBuffer(
     let pass = pass.as_ref().expect("invalid render pass");
     // TODO: as per webgpu.h buffer is nullable
     let buffer_id = buffer.as_ref().expect("invalid buffer").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_vertex_buffer(
-        &pass.context,
+    match pass.context.render_pass_set_vertex_buffer(
+        encoder,
         slot,
         buffer_id,
         offset,
@@ -3667,9 +3600,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetViewport(
     max_depth: f32,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_viewport(&pass.context, x, y, width, height, min_depth, max_depth) {
+    match pass.context.render_pass_set_viewport(encoder, x, y, width, height, min_depth, max_depth) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -3716,7 +3649,7 @@ pub unsafe extern "C" fn wgpuRenderPipelineGetBindGroupLayout(
             &render_pipeline.error_sink,
         )
     };
-    let (bind_group_layout_id, error) = gfx_select!(render_pipeline_id => context.render_pipeline_get_bind_group_layout(render_pipeline_id, group_index, None));
+    let (bind_group_layout_id, error) = context.render_pipeline_get_bind_group_layout(render_pipeline_id, group_index, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -3789,7 +3722,7 @@ pub unsafe extern "C" fn wgpuSurfaceConfigure(
         WGPUSType_SurfaceConfigurationExtras => native::WGPUSurfaceConfigurationExtras
     ));
 
-    match wgc::gfx_select!(device.id => context.surface_configure(surface.id, device.id, &surface_config))
+    match context.surface_configure(surface.id, device.id, &surface_config)
     {
         Some(cause) => handle_error_fatal(cause, "wgpuSurfaceConfigure"),
         None => {
@@ -3830,7 +3763,7 @@ pub unsafe extern "C" fn wgpuSurfaceGetCapabilities(
     let surface_id = surface.as_ref().expect("invalid surface").id;
     let capabilities = capabilities.expect("invalid return pointer \"capabilities\"");
 
-    let caps = match wgc::gfx_select!(adapter_id => context.surface_get_capabilities(surface_id, adapter_id))
+    let caps = match context.surface_get_capabilities(surface_id, adapter_id)
     {
         Ok(caps) => caps,
         Err(wgc::instance::GetSurfaceSupportError::Unsupported) => {
@@ -3912,7 +3845,7 @@ pub unsafe extern "C" fn wgpuSurfaceGetCurrentTexture(
         ),
     };
 
-    match wgc::gfx_select!(surface_data.device_id => context.surface_get_current_texture(surface.id, None))
+    match context.surface_get_current_texture(surface.id, None)
     {
         Ok(wgc::present::SurfaceOutput { status, texture_id }) => {
             surface
@@ -3960,7 +3893,7 @@ pub unsafe extern "C" fn wgpuSurfacePresent(surface: native::WGPUSurface) {
         ),
     };
 
-    match wgc::gfx_select!(surface_data.device_id => context.surface_present(surface.id)) {
+    match context.surface_present(surface.id) {
         Ok(_status) => surface
             .has_surface_presented
             .store(true, atomic::Ordering::SeqCst),
@@ -4055,7 +3988,7 @@ pub unsafe extern "C" fn wgpuTextureCreateView(
     };
 
     let (texture_view_id, error) =
-        gfx_select!(texture_id => context.texture_create_view(texture_id, &desc, None));
+        context.texture_create_view(texture_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, None, "wgpuTextureCreateView");
     }
@@ -4074,7 +4007,7 @@ pub unsafe extern "C" fn wgpuTextureDestroy(texture: native::WGPUTexture) {
     };
 
     // Per spec, no error to report. Even calling destroy multiple times is valid.
-    let _ = gfx_select!(texture_id => context.texture_destroy(texture_id));
+    let _ = context.texture_destroy(texture_id);
 }
 
 #[no_mangle]
@@ -4187,9 +4120,9 @@ pub unsafe extern "C" fn wgpuQueueSubmitForIndex(
         })
         .collect::<SmallVec<[_; 4]>>();
 
-    match gfx_select!(queue_id => context.queue_submit(queue_id, &command_buffers)) {
-        Ok(submission_index) => submission_index.index,
-        Err(cause) => handle_error_fatal(cause, "wgpuQueueSubmitForIndex"),
+    match context.queue_submit(queue_id, &command_buffers) {
+        Ok(submission_index) => submission_index,
+        Err(cause) => handle_error_fatal(cause.1, "wgpuQueueSubmitForIndex"),
     }
 }
 
@@ -4197,7 +4130,7 @@ pub unsafe extern "C" fn wgpuQueueSubmitForIndex(
 pub unsafe extern "C" fn wgpuDevicePoll(
     device: native::WGPUDevice,
     wait: bool,
-    wrapped_submission_index: Option<&native::WGPUWrappedSubmissionIndex>,
+    submission_index: Option<&native::WGPUSubmissionIndex>,
 ) -> bool {
     let (device_id, context) = {
         let device = device.as_ref().expect("invalid device");
@@ -4205,24 +4138,16 @@ pub unsafe extern "C" fn wgpuDevicePoll(
     };
 
     let maintain = match wait {
-        true => match wrapped_submission_index {
+        true => match submission_index {
             Some(index) => {
-                wgt::Maintain::WaitForSubmissionIndex(wgc::device::queue::WrappedSubmissionIndex {
-                    queue_id: index
-                        .queue
-                        .as_ref()
-                        .expect("invalid queue for wrapped submission index")
-                        .queue
-                        .id,
-                    index: index.submissionIndex,
-                })
+                wgt::Maintain::WaitForSubmissionIndex(*index)
             }
             None => wgt::Maintain::Wait,
         },
         false => wgt::Maintain::Poll,
     };
 
-    match gfx_select!(device_id => context.device_poll(device_id, maintain)) {
+    match context.device_poll(device_id, maintain) {
         Ok(queue_empty) => queue_empty,
         Err(cause) => {
             handle_error_fatal(cause, "wgpuDevicePoll");
@@ -4239,10 +4164,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetPushConstants(
     data: *const u8,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.set_push_constants(
-        &pass.context,
+    match pass.context.render_pass_set_push_constants(
+        encoder,
         wgt::ShaderStages::from_bits(stages).expect("invalid shader stage"),
         offset,
         make_slice(data, size_bytes as usize),
@@ -4266,9 +4191,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndirect(
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
     let buffer_id = buffer.as_ref().expect("invalid buffer").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.multi_draw_indirect(&pass.context, buffer_id, offset, count) {
+    match pass.context.render_pass_multi_draw_indirect(encoder, buffer_id, offset, count) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4288,9 +4213,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndexedIndirect(
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
     let buffer_id = buffer.as_ref().expect("invalid buffer").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.multi_draw_indexed_indirect(&pass.context, buffer_id, offset, count) {
+    match pass.context.render_pass_multi_draw_indexed_indirect(encoder, buffer_id, offset, count) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4313,10 +4238,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndirectCount(
     let pass = pass.as_ref().expect("invalid render pass");
     let buffer_id = buffer.as_ref().expect("invalid buffer").id;
     let count_buffer_id = count_buffer.as_ref().expect("invalid count buffer").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.multi_draw_indirect_count(
-        &pass.context,
+    match pass.context.render_pass_multi_draw_indirect_count(
+        encoder,
         buffer_id,
         offset,
         count_buffer_id,
@@ -4345,10 +4270,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndexedIndirectCount(
     let pass = pass.as_ref().expect("invalid render pass");
     let buffer_id = buffer.as_ref().expect("invalid buffer").id;
     let count_buffer_id = count_buffer.as_ref().expect("invalid count buffer").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.multi_draw_indexed_indirect_count(
-        &pass.context,
+    match pass.context.render_pass_multi_draw_indexed_indirect_count(
+        encoder,
         buffer_id,
         offset,
         count_buffer_id,
@@ -4373,9 +4298,9 @@ pub unsafe extern "C" fn wgpuComputePassEncoderBeginPipelineStatisticsQuery(
 ) {
     let pass = pass.as_ref().expect("invalid compute pass");
     let query_set_id = query_set.as_ref().expect("invalid query set").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.begin_pipeline_statistics_query(&pass.context, query_set_id, query_index) {
+    match pass.context.compute_pass_begin_pipeline_statistics_query(encoder, query_set_id, query_index) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4391,9 +4316,9 @@ pub unsafe extern "C" fn wgpuComputePassEncoderEndPipelineStatisticsQuery(
     pass: native::WGPUComputePassEncoder,
 ) {
     let pass = pass.as_ref().expect("invalid compute pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.end_pipeline_statistics_query(&pass.context) {
+    match pass.context.compute_pass_end_pipeline_statistics_query(encoder) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4412,9 +4337,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderBeginPipelineStatisticsQuery(
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
     let query_set_id = query_set.as_ref().expect("invalid query set").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.begin_pipeline_statistics_query(&pass.context, query_set_id, query_index) {
+    match pass.context.render_pass_begin_pipeline_statistics_query(encoder, query_set_id, query_index) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4430,9 +4355,9 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderEndPipelineStatisticsQuery(
     pass: native::WGPURenderPassEncoder,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut();
 
-    match encoder.end_pipeline_statistics_query(&pass.context) {
+    match pass.context.render_pass_end_pipeline_statistics_query(encoder) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -650,15 +650,17 @@ pub unsafe extern "C" fn wgpuCreateInstance(
 ) -> native::WGPUInstance {
     let instance_desc = match descriptor {
         Some(descriptor) => {
-            if descriptor.features.timedWaitAnyEnable != 0 || descriptor.features.timedWaitAnyMaxCount > 0 {
+            if descriptor.features.timedWaitAnyEnable != 0
+                || descriptor.features.timedWaitAnyMaxCount > 0
+            {
                 panic!("Unsupported timed WaitAny features specified");
             }
 
             follow_chain!(map_instance_descriptor(
-                    (descriptor),
-                    WGPUSType_InstanceExtras => native::WGPUInstanceExtras
-                ))
-        },
+                (descriptor),
+                WGPUSType_InstanceExtras => native::WGPUInstanceExtras
+            ))
+        }
         None => wgt::InstanceDescriptor::default(),
     };
 
@@ -676,7 +678,7 @@ pub unsafe extern "C" fn wgpuGetInstanceFeatures(
         nextInChain: std::ptr::null_mut(),
         // WaitAny is currently completely unsupported, so...
         timedWaitAnyEnable: false as native::WGPUBool,
-        timedWaitAnyMaxCount: 0
+        timedWaitAnyMaxCount: 0,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4357,7 +4357,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModuleSpirV(
     let descriptor = descriptor.expect("invalid descriptor");
 
     let desc = wgc::pipeline::ShaderModuleDescriptor {
-        label: ptr_into_label(descriptor.label),
+        label: string_view_into_label(descriptor.label),
         shader_bound_checks: unsafe { wgt::ShaderBoundChecks::unchecked() },
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -715,7 +715,7 @@ fn return_features(native: &mut native::WGPUSupportedFeatures, features: wgt::Fe
 #[no_mangle]
 pub unsafe extern "C" fn wgpuAdapterGetLimits(
     adapter: native::WGPUAdapter,
-    limits: Option<&mut native::WGPUSupportedLimits>,
+    limits: Option<&mut native::WGPULimits>,
 ) -> native::WGPUBool {
     let (adapter_id, context) = {
         let adapter = adapter.as_ref().expect("invalid adapter");
@@ -2572,7 +2572,7 @@ pub unsafe extern "C" fn wgpuSupportedFeaturesFreeMembers(
 #[no_mangle]
 pub unsafe extern "C" fn wgpuDeviceGetLimits(
     device: native::WGPUDevice,
-    limits: Option<&mut native::WGPUSupportedLimits>,
+    limits: Option<&mut native::WGPULimits>,
 ) -> native::WGPUBool {
     let (device_id, context) = {
         let device = device.as_ref().expect("invalid device");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4189,7 +4189,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModuleSpirV(
         descriptor.source,
         descriptor.sourceSize as usize,
     ));
-    let (shader_module_id, error) = gfx_select!(device_id => context.device_create_shader_module_spirv(device_id, &desc, source, None));
+    let (shader_module_id, error) =
+        context.device_create_shader_module_spirv(device_id, &desc, source, None);
     if let Some(cause) = error {
         handle_error(
             error_sink,
@@ -4240,9 +4241,13 @@ pub unsafe extern "C" fn wgpuComputePassEncoderSetPushConstants(
     data: *const u8,
 ) {
     let pass = pass.as_ref().expect("invalid compute pass");
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match encoder.set_push_constants(&pass.context, offset, make_slice(data, size_bytes as usize)) {
+    match pass.context.compute_pass_set_push_constants(
+        encoder,
+        offset,
+        make_slice(data, size_bytes as usize),
+    ) {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4467,9 +4472,12 @@ pub unsafe extern "C" fn wgpuComputePassEncoderWriteTimestamp(
 ) {
     let pass = pass.as_ref().expect("invalid compute pass");
     let query_set_id = query_set.as_ref().expect("invalid query set").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match encoder.write_timestamp(&pass.context, query_set_id, query_index) {
+    match pass
+        .context
+        .compute_pass_write_timestamp(encoder, query_set_id, query_index)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4488,9 +4496,12 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderWriteTimestamp(
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
     let query_set_id = query_set.as_ref().expect("invalid query set").id;
-    let encoder = pass.encoder.as_mut().unwrap();
+    let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match encoder.write_timestamp(&pass.context, query_set_id, query_index) {
+    match pass
+        .context
+        .render_pass_write_timestamp(encoder, query_set_id, query_index)
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,7 +1,6 @@
-use crate::{map_enum, native};
+use crate::{map_enum, native, utils};
 use log::{Level, LevelFilter, Metadata, Record};
 use parking_lot::RwLock;
-use std::ffi::CString;
 
 #[no_mangle]
 pub extern "C" fn wgpuGetVersion() -> std::os::raw::c_uint {
@@ -40,7 +39,6 @@ impl log::Log for Logger {
 
         if let Some(callback) = logger.callback {
             let msg = record.args().to_string();
-            let msg_c = CString::new(msg).unwrap();
             let level = match record.level() {
                 Level::Error => native::WGPULogLevel_Error,
                 Level::Warn => native::WGPULogLevel_Warn,
@@ -50,7 +48,7 @@ impl log::Log for Logger {
             };
 
             unsafe {
-                callback(level, msg_c.as_ptr(), logger.userdata);
+                callback(level, utils::str_into_string_view(&msg), logger.userdata);
             }
 
             // We do not use std::mem::forget(msg_c), so Rust will reclaim the memory

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -2,7 +2,6 @@ use crate::native;
 
 #[no_mangle]
 pub extern "C" fn wgpuGetProcAddress(
-    _device: native::WGPUDevice,
     _proc_name: *const ::std::os::raw::c_char,
 ) -> native::WGPUProc {
     unimplemented!();
@@ -73,9 +72,8 @@ pub extern "C" fn wgpuComputePipelineSetLabel(
 pub extern "C" fn wgpuDeviceCreateComputePipelineAsync(
     _device: native::WGPUDevice,
     _descriptor: *const native::WGPUComputePipelineDescriptor,
-    _callback: native::WGPUDeviceCreateComputePipelineAsyncCallback,
-    _userdata: *mut ::std::os::raw::c_void,
-) {
+    _callback: native::WGPUCreateComputePipelineAsyncCallbackInfo,
+) -> native::WGPUFuture {
     unimplemented!();
 }
 
@@ -83,9 +81,8 @@ pub extern "C" fn wgpuDeviceCreateComputePipelineAsync(
 pub extern "C" fn wgpuDeviceCreateRenderPipelineAsync(
     _device: native::WGPUDevice,
     _descriptor: *const native::WGPURenderPipelineDescriptor,
-    _callback: native::WGPUDeviceCreateRenderPipelineAsyncCallback,
-    _userdata: *mut ::std::os::raw::c_void,
-) {
+    _callback: native::WGPUCreateRenderPipelineAsyncCallbackInfo,
+) -> native::WGPUFuture {
     unimplemented!();
 }
 
@@ -177,9 +174,8 @@ pub extern "C" fn wgpuSamplerSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuShaderModuleGetCompilationInfo(
     _shader_module: native::WGPUShaderModule,
-    _callback: native::WGPUShaderModuleGetCompilationInfoCallback,
-    _userdata: *mut ::std::os::raw::c_void,
-) {
+    _callback: native::WGPUCompilationInfoCallbackInfo,
+) -> native::WGPUFuture {
     unimplemented!();
 }
 
@@ -212,5 +208,15 @@ pub extern "C" fn wgpuTextureViewSetLabel(
     _texture_view: native::WGPUTextureView,
     _label: *const ::std::os::raw::c_char,
 ) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuInstanceWaitAny(
+    _instance: native::WGPUInstance,
+    _future_count: usize,
+    _futures: *mut native::WGPUFutureWaitInfo,
+    _timeout_ns: u64,
+) -> native::WGPUWaitStatus {
     unimplemented!();
 }

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -1,16 +1,14 @@
 use crate::native;
 
 #[no_mangle]
-pub extern "C" fn wgpuGetProcAddress(
-    _proc_name: *const ::std::os::raw::c_char,
-) -> native::WGPUProc {
+pub extern "C" fn wgpuGetProcAddress(_proc_name: native::WGPUStringView) -> native::WGPUProc {
     unimplemented!();
 }
 
 #[no_mangle]
 pub extern "C" fn wgpuBindGroupSetLabel(
     _bind_group: native::WGPUBindGroup,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -18,7 +16,7 @@ pub extern "C" fn wgpuBindGroupSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuBindGroupLayoutSetLabel(
     _bind_group_layout: native::WGPUBindGroupLayout,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -29,17 +27,14 @@ pub extern "C" fn wgpuBufferGetMapState(_buffer: native::WGPUBuffer) -> native::
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuBufferSetLabel(
-    _buffer: native::WGPUBuffer,
-    _label: *const ::std::os::raw::c_char,
-) {
+pub extern "C" fn wgpuBufferSetLabel(_buffer: native::WGPUBuffer, _label: native::WGPUStringView) {
     unimplemented!();
 }
 
 #[no_mangle]
 pub extern "C" fn wgpuCommandBufferSetLabel(
     _command_buffer: native::WGPUCommandBuffer,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -47,7 +42,7 @@ pub extern "C" fn wgpuCommandBufferSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuCommandEncoderSetLabel(
     _command_encoder: native::WGPUCommandEncoder,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -55,7 +50,7 @@ pub extern "C" fn wgpuCommandEncoderSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuComputePassEncoderSetLabel(
     _compute_pass_encoder: native::WGPUComputePassEncoder,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -63,7 +58,7 @@ pub extern "C" fn wgpuComputePassEncoderSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuComputePipelineSetLabel(
     _compute_pipeline: native::WGPUComputePipeline,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -87,10 +82,7 @@ pub extern "C" fn wgpuDeviceCreateRenderPipelineAsync(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuDeviceSetLabel(
-    _device: native::WGPUDevice,
-    _label: *const ::std::os::raw::c_char,
-) {
+pub extern "C" fn wgpuDeviceSetLabel(_device: native::WGPUDevice, _label: native::WGPUStringView) {
     unimplemented!();
 }
 
@@ -110,7 +102,7 @@ pub extern "C" fn wgpuInstanceProcessEvents(_instance: native::WGPUInstance) {
 #[no_mangle]
 pub extern "C" fn wgpuPipelineLayoutSetLabel(
     _pipeline_layout: native::WGPUPipelineLayout,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -118,23 +110,20 @@ pub extern "C" fn wgpuPipelineLayoutSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuQuerySetSetLabel(
     _query_set: native::WGPUQuerySet,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuQueueSetLabel(
-    _queue: native::WGPUQueue,
-    _label: *const ::std::os::raw::c_char,
-) {
+pub extern "C" fn wgpuQueueSetLabel(_queue: native::WGPUQueue, _label: native::WGPUStringView) {
     unimplemented!();
 }
 
 #[no_mangle]
 pub extern "C" fn wgpuRenderBundleSetLabel(
     _render_bundle: native::WGPURenderBundle,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -142,7 +131,7 @@ pub extern "C" fn wgpuRenderBundleSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuRenderBundleEncoderSetLabel(
     _render_bundle_encoder: native::WGPURenderBundleEncoder,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -150,7 +139,7 @@ pub extern "C" fn wgpuRenderBundleEncoderSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuRenderPassEncoderSetLabel(
     _render_pass_encoder: native::WGPURenderPassEncoder,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -158,7 +147,7 @@ pub extern "C" fn wgpuRenderPassEncoderSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuRenderPipelineSetLabel(
     _render_pipeline: native::WGPURenderPipeline,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -166,7 +155,7 @@ pub extern "C" fn wgpuRenderPipelineSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuSamplerSetLabel(
     _sampler: native::WGPUSampler,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -182,7 +171,7 @@ pub extern "C" fn wgpuShaderModuleGetCompilationInfo(
 #[no_mangle]
 pub extern "C" fn wgpuShaderModuleSetLabel(
     _shader_module: native::WGPUShaderModule,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -190,7 +179,7 @@ pub extern "C" fn wgpuShaderModuleSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuSurfaceSetLabel(
     _surface: native::WGPUSurface,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -198,7 +187,7 @@ pub extern "C" fn wgpuSurfaceSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuTextureSetLabel(
     _texture: native::WGPUTexture,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }
@@ -206,7 +195,7 @@ pub extern "C" fn wgpuTextureSetLabel(
 #[no_mangle]
 pub extern "C" fn wgpuTextureViewSetLabel(
     _texture_view: native::WGPUTextureView,
-    _label: *const ::std::os::raw::c_char,
+    _label: native::WGPUStringView,
 ) {
     unimplemented!();
 }

--- a/src/unimplemented.rs
+++ b/src/unimplemented.rs
@@ -82,7 +82,25 @@ pub extern "C" fn wgpuDeviceCreateRenderPipelineAsync(
 }
 
 #[no_mangle]
+pub extern "C" fn wgpuDeviceGetAdapterInfo(_device: native::WGPUDevice) -> native::WGPUAdapterInfo {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuDeviceGetLostFuture(_device: native::WGPUDevice) -> native::WGPUFuture {
+    unimplemented!();
+}
+
+#[no_mangle]
 pub extern "C" fn wgpuDeviceSetLabel(_device: native::WGPUDevice, _label: native::WGPUStringView) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuInstanceGetWGSLLanguageFeatures(
+    _instance: native::WGPUInstance,
+    _features: *mut native::WGPUSupportedWGSLLanguageFeatures,
+) -> native::WGPUStatus {
     unimplemented!();
 }
 
@@ -172,6 +190,13 @@ pub extern "C" fn wgpuShaderModuleGetCompilationInfo(
 pub extern "C" fn wgpuShaderModuleSetLabel(
     _shader_module: native::WGPUShaderModule,
     _label: native::WGPUStringView,
+) {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub extern "C" fn wgpuSupportedWGSLLanguageFeaturesFreeMembers(
+    _supported_wgsl_language_features: native::WGPUSupportedWGSLLanguageFeatures,
 ) {
     unimplemented!();
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -278,14 +278,12 @@ pub unsafe fn string_view_into_str<'a>(string_view: native::WGPUStringView) -> O
             _ => panic!("Null address to WGPUStringView!"),
         }
     } else {
-        unsafe {
-            let bytes = match string_view.length {
-                crate::conv::WGPU_STRLEN => CStr::from_ptr(string_view.data).to_bytes(),
-                _ => make_slice(string_view.data as *const u8, string_view.length),
-            };
+        let bytes = match string_view.length {
+            crate::conv::WGPU_STRLEN => CStr::from_ptr(string_view.data).to_bytes(),
+            _ => make_slice(string_view.data as *const u8, string_view.length),
+        };
 
-            Some(std::str::from_utf8_unchecked(bytes))
-        }
+        Some(std::str::from_utf8_unchecked(bytes))
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -166,7 +166,7 @@ macro_rules! follow_chain {
             $(
                 let mut $stype: Option<&$ty> = None;
             )*
-            let mut chain_opt: Option<&$crate::native::WGPUChainedStruct> = $base1.nextInChain.as_ref();
+            let mut chain_opt: Option<&$crate::native::WGPUChainedStruct> = ($base1.nextInChain as *const $crate::native::WGPUChainedStruct).as_ref();
             while let Some(next_in_chain) = chain_opt {
                 match next_in_chain.sType {
                     $(


### PR DESCRIPTION
This builds on top of #441 (which upgrades `wgpu-core` to v23.0.0), as well as the commits added to #427 after it was forked.

- Only minor compatibility changes were needed to upgrade to latest `webgpu.h` (@PJB3005 did all the heavy work, thanks!).
- The list in `unimplemented.rs` needs to be double checked.
- I've upgraded the examples, but did not intensively tested it in other contexts.
