### PR TITLE
Add RenderBundleEncoderSetPushConstants

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -293,6 +293,7 @@ uint32_t wgpuGetVersion(void);
 
 void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void const * data);
 void wgpuComputePassEncoderSetPushConstants(WGPUComputePassEncoder encoder, uint32_t offset, uint32_t sizeBytes, void const * data);
+void wgpuRenderBundleEncoderSetPushConstants(WGPURenderBundleEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void const * data);
 
 void wgpuRenderPassEncoderMultiDrawIndirect(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);
 void wgpuRenderPassEncoderMultiDrawIndexedIndirect(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4315,6 +4315,28 @@ pub unsafe extern "C" fn wgpuComputePassEncoderSetPushConstants(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wgpuRenderBundleEncoderSetPushConstants(
+    bundle: native::WGPURenderBundleEncoder,
+    stages: native::WGPUShaderStageFlags,
+    offset: u32,
+    size_bytes: u32,
+    data: *const u8,
+) {
+    let bundle = bundle.as_ref().expect("invalid render bundle");
+    let encoder = bundle.encoder.as_mut().expect("invalid render bundle");
+    let encoder = encoder.expect("invalid render bundle");
+    let encoder = encoder.as_mut().unwrap();
+
+    bundle_ffi::wgpu_render_bundle_set_push_constants(
+        encoder,
+        wgt::ShaderStages::from_bits(stages).expect("invalid shader stage"),
+        offset,
+        size_bytes,
+        data,
+    );
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wgpuRenderPassEncoderMultiDrawIndirect(
     pass: native::WGPURenderPassEncoder,
     buffer: native::WGPUBuffer,


### PR DESCRIPTION
RenderBundleEncoder.SetPushConstants is available but broken in wgpu 23.0.0. It should be fixed in 24.0.  This code adds it to wgpu-native.