### PR TITLE
String passed to the callback must be null terminated

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2696,7 +2696,7 @@ pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
                         callback(
                             native::WGPURequestAdapterStatus_Error,
                             std::ptr::null_mut(),
-                            "unsupported backend type: d3d11\0".as_ptr() as _,
+                            c"unsupported backend type: d3d11".as_ptr() as _,
                             userdata,
                         );
                         return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2696,7 +2696,7 @@ pub unsafe extern "C" fn wgpuInstanceRequestAdapter(
                         callback(
                             native::WGPURequestAdapterStatus_Error,
                             std::ptr::null_mut(),
-                            "unsupported backend type: d3d11".as_ptr() as _,
+                            "unsupported backend type: d3d11\0".as_ptr() as _,
                             userdata,
                         );
                         return;


### PR DESCRIPTION
This is quite hard to spot. Stumbled upon it while trying to force `wgpuInstanceRequestAdapter` to return a message in the response.