### PR TITLE
Update README to include Multiplatform wgpu for Kotlin/Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The bindings are based on the WebGPU-native header found at `ffi/webgpu-headers/
 - [dvijaha/WGPUNative.jl](https://github.com/dvijaha/WGPUNative.jl) - stable Julia wrapper
 - [kgpu/wgpuj](https://github.com/kgpu/kgpu/tree/master/wgpuj) - Java/Kotlin wrapper
 - [wgpu4k/wgpu4k](https://github.com/wgpu4k/wgpu4k) - WIP Kotlin Multi Platform wrapper
+- [karmakrafts/Multiplatform wgpu](https://git.karmakrafts.dev/kk/multiplatform-wgpu) - Kotlin/Native wrapper
 - [rajveermalviya/go-webgpu](https://github.com/rajveermalviya/go-webgpu) - Go wrapper
 - [WebGPU-C++](https://github.com/eliemichel/WebGPU-Cpp) - Auto-generated C++ wrapper (developed for the [Learn WebGPU native](https://eliemichel.github.io/LearnWebGPU) course)
 - [jai_wgpu_native](https://github.com/SogoCZE/jai_wgpu_native) - Raw Jai bindings


### PR DESCRIPTION
I made some complete Kotlin/Native bindings for wgpu-native which support the following platforms:
* Windows x64
* Linux x64
* Linux arm64
* macOS x64
* macOS arm64
* iOS x64
* iOS arm64
* Android x64
* Android arm64
* Android arm32 (Mainly to support GK20A based devices like the NVIDIA Shield 2015)

And i feel like they're ready enough to be mentioned in the README of this project.