### PR TITLE
Fix read-only depth/stencil attachments

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -5,10 +5,11 @@ use std::borrow::Cow;
 use std::num::{NonZeroIsize, NonZeroU32, NonZeroU64};
 use std::ptr::NonNull;
 
-map_enum!(
+map_enum_with_undefined!(
     map_store_op,
     WGPUStoreOp,
     wgc::command::StoreOp,
+    "Unknown store operation",
     Discard,
     Store
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1141,19 +1141,13 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
                 .expect("invalid texture view for depth stencil attachment")
                 .id,
             depth: wgc::command::PassChannel {
-                load_op: conv::map_load_op(desc.depthLoadOp, Some(desc.depthClearValue))
-                    .or(Some(wgc::command::LoadOp::Load)),
-                store_op: Some(
-                    conv::map_store_op(desc.depthStoreOp).unwrap_or(wgc::command::StoreOp::Store),
-                ),
+                load_op: conv::map_load_op(desc.depthLoadOp, Some(desc.depthClearValue)),
+                store_op: conv::map_store_op(desc.depthStoreOp),
                 read_only: desc.depthReadOnly != 0,
             },
             stencil: wgc::command::PassChannel {
-                load_op: conv::map_load_op(desc.stencilLoadOp, Some(desc.stencilClearValue))
-                    .or(Some(wgc::command::LoadOp::Load)),
-                store_op: Some(
-                    conv::map_store_op(desc.stencilStoreOp).unwrap_or(wgc::command::StoreOp::Store),
-                ),
+                load_op: conv::map_load_op(desc.stencilLoadOp, Some(desc.stencilClearValue)),
+                store_op: conv::map_store_op(desc.stencilStoreOp),
                 read_only: desc.stencilReadOnly != 0,
             },
         }


### PR DESCRIPTION
Read-only depth/stencil attachments must have load/store ops None (or _Undefined enum value in C API). However, when converting WGPURenderPassDepthStencilAttachment, WGPULoadOp_Undefined was being mapped to Some(wgc::command::LoadOp::Load) rather than None. Same for store op.