### PR TITLE
ffi/wgpu.h: Typo in param name & GLSL shader source struct

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -260,7 +260,7 @@ size_t wgpuInstanceEnumerateAdapters(WGPUInstance instance, WGPU_NULLABLE WGPUIn
 WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands);
 
 // Returns true if the queue is empty, or false if there are more queue submissions still in flight.
-WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUSubmissionIndex const * wrappedSubmissionIndex);
+WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUSubmissionIndex const * submissionIndex);
 WGPUShaderModule wgpuDeviceCreateShaderModuleSpirV(WGPUDevice device, WGPUShaderModuleDescriptorSpirV const * descriptor);
 
 void wgpuSetLogCallback(WGPULogCallback callback, void * userdata);

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -8,7 +8,7 @@ typedef enum WGPUNativeSType {
     WGPUSType_DeviceExtras = 0x00030001,
     WGPUSType_NativeLimits = 0x00030002,
     WGPUSType_PipelineLayoutExtras = 0x00030003,
-    WGPUSType_ShaderModuleGLSLDescriptor = 0x00030004,
+    WGPUSType_ShaderSourceGLSL = 0x00030004,
     WGPUSType_InstanceExtras = 0x00030006,
     WGPUSType_BindGroupEntryExtras = 0x00030007,
     WGPUSType_BindGroupLayoutEntryExtras = 0x00030008,
@@ -159,13 +159,13 @@ typedef struct WGPUShaderDefine {
     WGPUStringView value;
 } WGPUShaderDefine;
 
-typedef struct WGPUShaderModuleGLSLDescriptor {
+typedef struct WGPUShaderSourceGLSL {
     WGPUChainedStruct chain;
     WGPUShaderStage stage;
     WGPUStringView code;
     uint32_t defineCount;
     WGPUShaderDefine * defines;
-} WGPUShaderModuleGLSLDescriptor;
+} WGPUShaderSourceGLSL;
 
 typedef struct WGPUShaderModuleDescriptorSpirV {
     WGPUStringView label;

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -583,7 +583,7 @@ pub unsafe fn map_shader_module<'a>(
     _: &native::WGPUShaderModuleDescriptor,
     spirv: Option<&native::WGPUShaderSourceSPIRV>,
     wgsl: Option<&native::WGPUShaderSourceWGSL>,
-    glsl: Option<&native::WGPUShaderModuleGLSLDescriptor>,
+    glsl: Option<&native::WGPUShaderSourceGLSL>,
 ) -> Result<wgc::pipeline::ShaderModuleSource<'a>, ShaderParseError> {
     #[cfg(feature = "wgsl")]
     if let Some(wgsl) = wgsl {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2403,7 +2403,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModule(
         map_shader_module((descriptor),
         WGPUSType_ShaderSourceSPIRV => native::WGPUShaderSourceSPIRV,
         WGPUSType_ShaderSourceWGSL => native::WGPUShaderSourceWGSL,
-        WGPUSType_ShaderModuleGLSLDescriptor => native::WGPUShaderModuleGLSLDescriptor)
+        WGPUSType_ShaderSourceGLSL => native::WGPUShaderSourceGLSL)
     ) {
         Ok(source) => source,
         Err(cause) => {


### PR DESCRIPTION
Presumably this got missed in https://github.com/gfx-rs/wgpu-native/pull/455

I'm going through updating my bindings to v0.24.0, so I might come across other such typos which I'll add to this PR. So feel free to let this sit for a few days :)

I am unsure of if there's a difference between `WGPUShaderModuleDescriptorSpirV` and `WGPUShaderSourceSPIRV`, so I left this as is. `wgpuDeviceCreateShaderModuleSpirV` is to be replaced by `create_shader_module_passthrough` in v25 anyway.