### PR TITLE
Add `vulkan4j`'s WebGPU-Native Java binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The bindings are based on the WebGPU-native header found at `ffi/webgpu-headers/
 - [cshenton/WebGPU.jl](https://github.com/cshenton/WebGPU.jl) - experimental Julia wrapper
 - [dvijaha/WGPUNative.jl](https://github.com/dvijaha/WGPUNative.jl) - stable Julia wrapper
 - [kgpu/wgpuj](https://github.com/kgpu/kgpu/tree/master/wgpuj) - Java/Kotlin wrapper
+- [club-doki7/vulkan4j](https://github.com/club-doki7/vulkan4j) - Java wrapper (FFM-based)
 - [wgpu4k/wgpu4k](https://github.com/wgpu4k/wgpu4k) / [wgpu4k/wgpu4k-native](https://github.com/wgpu4k/wgpu4k-native) - Kotlin/Multiplatform wrappers
 - [karmakrafts/Multiplatform wgpu](https://git.karmakrafts.dev/kk/multiplatform-wgpu) - Kotlin/Native wrapper
 - [rajveermalviya/go-webgpu](https://github.com/rajveermalviya/go-webgpu) - Go wrapper


### PR DESCRIPTION
- Maven Central: https://central.sonatype.com/artifact/club.doki7/webgpu
- JavaDoc page: https://vulkan4j.doki7.club/club.doki7.webgpu/module-summary.html
- Working example: https://github.com/club-doki7/vulkan4j/blob/master/modules/example/src/main/java/example/webgpu/LearnWebGPU.java