### PR TITLE
Expose WinUI SwapChainPanel as a surface source type

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -14,6 +14,7 @@ typedef enum WGPUNativeSType {
     WGPUSType_BindGroupLayoutEntryExtras = 0x00030008,
     WGPUSType_QuerySetDescriptorExtras = 0x00030009,
     WGPUSType_SurfaceConfigurationExtras = 0x0003000A,
+    WGPUSType_SurfaceSourceSwapChainPanel = 0x0003000B,
     WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeSType;
 
@@ -235,6 +236,18 @@ typedef struct WGPUSurfaceConfigurationExtras {
     WGPUChainedStruct chain;
     uint32_t desiredMaximumFrameLatency;
 } WGPUSurfaceConfigurationExtras WGPU_STRUCTURE_ATTRIBUTE;
+
+/**
+ * Chained in @ref WGPUSurfaceDescriptor to make a @ref WGPUSurface wrapping a WinUI [`SwapChainPanel`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.swapchainpanel).
+ */
+typedef struct WGPUSurfaceSourceSwapChainPanel {
+    WGPUChainedStruct chain;
+    /**
+     * A pointer to the [`ISwapChainPanelNative`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/win32/microsoft.ui.xaml.media.dxinterop/nn-microsoft-ui-xaml-media-dxinterop-iswapchainpanelnative)
+     * interface of the SwapChainPanel that will be wrapped by the @ref WGPUSurface.
+     */
+    void * panelNative;
+} WGPUSurfaceSourceSwapChainPanel WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, WGPUStringView message, void * userdata);
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1604,7 +1604,7 @@ pub enum CreateSurfaceParams {
     #[cfg(all(any(target_os = "ios", target_os = "macos"), feature = "metal"))]
     Metal(*mut std::ffi::c_void),
     #[cfg(all(target_os = "windows", feature = "dx12"))]
-    SwapChainPanel(*mut std::ffi::c_void)
+    SwapChainPanel(*mut std::ffi::c_void),
 }
 
 pub unsafe fn map_surface(

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1603,6 +1603,7 @@ pub enum CreateSurfaceParams {
     ),
     #[cfg(all(any(target_os = "ios", target_os = "macos"), feature = "metal"))]
     Metal(*mut std::ffi::c_void),
+    #[cfg(all(target_os = "windows", feature = "dx12"))]
     SwapChainPanel(*mut std::ffi::c_void)
 }
 
@@ -1614,7 +1615,7 @@ pub unsafe fn map_surface(
     wl: Option<&native::WGPUSurfaceSourceWaylandSurface>,
     _metal: Option<&native::WGPUSurfaceSourceMetalLayer>,
     android: Option<&native::WGPUSurfaceSourceAndroidNativeWindow>,
-    swap_chain_panel: Option<&native::WGPUSurfaceSourceSwapChainPanel>,
+    _swap_chain_panel: Option<&native::WGPUSurfaceSourceSwapChainPanel>,
 ) -> CreateSurfaceParams {
     if let Some(win) = win {
         let display_handle = raw_window_handle::WindowsDisplayHandle::new();
@@ -1679,8 +1680,9 @@ pub unsafe fn map_surface(
         ));
     }
 
