### PR TITLE
Explicitly pass MacOS SDK sysroot to bindgen arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,14 @@ jobs:
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             # Macos
-          - name: Macos x86_64
+          - name: Macos 14 x86_64
             os: macos-14
             target: x86_64-apple-darwin
-          - name: Macos aarch64
+          - name: Macos 14 aarch64
             os: macos-14
+            target: aarch64-apple-darwin
+          - name: Macos 15 aarch64
+            os: macos-15
             target: aarch64-apple-darwin
             # Windows
           - name: Windows gnu x86_64

--- a/build.rs
+++ b/build.rs
@@ -63,6 +63,15 @@ fn main() {
         builder = builder
             .clang_arg(format!("-isysroot {sdk}"))
             .clang_arg("--target=arm64-apple-ios");
+    } else if let Ok("macos") = env::var("CARGO_CFG_TARGET_OS").as_ref().map(|x| &**x) {
+        let output = Command::new("xcrun")
+            .args(["--sdk", "macosx", "--show-sdk-path"])
+            .output()
+            .expect("xcrun failed")
+            .stdout;
+        let sdk = std::str::from_utf8(&output).expect("invalid output from `xcrun`");
+        builder = builder
+            .clang_arg(format!("-isysroot{}", sdk.trim()));
     }
 
     let bindings = builder.generate().expect("Unable to generate bindings");

--- a/build.rs
+++ b/build.rs
@@ -70,8 +70,7 @@ fn main() {
             .expect("xcrun failed")
             .stdout;
         let sdk = std::str::from_utf8(&output).expect("invalid output from `xcrun`");
-        builder = builder
-            .clang_arg(format!("-isysroot{}", sdk.trim()));
+        builder = builder.clang_arg(format!("-isysroot{}", sdk.trim()));
     }
 
     let bindings = builder.generate().expect("Unable to generate bindings");


### PR DESCRIPTION
Resolves issue in #493 . Bindgen is not including the proper MacOS SDK sysroot. Explicitly passing this resolves the build issue 

```sh
wgpu-native % ( make && make lib-native) 1>/dev/null && echo "Build success" || "Build failed"
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
    Finished `release` profile [optimized] target(s) in 0.03s
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
Build success
```