-    if let Some(swap_chain_panel) = swap_chain_panel {
-        return CreateSurfaceParams::SwapChainPanel(swap_chain_panel.panelNative)
+    #[cfg(all(target_os = "windows", feature = "dx12"))]
+    if let Some(swap_chain_panel) = _swap_chain_panel {
+        return CreateSurfaceParams::SwapChainPanel(swap_chain_panel.panelNative);
     }
 
     panic!("Error: Unsupported Surface");

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1576,6 +1576,7 @@ pub enum CreateSurfaceParams {
     ),
     #[cfg(all(any(target_os = "ios", target_os = "macos"), feature = "metal"))]
     Metal(*mut std::ffi::c_void),
+    SwapChainPanel(*mut std::ffi::c_void)
 }
 
 pub unsafe fn map_surface(
@@ -1586,6 +1587,7 @@ pub unsafe fn map_surface(
     wl: Option<&native::WGPUSurfaceSourceWaylandSurface>,
     _metal: Option<&native::WGPUSurfaceSourceMetalLayer>,
     android: Option<&native::WGPUSurfaceSourceAndroidNativeWindow>,
+    swap_chain_panel: Option<&native::WGPUSurfaceSourceSwapChainPanel>,
 ) -> CreateSurfaceParams {
     if let Some(win) = win {
         let display_handle = raw_window_handle::WindowsDisplayHandle::new();
@@ -1648,6 +1650,10 @@ pub unsafe fn map_surface(
             raw_window_handle::RawDisplayHandle::Android(display_handle),
             raw_window_handle::RawWindowHandle::AndroidNdk(window_handle),
         ));
+    }
+
+    if let Some(swap_chain_panel) = swap_chain_panel {
+        return CreateSurfaceParams::SwapChainPanel(swap_chain_panel.panelNative)
     }
 
     panic!("Error: Unsupported Surface");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2665,7 +2665,8 @@ pub unsafe extern "C" fn wgpuInstanceCreateSurface(
             WGPUSType_SurfaceSourceXlibWindow => native::WGPUSurfaceSourceXlibWindow,
             WGPUSType_SurfaceSourceWaylandSurface => native::WGPUSurfaceSourceWaylandSurface,
             WGPUSType_SurfaceSourceMetalLayer => native::WGPUSurfaceSourceMetalLayer,
-            WGPUSType_SurfaceSourceAndroidNativeWindow => native::WGPUSurfaceSourceAndroidNativeWindow)
+            WGPUSType_SurfaceSourceAndroidNativeWindow => native::WGPUSurfaceSourceAndroidNativeWindow,
+            WGPUSType_SurfaceSourceSwapChainPanel => native::WGPUSurfaceSourceSwapChainPanel)
     );
 
     let surface_id = match create_surface_params {
@@ -2678,6 +2679,12 @@ pub unsafe extern "C" fn wgpuInstanceCreateSurface(
         #[cfg(all(any(target_os = "ios", target_os = "macos"), feature = "metal"))]
         CreateSurfaceParams::Metal(layer) => {
             match context.instance_create_surface_metal(layer, None) {
+                Ok(surface_id) => surface_id,
+                Err(cause) => handle_error_fatal(cause, "wgpuInstanceCreateSurface"),
+            }
+        }
+        CreateSurfaceParams::SwapChainPanel(panel) => {
+            match context.instance_create_surface_from_swap_chain_panel(panel, None) {
                 Ok(surface_id) => surface_id,
                 Err(cause) => handle_error_fatal(cause, "wgpuInstanceCreateSurface"),
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2675,6 +2675,7 @@ pub unsafe extern "C" fn wgpuInstanceCreateSurface(
                 Err(cause) => handle_error_fatal(cause, "wgpuInstanceCreateSurface"),
             }
         }
+        #[cfg(all(target_os = "windows", feature = "dx12"))]
         CreateSurfaceParams::SwapChainPanel(panel) => {
             match context.instance_create_surface_from_swap_chain_panel(panel, None) {
                 Ok(surface_id) => surface_id,


### PR DESCRIPTION
wgpu added support for WinUI [SwapChainPanels](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.swapchainpanel) in https://github.com/gfx-rs/wgpu/pull/4191.

This PR makes the feature usable through wgpu-native.

Example usage:
```
  WGPUSurfaceSourceSwapChainPanel surfaceSource = {
      .chain = {.sType = (WGPUSType)WGPUSType_SurfaceSourceSwapChainPanel },
      .panelNative = swapChainPanel().as<ISwapChainPanelNative>().get()
  };

  WGPUSurfaceDescriptor surfaceDescriptor = {
      .nextInChain = &surfaceSource.chain,
  };

  WGPUSurface surface = wgpuInstanceCreateSurface(instance, &surfaceDescriptor);
```