### PR TITLE
Update to wgpu v27.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -84,12 +84,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -170,16 +164,14 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
- "serde",
- "termcolor",
  "unicode-width",
 ]
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -193,11 +185,11 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics-types"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "libc",
 ]
@@ -312,7 +304,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "gpu-alloc-types",
 ]
 
@@ -322,7 +314,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -343,7 +335,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "gpu-descriptor-types",
  "hashbrown",
 ]
@@ -354,7 +346,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -380,12 +372,6 @@ dependencies = [
  "foldhash",
  "serde",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hexf-parse"
@@ -507,11 +493,11 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "metal"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -528,18 +514,20 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "naga"
-version = "25.0.1"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v25.0.2#f35cf942af1a3bb6f48aa9185f4d2bcee809f814"
+version = "26.0.4"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.9.1",
+ "bitflags",
+ "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
  "hashbrown",
  "hexf-parse",
  "indexmap",
+ "libm",
  "log",
  "num-traits",
  "once_cell",
@@ -548,16 +536,15 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "spirv",
- "strum",
  "thiserror 2.0.12",
  "unicode-ident",
 ]
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -644,7 +631,6 @@ dependencies = [
  "fixedbitset",
  "hashbrown",
  "indexmap",
- "serde",
 ]
 
 [[package]]
@@ -720,7 +706,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -829,29 +815,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.9.1",
-]
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "bitflags",
 ]
 
 [[package]]
@@ -863,15 +827,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -1008,13 +963,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "25.0.2"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v25.0.2#f35cf942af1a3bb6f48aa9185f4d2bcee809f814"
+version = "26.0.4"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.9.1",
+ "bitflags",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -1039,38 +994,38 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "25.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v25.0.2#f35cf942af1a3bb6f48aa9185f4d2bcee809f814"
+version = "26.0.4"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "25.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v25.0.2#f35cf942af1a3bb6f48aa9185f4d2bcee809f814"
+version = "26.0.4"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "25.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v25.0.2#f35cf942af1a3bb6f48aa9185f4d2bcee809f814"
+version = "26.0.4"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "25.0.2"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v25.0.2#f35cf942af1a3bb6f48aa9185f4d2bcee809f814"
+version = "26.0.4"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.9.1",
+ "bitflags",
  "block",
  "bytemuck",
  "cfg-if",
@@ -1111,7 +1066,7 @@ name = "wgpu-native"
 version = "0.0.0"
 dependencies = [
  "bindgen",
- "bitflags 2.9.1",
+ "bitflags",
  "log",
  "naga",
  "parking_lot",
@@ -1127,25 +1082,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "25.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v25.0.2#f35cf942af1a3bb6f48aa9185f4d2bcee809f814"
+version = "26.0.4"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "bytemuck",
  "js-sys",
  "log",
  "serde",
  "thiserror 2.0.12",
  "web-sys",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys",
 ]
 
 [[package]]
@@ -1209,15 +1155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,9 +46,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bindgen"
-version = "0.72.0"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -87,9 +81,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
  "serde",
 ]
@@ -108,18 +102,18 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.9.3"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -137,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -279,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
@@ -343,7 +337,7 @@ checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
  "bitflags",
  "gpu-descriptor-types",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -369,12 +363,10 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -396,13 +388,14 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -422,9 +415,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -449,18 +442,18 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -471,25 +464,24 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "malloc_buf"
@@ -502,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "metal"
@@ -530,7 +522,8 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "naga"
 version = "27.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b2e757b11b47345d44e7760e45458339bc490463d9548cd8651c53ae523153"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -551,7 +544,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "spirv",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "unicode-ident",
 ]
 
@@ -601,18 +594,18 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "ordered-float"
-version = "4.6.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -620,15 +613,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -639,12 +632,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "petgraph"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "indexmap",
 ]
 
@@ -671,9 +664,9 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -681,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -696,9 +689,9 @@ checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -717,18 +710,18 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -738,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -749,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "renderdoc-sys"
@@ -773,9 +766,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "scopeguard"
@@ -785,18 +778,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -835,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -855,11 +858,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -875,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -886,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-width"
@@ -910,21 +913,22 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -936,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -946,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -959,18 +963,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -978,8 +982,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
+version = "27.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d654c0b6c6335edfca18c11bdaed964def641b8e9997d3a495a2ff4077c922"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -999,7 +1004,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
@@ -1010,7 +1015,8 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-apple"
 version = "27.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
 dependencies = [
  "wgpu-hal",
 ]
@@ -1018,7 +1024,8 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-emscripten"
 version = "27.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
 dependencies = [
  "wgpu-hal",
 ]
@@ -1026,15 +1033,17 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
 version = "27.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
+version = "27.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2618a2d6b8a5964ecc1ac32a5db56cb3b1e518725fcd773fd9a782e023453f2b"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -1069,7 +1078,7 @@ dependencies = [
  "raw-window-handle",
  "renderdoc-sys",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -1090,7 +1099,7 @@ dependencies = [
  "raw-window-handle",
  "serde",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "wgpu-core",
  "wgpu-hal",
  "wgpu-types",
@@ -1098,15 +1107,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
+version = "27.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
  "bitflags",
  "bytemuck",
  "js-sys",
  "log",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "web-sys",
 ]
 
@@ -1117,7 +1127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1130,7 +1140,7 @@ dependencies = [
  "windows-interface",
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1156,12 +1166,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1171,7 +1187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1180,30 +1196,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1213,22 +1213,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1237,22 +1225,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1261,22 +1237,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1285,25 +1249,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
 name = "xml-rs"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,7 +343,7 @@ checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
  "bitflags",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -369,7 +375,16 @@ checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "foldhash 0.2.0",
  "serde",
 ]
 
@@ -386,7 +401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -514,8 +529,8 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "naga"
-version = "26.0.4"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
+version = "27.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -524,7 +539,7 @@ dependencies = [
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown",
+ "hashbrown 0.16.0",
  "hexf-parse",
  "indexmap",
  "libm",
@@ -629,7 +644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
  "fixedbitset",
- "hashbrown",
+ "hashbrown 0.15.4",
  "indexmap",
 ]
 
@@ -963,8 +978,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "26.0.4"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
+version = "27.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -973,7 +988,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown",
+ "hashbrown 0.16.0",
  "indexmap",
  "log",
  "naga",
@@ -994,32 +1009,32 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "26.0.4"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
+version = "27.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "26.0.4"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
+version = "27.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "26.0.4"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
+version = "27.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "26.0.4"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
+version = "27.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -1036,7 +1051,7 @@ dependencies = [
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hashbrown",
+ "hashbrown 0.16.0",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -1046,6 +1061,7 @@ dependencies = [
  "naga",
  "ndk-sys",
  "objc",
+ "once_cell",
  "ordered-float",
  "parking_lot",
  "profiling",
@@ -1082,8 +1098,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "26.0.4"
-source = "git+https://github.com/gfx-rs/wgpu?tag=v26.0.4#983d46054c521a2d3771b2a7f94d960687500f88"
+version = "27.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?tag=v27.0.0#482a983e1006333dc249bd1a08b04db3e4a48230"
 dependencies = [
  "bitflags",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,23 +22,19 @@ resolver = "2"
 
 [workspace.dependencies.wgc]
 package = "wgpu-core"
-git = "https://github.com/gfx-rs/wgpu"
-tag = "v27.0.0"
+version = "27.0.1"
 
 [workspace.dependencies.wgt]
 package = "wgpu-types"
-git = "https://github.com/gfx-rs/wgpu"
-tag = "v27.0.0"
+version = "27.0.1"
 
 [workspace.dependencies.hal]
 package = "wgpu-hal"
-git = "https://github.com/gfx-rs/wgpu"
-tag = "v27.0.0"
+version = "27.0.2"
 
 [workspace.dependencies.naga]
 package = "naga"
-git = "https://github.com/gfx-rs/wgpu"
-tag = "v27.0.0"
+version = "27.0.0"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,7 @@ version = "27.0.0"
 crate-type = ["cdylib", "staticlib"]
 
 [features]
-default = ["wgsl", "spirv", "glsl", "dx12", "metal"]
-
-#! ### Backends
-# --------------------------------------------------------------------
-#! ⚠️ WIP: Not all backends can be manually configured today.
-#! On Windows, Linux & Android the Vulkan & GLES backends are always enabled.
-#! See [#3514](https://github.com/gfx-rs/wgpu/issues/3514) for more details.
+default = ["wgsl", "spirv", "glsl", "dx12", "metal", "vulkan", "gles"]
 
 ## Enables the DX12 backend on Windows.
 dx12 = ["wgc/dx12"]
@@ -56,6 +50,11 @@ metal = ["wgc/metal"]
 
 ## Enables the GLES backend via [ANGLE](https://github.com/google/angle) on macOS using.
 angle = ["wgc/gles"]
+
+## Enables the Vulkan backend on Windows, Linux, and Android.
+vulkan = ["wgc/vulkan"]
+## Enables the OpenGL/GLES backend on Windows, Linux, Android.
+gles = ["wgc/gles"]
 
 ## Enables the Vulkan backend on macOS & iOS.
 vulkan-portability = ["wgc/vulkan"]
@@ -101,26 +100,6 @@ replay = ["serde", "wgc/replay"]
 [dependencies.wgc]
 workspace = true
 features = ["raw-window-handle"]
-
-# Enable `wgc` by default on macOS and iOS to allow the `metal` crate feature to
-# enable the Metal backend while being no-op on other targets.
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgc]
-workspace = true
-
-# We want the wgpu-core Direct3D backend and OpenGL (via WGL) on Windows.
-[target.'cfg(windows)'.dependencies.wgc]
-workspace = true
-features = ["gles"]
-
-# We want the wgpu-core Vulkan backend on Unix (but not macOS, iOS) and Windows.
-[target.'cfg(any(windows, all(unix, not(target_os = "ios"), not(target_os = "macos"))))'.dependencies.wgc]
-workspace = true
-features = ["vulkan"]
-
-# We want the wgpu-core GLES backend on Unix (but not macOS, iOS).
-[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies.wgc]
-workspace = true
-features = ["gles"]
 
 [dependencies.hal]
 workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,22 +23,22 @@ resolver = "2"
 [workspace.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-tag = "v26.0.4"
+tag = "v27.0.0"
 
 [workspace.dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-tag = "v26.0.4"
+tag = "v27.0.0"
 
 [workspace.dependencies.hal]
 package = "wgpu-hal"
 git = "https://github.com/gfx-rs/wgpu"
-tag = "v26.0.4"
+tag = "v27.0.0"
 
 [workspace.dependencies.naga]
 package = "naga"
 git = "https://github.com/gfx-rs/wgpu"
-tag = "v26.0.4"
+tag = "v27.0.0"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,22 +23,22 @@ resolver = "2"
 [workspace.dependencies.wgc]
 package = "wgpu-core"
 git = "https://github.com/gfx-rs/wgpu"
-tag = "v25.0.2"
+tag = "v26.0.4"
 
 [workspace.dependencies.wgt]
 package = "wgpu-types"
 git = "https://github.com/gfx-rs/wgpu"
-tag = "v25.0.2"
+tag = "v26.0.4"
 
 [workspace.dependencies.hal]
 package = "wgpu-hal"
 git = "https://github.com/gfx-rs/wgpu"
-tag = "v25.0.2"
+tag = "v26.0.4"
 
 [workspace.dependencies.naga]
 package = "naga"
 git = "https://github.com/gfx-rs/wgpu"
-tag = "v25.0.2"
+tag = "v26.0.4"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -22,7 +22,6 @@ typedef enum WGPUNativeSType {
 typedef enum WGPUNativeFeature {
     WGPUNativeFeature_PushConstants = 0x00030001,
     WGPUNativeFeature_TextureAdapterSpecificFormatFeatures = 0x00030002,
-    WGPUNativeFeature_MultiDrawIndirect = 0x00030003,
     WGPUNativeFeature_MultiDrawIndirectCount = 0x00030004,
     WGPUNativeFeature_VertexWritableStorage = 0x00030005,
     WGPUNativeFeature_TextureBindingArray = 0x00030006,
@@ -46,7 +45,6 @@ typedef enum WGPUNativeFeature {
     // WGPUNativeFeature_Multiview = 0x00030018,
     WGPUNativeFeature_VertexAttribute64bit = 0x00030019,
     WGPUNativeFeature_TextureFormatNv12 = 0x0003001A,
-    WGPUNativeFeature_RayTracingAccelerationStructure = 0x0003001B,
     WGPUNativeFeature_RayQuery = 0x0003001C,
     WGPUNativeFeature_ShaderF64 = 0x0003001D,
     WGPUNativeFeature_ShaderI16 = 0x0003001E,
@@ -297,6 +295,7 @@ typedef enum WGPUNativeTextureFormat {
     WGPUNativeTextureFormat_Rgba16Snorm = 0x00030006,
     // From Features::TEXTURE_FORMAT_NV12
     WGPUNativeTextureFormat_NV12 = 0x00030007,
+    WGPUNativeTextureFormat_P010 = 0x00030008,
 } WGPUNativeTextureFormat;
 
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -15,6 +15,7 @@ typedef enum WGPUNativeSType {
     WGPUSType_QuerySetDescriptorExtras = 0x00030009,
     WGPUSType_SurfaceConfigurationExtras = 0x0003000A,
     WGPUSType_SurfaceSourceSwapChainPanel = 0x0003000B,
+    WGPUSType_PrimitiveStateExtras = 0x0003000C,
     WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeSType;
 
@@ -37,9 +38,9 @@ typedef enum WGPUNativeFeature {
     // TODO: requires wgpu.h api change
     // WGPUNativeFeature_AddressModeClampToZero = 0x00030011,
     // WGPUNativeFeature_AddressModeClampToBorder = 0x00030012,
-    // WGPUNativeFeature_PolygonModeLine = 0x00030013,
-    // WGPUNativeFeature_PolygonModePoint = 0x00030014,
-    // WGPUNativeFeature_ConservativeRasterization = 0x00030015,
+    WGPUNativeFeature_PolygonModeLine = 0x00030013,
+    WGPUNativeFeature_PolygonModePoint = 0x00030014,
+    WGPUNativeFeature_ConservativeRasterization = 0x00030015,
     // WGPUNativeFeature_ClearTexture = 0x00030016,
     WGPUNativeFeature_SpirvShaderPassthrough = 0x00030017,
     // WGPUNativeFeature_Multiview = 0x00030018,
@@ -261,16 +262,28 @@ typedef struct WGPUSurfaceConfigurationExtras {
 } WGPUSurfaceConfigurationExtras WGPU_STRUCTURE_ATTRIBUTE;
 
 /**
- * Chained in @ref WGPUSurfaceDescriptor to make a @ref WGPUSurface wrapping a WinUI [`SwapChainPanel`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.swapchainpanel).
- */
+* Chained in @ref WGPUSurfaceDescriptor to make a @ref WGPUSurface wrapping a WinUI [`SwapChainPanel`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.swapchainpanel).
+*/
 typedef struct WGPUSurfaceSourceSwapChainPanel {
     WGPUChainedStruct chain;
     /**
-     * A pointer to the [`ISwapChainPanelNative`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/win32/microsoft.ui.xaml.media.dxinterop/nn-microsoft-ui-xaml-media-dxinterop-iswapchainpanelnative)
-     * interface of the SwapChainPanel that will be wrapped by the @ref WGPUSurface.
-     */
+    * A pointer to the [`ISwapChainPanelNative`](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/win32/microsoft.ui.xaml.media.dxinterop/nn-microsoft-ui-xaml-media-dxinterop-iswapchainpanelnative)
+    * interface of the SwapChainPanel that will be wrapped by the @ref WGPUSurface.
+    */
     void * panelNative;
 } WGPUSurfaceSourceSwapChainPanel WGPU_STRUCTURE_ATTRIBUTE;
+
+typedef enum WGPUPolygonMode {
+    WGPUPolygonMode_Fill = 0,
+    WGPUPolygonMode_Line = 1,
+    WGPUPolygonMode_Point = 2,
+} WGPUPolygonMode;
+
+typedef struct WGPUPrimitiveStateExtras {
+    WGPUChainedStruct chain;
+    WGPUPolygonMode polygonMode;
+    WGPUBool conservative;
+} WGPUPrimitiveStateExtras WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, WGPUStringView message, void * userdata);
 
@@ -285,6 +298,7 @@ typedef enum WGPUNativeTextureFormat {
     // From Features::TEXTURE_FORMAT_NV12
     WGPUNativeTextureFormat_NV12 = 0x00030007,
 } WGPUNativeTextureFormat;
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -144,9 +144,11 @@ typedef struct WGPUInstanceExtras {
     WGPUDx12Compiler dx12ShaderCompiler;
     WGPUGles3MinorVersion gles3MinorVersion;
     WGPUGLFenceBehaviour glFenceBehaviour;
-    WGPUStringView dxilPath;
     WGPUStringView dxcPath;
     WGPUDxcMaxShaderModel dxcMaxShaderModel;
+
+    WGPU_NULLABLE const uint8_t* budgetForDeviceCreation;
+    WGPU_NULLABLE const uint8_t* budgetForDeviceLoss;
 } WGPUInstanceExtras;
 
 typedef struct WGPUDeviceExtras {

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -335,6 +335,7 @@ pub unsafe fn map_instance_descriptor(
                 },
                 dx12: wgt::Dx12BackendOptions {
                     shader_compiler: dx12_shader_compiler,
+                    ..Default::default()
                 },
                 noop: Default::default(),
             },
@@ -380,6 +381,7 @@ pub(crate) unsafe fn map_device_descriptor<'a>(
             // TODO(wgpu.h)
             memory_hints: Default::default(),
             trace: Default::default(),
+            experimental_features: wgt::ExperimentalFeatures::disabled(),
         },
         match des.uncapturedErrorCallbackInfo.callback {
             None => None,
@@ -1006,6 +1008,7 @@ pub fn to_native_texture_format(rs_type: wgt::TextureFormat) -> Option<native::W
         wgt::TextureFormat::Rgba16Unorm => Some(native::WGPUNativeTextureFormat_Rgba16Unorm),
         wgt::TextureFormat::Rgba16Snorm => Some(native::WGPUNativeTextureFormat_Rgba16Snorm),
         wgt::TextureFormat::NV12 => Some(native::WGPUNativeTextureFormat_NV12),
+        wgt::TextureFormat::P010 => Some(native::WGPUNativeTextureFormat_P010)
     }
 }
 
@@ -1127,9 +1130,6 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES) {
         temp.push(native::WGPUNativeFeature_TextureAdapterSpecificFormatFeatures);
     }
-    if features.contains(wgt::Features::MULTI_DRAW_INDIRECT) {
-        temp.push(native::WGPUNativeFeature_MultiDrawIndirect);
-    }
     if features.contains(wgt::Features::MULTI_DRAW_INDIRECT_COUNT) {
         temp.push(native::WGPUNativeFeature_MultiDrawIndirectCount);
     }
@@ -1196,9 +1196,6 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     // if features.contains(wgt::Features::CLEAR_TEXTURE) {
     //     temp.push(native::WGPUNativeFeature_ClearTexture);
     // }
-    if features.contains(wgt::Features::SPIRV_SHADER_PASSTHROUGH) {
-        temp.push(native::WGPUNativeFeature_SpirvShaderPassthrough);
-    }
     // if features.contains(wgt::Features::MULTIVIEW) {
     //     temp.push(native::WGPUNativeFeature_Multiview);
     // }
@@ -1207,9 +1204,6 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     }
     if features.contains(wgt::Features::TEXTURE_FORMAT_NV12) {
         temp.push(native::WGPUNativeFeature_TextureFormatNv12);
-    }
-    if features.contains(wgt::Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE) {
-        temp.push(native::WGPUNativeFeature_RayTracingAccelerationStructure);
     }
     if features.contains(wgt::Features::EXPERIMENTAL_RAY_QUERY) {
         temp.push(native::WGPUNativeFeature_RayQuery);
@@ -1268,7 +1262,6 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         // wgpu-rs only features
         native::WGPUNativeFeature_PushConstants => Some(Features::PUSH_CONSTANTS),
         native::WGPUNativeFeature_TextureAdapterSpecificFormatFeatures => Some(Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES),
-        native::WGPUNativeFeature_MultiDrawIndirect => Some(Features::MULTI_DRAW_INDIRECT),
         native::WGPUNativeFeature_MultiDrawIndirectCount => Some(Features::MULTI_DRAW_INDIRECT_COUNT),
         native::WGPUNativeFeature_VertexWritableStorage => Some(Features::VERTEX_WRITABLE_STORAGE),
         native::WGPUNativeFeature_TextureBindingArray => Some(Features::TEXTURE_BINDING_ARRAY),
@@ -1291,11 +1284,9 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUNativeFeature_PolygonModePoint => Some(Features::POLYGON_MODE_POINT),
         native::WGPUNativeFeature_ConservativeRasterization => Some(Features::CONSERVATIVE_RASTERIZATION),
         // native::WGPUNativeFeature_ClearTexture => Some(Features::CLEAR_TEXTURE),
-        native::WGPUNativeFeature_SpirvShaderPassthrough => Some(Features::SPIRV_SHADER_PASSTHROUGH),
         // native::WGPUNativeFeature_Multiview => Some(Features::MULTIVIEW),
         native::WGPUNativeFeature_VertexAttribute64bit => Some(Features::VERTEX_ATTRIBUTE_64BIT),
         native::WGPUNativeFeature_TextureFormatNv12 => Some(Features::TEXTURE_FORMAT_NV12),
-        native::WGPUNativeFeature_RayTracingAccelerationStructure => Some(Features::EXPERIMENTAL_RAY_TRACING_ACCELERATION_STRUCTURE),
         native::WGPUNativeFeature_RayQuery => Some(Features::EXPERIMENTAL_RAY_QUERY),
         native::WGPUNativeFeature_ShaderF64 => Some(Features::SHADER_F64),
         native::WGPUNativeFeature_ShaderInt64 => Some(Features::SHADER_INT64),

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -416,11 +416,11 @@ pub unsafe fn map_pipeline_layout_descriptor<'a>(
             .collect()
     });
 
-    return wgc::binding_model::PipelineLayoutDescriptor {
+    wgc::binding_model::PipelineLayoutDescriptor {
         label: string_view_into_label(des.label),
         bind_group_layouts: Cow::from(bind_group_layouts),
         push_constant_ranges: Cow::from(push_constant_ranges),
-    };
+    }
 }
 
 #[inline]
@@ -1610,6 +1610,7 @@ pub enum CreateSurfaceParams {
     SwapChainPanel(*mut std::ffi::c_void),
 }
 
+#[allow(clippy::too_many_arguments)]
 pub unsafe fn map_surface(
     _: &native::WGPUSurfaceDescriptor,
     win: Option<&native::WGPUSurfaceSourceWindowsHWND>,

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -312,12 +312,8 @@ pub unsafe fn map_instance_descriptor(
     if let Some(extras) = extras {
         let dx12_shader_compiler = match extras.dx12ShaderCompiler {
             native::WGPUDx12Compiler_Fxc => wgt::Dx12Compiler::Fxc,
-            native::WGPUDx12Compiler_Dxc => match (
-                string_view_into_str(extras.dxilPath),
-                string_view_into_str(extras.dxcPath),
-            ) {
-                (Some(dxil_path), Some(dxc_path)) => wgt::Dx12Compiler::DynamicDxc {
-                    dxil_path: dxil_path.to_string(),
+            native::WGPUDx12Compiler_Dxc => match string_view_into_str(extras.dxcPath) {
+                Some(dxc_path) => wgt::Dx12Compiler::DynamicDxc {
                     dxc_path: dxc_path.to_string(),
                     max_shader_model: map_dxc_max_shader_model(extras.dxcMaxShaderModel),
                 },
@@ -325,6 +321,9 @@ pub unsafe fn map_instance_descriptor(
             },
             _ => wgt::Dx12Compiler::default(),
         };
+
+        let for_resource_creation = unsafe { extras.budgetForDeviceCreation.as_ref() }.copied();
+        let for_device_loss = unsafe { extras.budgetForDeviceCreation.as_ref() }.copied();
 
         wgt::InstanceDescriptor {
             backends: map_instance_backend_flags(extras.backends as native::WGPUInstanceBackend),
@@ -341,6 +340,10 @@ pub unsafe fn map_instance_descriptor(
             flags: match extras.flags {
                 native::WGPUInstanceFlag_Default => wgt::InstanceFlags::default(),
                 flags => map_instance_flags(flags),
+            },
+            memory_budget_thresholds: wgt::MemoryBudgetThresholds {
+                for_device_loss,
+                for_resource_creation,
             },
         }
     } else {

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1184,15 +1184,15 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     // if features.contains(wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER) {
     //     temp.push(native::WGPUNativeFeature_AddressModeClampToBorder);
     // }
-    // if features.contains(wgt::Features::POLYGON_MODE_LINE) {
-    //     temp.push(native::WGPUNativeFeature_PolygonModeLine);
-    // }
-    // if features.contains(wgt::Features::POLYGON_MODE_POINT) {
-    //     temp.push(native::WGPUNativeFeature_PolygonModePoint);
-    // }
-    // if features.contains(wgt::Features::CONSERVATIVE_RASTERIZATION) {
-    //     temp.push(native::WGPUNativeFeature_ConservativeRasterization);
-    // }
+    if features.contains(wgt::Features::POLYGON_MODE_LINE) {
+        temp.push(native::WGPUNativeFeature_PolygonModeLine);
+    }
+    if features.contains(wgt::Features::POLYGON_MODE_POINT) {
+        temp.push(native::WGPUNativeFeature_PolygonModePoint);
+    }
+    if features.contains(wgt::Features::CONSERVATIVE_RASTERIZATION) {
+        temp.push(native::WGPUNativeFeature_ConservativeRasterization);
+    }
     // if features.contains(wgt::Features::CLEAR_TEXTURE) {
     //     temp.push(native::WGPUNativeFeature_ClearTexture);
     // }
@@ -1287,9 +1287,9 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         // TODO: requires wgpu.h api change
         // native::WGPUNativeFeature_AddressModeClampToZero => Some(Features::ADDRESS_MODE_CLAMP_TO_ZERO),
         // native::WGPUNativeFeature_AddressModeClampToBorder => Some(Features::ADDRESS_MODE_CLAMP_TO_BORDER),
-        // native::WGPUNativeFeature_PolygonModeLine => Some(Features::POLYGON_MODE_LINE),
-        // native::WGPUNativeFeature_PolygonModePoint => Some(Features::POLYGON_MODE_POINT),
-        // native::WGPUNativeFeature_ConservativeRasterization => Some(Features::CONSERVATIVE_RASTERIZATION),
+        native::WGPUNativeFeature_PolygonModeLine => Some(Features::POLYGON_MODE_LINE),
+        native::WGPUNativeFeature_PolygonModePoint => Some(Features::POLYGON_MODE_POINT),
+        native::WGPUNativeFeature_ConservativeRasterization => Some(Features::CONSERVATIVE_RASTERIZATION),
         // native::WGPUNativeFeature_ClearTexture => Some(Features::CLEAR_TEXTURE),
         native::WGPUNativeFeature_SpirvShaderPassthrough => Some(Features::SPIRV_SHADER_PASSTHROUGH),
         // native::WGPUNativeFeature_Multiview => Some(Features::MULTIVIEW),
@@ -1753,6 +1753,47 @@ pub fn map_adapter_type(device_type: wgt::DeviceType) -> native::WGPUAdapterType
         wgt::DeviceType::DiscreteGpu => native::WGPUAdapterType_DiscreteGPU,
         wgt::DeviceType::VirtualGpu => native::WGPUAdapterType_CPU, // close enough?
         wgt::DeviceType::Cpu => native::WGPUAdapterType_CPU,
+    }
+}
+
+fn map_polygon_mode(mode: native::WGPUPolygonMode) -> wgt::PolygonMode {
+    match mode {
+        native::WGPUPolygonMode_Fill => wgt::PolygonMode::Fill,
+        native::WGPUPolygonMode_Line => wgt::PolygonMode::Line,
+        native::WGPUPolygonMode_Point => wgt::PolygonMode::Point,
+        _ => panic!("unknown polygon mode {mode}"),
+    }
+}
+
+pub fn map_primitive_state(
+    primitive: native::WGPUPrimitiveState,
+    extras: Option<&native::WGPUPrimitiveStateExtras>,
+) -> wgt::PrimitiveState {
+    let polygon_mode = extras
+        .map(|extras| map_polygon_mode(extras.polygonMode))
+        .unwrap_or_default();
+    let conservative = extras
+        .map(|extras| extras.conservative != 0)
+        .unwrap_or_default();
+
+    wgt::PrimitiveState {
+        topology: map_primitive_topology(primitive.topology)
+            .unwrap_or(wgt::PrimitiveTopology::TriangleList),
+        strip_index_format: map_index_format(primitive.stripIndexFormat).ok(),
+        front_face: match primitive.frontFace {
+            native::WGPUFrontFace_CCW | native::WGPUFrontFace_Undefined => wgt::FrontFace::Ccw,
+            native::WGPUFrontFace_CW => wgt::FrontFace::Cw,
+            _ => panic!("invalid front face for primitive state"),
+        },
+        cull_mode: match primitive.cullMode {
+            native::WGPUCullMode_None | native::WGPUCullMode_Undefined => None,
+            native::WGPUCullMode_Front => Some(wgt::Face::Front),
+            native::WGPUCullMode_Back => Some(wgt::Face::Back),
+            _ => panic!("invalid cull mode for primitive state"),
+        },
+        unclipped_depth: primitive.unclippedDepth != 0,
+        polygon_mode,
+        conservative,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1690,14 +1690,13 @@ pub unsafe extern "C" fn wgpuComputePassEncoderSetBindGroup(
     dynamic_offsets: *const u32,
 ) {
     let pass = pass.as_ref().expect("invalid compute pass");
-    //TODO: as per webgpu.h bindgroup is nullable
-    let bind_group_id = bind_group.as_ref().expect("invalid bind group").id;
+    let bind_group_id = bind_group.as_ref().map(|bg| bg.id);
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
     match pass.context.compute_pass_set_bind_group(
         encoder,
         group_index,
-        Some(bind_group_id),
+        bind_group_id,
         make_slice(dynamic_offsets, dynamic_offset_count),
     ) {
         Ok(()) => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,8 @@ impl Drop for WGPUDeviceImpl {
         if !thread::panicking() {
             let context = &self.context;
 
-            match context.device_poll(self.id, wgt::PollType::Wait) {
+            // wait_indefinitely() *should* match the old behavior of using wgt::PollType::Wait
+            match context.device_poll(self.id, wgt::PollType::wait_indefinitely()) {
                 Ok(_) => (),
                 Err(err) => handle_error_fatal(err, "WGPUDeviceImpl::drop"),
             }
@@ -1406,7 +1407,8 @@ pub unsafe extern "C" fn wgpuCommandEncoderFinish(
         None => wgt::CommandBufferDescriptor::default(),
     };
 
-    let (command_buffer_id, error) = context.command_encoder_finish(command_encoder_id, &desc);
+    let (command_buffer_id, error) =
+        context.command_encoder_finish(command_encoder_id, &desc, None);
     if let Some(cause) = error {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderFinish");
     }
@@ -1990,7 +1992,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateComputePipeline(
     };
 
     let (compute_pipeline_id, error) =
-        context.device_create_compute_pipeline(device_id, &desc, None, None);
+        context.device_create_compute_pipeline(device_id, &desc, None);
     if let Some(cause) = error {
         if let wgc::pipeline::CreateComputePipelineError::Internal(ref error) = cause {
             log::warn!(
@@ -2270,8 +2272,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
         cache: None,
     };
 
-    let (render_pipeline_id, error) =
-        context.device_create_render_pipeline(device_id, &desc, None, None);
+    let (render_pipeline_id, error) = context.device_create_render_pipeline(device_id, &desc, None);
     if let Some(cause) = error {
         if let wgc::pipeline::CreateRenderPipelineError::Internal { stage, ref error } = cause {
             log::error!("Shader translation error for stage {:?}: {}", stage, error);
@@ -4268,6 +4269,7 @@ pub unsafe extern "C" fn wgpuQueueSubmitForIndex(
     }
 }
 
+// FIXME: rework this function to match how wgpu v27 handles polling devices
 #[no_mangle]
 pub unsafe extern "C" fn wgpuDevicePoll(
     device: native::WGPUDevice,
@@ -4281,8 +4283,11 @@ pub unsafe extern "C" fn wgpuDevicePoll(
 
     let maintain = match wait {
         true => match submission_index {
-            Some(index) => wgt::PollType::WaitForSubmissionIndex(*index),
-            None => wgt::PollType::Wait,
+            Some(&index) => wgt::PollType::Wait {
+                submission_index: Some(index),
+                timeout: None,
+            },
+            None => wgt::PollType::wait_indefinitely(),
         },
         false => wgt::PollType::Poll,
     };
@@ -4296,6 +4301,7 @@ pub unsafe extern "C" fn wgpuDevicePoll(
     }
 }
 
+// FIXME: wgpu has generic shader passthrough now, we should be doing something similar
 #[no_mangle]
 pub unsafe extern "C" fn wgpuDeviceCreateShaderModuleSpirV(
     device: native::WGPUDevice,
@@ -4314,11 +4320,11 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModuleSpirV(
 
     let desc_label = string_view_into_label(descriptor.label);
 
-    let desc =
-        wgc::pipeline::ShaderModuleDescriptorPassthrough::SpirV(wgt::ShaderModuleDescriptorSpirV {
-            label: desc_label.clone(),
-            source,
-        });
+    let desc = wgc::pipeline::ShaderModuleDescriptorPassthrough {
+        label: desc_label.to_owned(),
+        spirv: Some(source),
+        ..Default::default()
+    };
 
     let (shader_module_id, error) =
         context.device_create_shader_module_passthrough(device_id, &desc, None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ use wgc::{
     id, resource, Label,
 };
 
+use crate::conv::map_primitive_state;
+
 pub mod conv;
 pub mod logging;
 pub mod unimplemented;
@@ -2178,24 +2180,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
                     .collect(),
             ),
         },
-        primitive: wgt::PrimitiveState {
-            topology: conv::map_primitive_topology(descriptor.primitive.topology)
-                .unwrap_or(wgt::PrimitiveTopology::TriangleList),
-            strip_index_format: conv::map_index_format(descriptor.primitive.stripIndexFormat).ok(),
-            front_face: match descriptor.primitive.frontFace {
-                native::WGPUFrontFace_CCW | native::WGPUFrontFace_Undefined => wgt::FrontFace::Ccw,
-                native::WGPUFrontFace_CW => wgt::FrontFace::Cw,
-                _ => panic!("invalid front face for primitive state"),
-            },
-            cull_mode: match descriptor.primitive.cullMode {
-                native::WGPUCullMode_None | native::WGPUCullMode_Undefined => None,
-                native::WGPUCullMode_Front => Some(wgt::Face::Front),
-                native::WGPUCullMode_Back => Some(wgt::Face::Back),
-                _ => panic!("invalid cull mode for primitive state"),
-            },
-            unclipped_depth: descriptor.primitive.unclippedDepth != 0,
-            polygon_mode: wgt::PolygonMode::Fill,
-            conservative: false,
+        primitive: {
+            follow_chain!(map_primitive_state((descriptor.primitive), WGPUSType_PrimitiveStateExtras => native::WGPUPrimitiveStateExtras))
         },
         depth_stencil: descriptor.depthStencil.as_ref().map(|desc| {
             let format = conv::map_texture_format(desc.format)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,7 @@
 #![allow(
-    clippy::missing_safety_doc,
-    clippy::arc_with_non_send_sync,
-    clippy::crate_in_macro_def,
-    clippy::manual_unwrap_or_default,
-    clippy::let_unit_value,
-    clippy::needless_return,
-    clippy::too_many_arguments,
-    clippy::collapsible_else_if,
-    clippy::manual_unwrap_or,
-    clippy::empty_line_after_doc_comments
-)] // TODO fix these warnings
+    clippy::missing_safety_doc, 
+    clippy::arc_with_non_send_sync // Need to investigate?
+)]
 
 use conv::{
     from_u64_bits, map_adapter_type, map_backend_type, map_bind_group_entry,
@@ -911,7 +903,7 @@ pub unsafe extern "C" fn wgpuBufferDestroy(buffer: native::WGPUBuffer) {
         (buffer.id, &buffer.context)
     };
     // Per spec, no error to report. Even calling destroy multiple times is valid.
-    let _ = context.buffer_destroy(buffer_id);
+    context.buffer_destroy(buffer_id);
 }
 
 #[no_mangle]
@@ -2217,10 +2209,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateRenderPipeline(
                 if desc.depthWriteEnabled == native::WGPUOptionalBool_Undefined {
                     panic!("Depth write not specified for depth format")
                 }
-            } else {
-                if desc.depthWriteEnabled == native::WGPUOptionalBool_True {
-                    panic!("Depth write enabled for non-depth format")
-                }
+            } else if desc.depthWriteEnabled == native::WGPUOptionalBool_True {
+                panic!("Depth write enabled for non-depth format")
             }
 
             wgt::DepthStencilState {
@@ -4169,7 +4159,7 @@ pub unsafe extern "C" fn wgpuTextureDestroy(texture: native::WGPUTexture) {
     };
 
     // Per spec, no error to report. Even calling destroy multiple times is valid.
-    let _ = context.texture_destroy(texture_id);
+    context.texture_destroy(texture_id);
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
     error,
     ffi::c_void,
     fmt::Display,
-    mem,
+    mem::{self},
     num::NonZeroU64,
     sync::{atomic, Arc, Weak},
     thread,
@@ -187,7 +187,7 @@ impl Drop for WGPUDeviceImpl {
         if !thread::panicking() {
             let context = &self.context;
 
-            // wait_indefinitely() *should* match the old behavior of using wgt::PollType::Wait
+            // pre v27 this would wait for 60 seconds instead of waiting indefinitely
             match context.device_poll(self.id, wgt::PollType::wait_indefinitely()) {
                 Ok(_) => (),
                 Err(err) => handle_error_fatal(err, "WGPUDeviceImpl::drop"),
@@ -2856,6 +2856,7 @@ pub unsafe extern "C" fn wgpuQuerySetDestroy(query_set: native::WGPUQuerySet) {
         (query_set.id, &query_set.context)
     };
 
+    // FIXME: we shouldn't be using drop to implement this!
     context.query_set_drop(query_set_id);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use smallvec::SmallVec;
 use std::{
     borrow::Cow,
     error,
+    ffi::c_void,
     fmt::Display,
     mem,
     num::NonZeroU64,
@@ -2487,8 +2488,13 @@ pub unsafe extern "C" fn wgpuDeviceCreateTexture(
 }
 
 #[no_mangle]
-pub extern "C" fn wgpuDeviceDestroy(_device: native::WGPUDevice) {
-    //TODO: needs to be implemented in wgpu-core
+pub unsafe extern "C" fn wgpuDeviceDestroy(device: native::WGPUDevice) {
+    let (device_id, context) = {
+        let device = device.as_ref().expect("invalid device");
+        (device.id, &device.context)
+    };
+
+    context.device_destroy(device_id);
 }
 
 #[no_mangle]
@@ -2862,8 +2868,13 @@ pub unsafe extern "C" fn wgpuPipelineLayoutRelease(pipeline_layout: native::WGPU
 // QuerySet methods
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuQuerySetDestroy(_query_set: native::WGPUQuerySet) {
-    //TODO: needs to be implemented in wgpu-core
+pub unsafe extern "C" fn wgpuQuerySetDestroy(query_set: native::WGPUQuerySet) {
+    let (query_set_id, context) = {
+        let query_set = query_set.as_ref().expect("query set");
+        (query_set.id, &query_set.context)
+    };
+
+    context.query_set_drop(query_set_id);
 }
 
 #[no_mangle]
@@ -2949,7 +2960,7 @@ pub unsafe extern "C" fn wgpuQueueWriteBuffer(
     queue: native::WGPUQueue,
     buffer: native::WGPUBuffer,
     buffer_offset: u64,
-    data: *const u8, // TODO: Check - this might not follow the header
+    data: *const c_void,
     data_size: usize,
 ) {
     let (queue_id, context, error_sink) = {
@@ -2962,7 +2973,7 @@ pub unsafe extern "C" fn wgpuQueueWriteBuffer(
         queue_id,
         buffer_id,
         buffer_offset,
-        make_slice(data, data_size),
+        make_slice(data.cast(), data_size),
     ) {
         handle_error(error_sink, cause, None, "wgpuQueueWriteBuffer");
     }
@@ -2972,7 +2983,7 @@ pub unsafe extern "C" fn wgpuQueueWriteBuffer(
 pub unsafe extern "C" fn wgpuQueueWriteTexture(
     queue: native::WGPUQueue,
     destination: Option<&native::WGPUTexelCopyTextureInfo>,
-    data: *const u8, // TODO: Check - this might not follow the header
+    data: *const c_void,
     data_size: usize,
     data_layout: Option<&native::WGPUTexelCopyBufferLayout>,
     write_size: Option<&native::WGPUExtent3D>,
@@ -2985,7 +2996,7 @@ pub unsafe extern "C" fn wgpuQueueWriteTexture(
     if let Err(cause) = context.queue_write_texture(
         queue_id,
         &conv::map_image_copy_texture(destination.expect("invalid destination")),
-        make_slice(data, data_size),
+        make_slice(data.cast(), data_size),
         &conv::map_texture_data_layout(data_layout.expect("invalid data layout")),
         &conv::map_extent3d(write_size.expect("invalid write size")),
     ) {
@@ -3190,8 +3201,7 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetBindGroup(
     dynamic_offsets: *const u32,
 ) {
     let bundle = bundle.as_ref().expect("invalid render bundle");
-    // TODO: as per webgpu.h bindgroup is nullable
-    let bind_group_id = group.as_ref().expect("invalid bind group").id;
+    let bind_group_id = group.as_ref().map(|bg| bg.id);
     let encoder = bundle.encoder.as_mut().expect("invalid render bundle");
     let encoder = encoder.expect("invalid render bundle");
     let encoder = encoder.as_mut().unwrap();
@@ -3199,7 +3209,7 @@ pub unsafe extern "C" fn wgpuRenderBundleEncoderSetBindGroup(
     bundle_ffi::wgpu_render_bundle_set_bind_group(
         encoder,
         group_index,
-        Some(bind_group_id),
+        bind_group_id,
         dynamic_offsets,
         dynamic_offset_count,
     );
@@ -3554,14 +3564,13 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetBindGroup(
     dynamic_offsets: *const u32,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
-    // TODO: as per webgpu.h bindgroup is nullable
-    let bind_group_id = bind_group.as_ref().expect("invalid bind group").id;
+    let bind_group_id = bind_group.as_ref().map(|bg| bg.id);
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
     match pass.context.render_pass_set_bind_group(
         encoder,
         group_index,
-        Some(bind_group_id),
+        bind_group_id,
         make_slice(dynamic_offsets, dynamic_offset_count),
     ) {
         Ok(()) => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1200,7 +1200,9 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
                             .expect("invalid load op for render pass color attachment"),
                             store_op: conv::map_store_op(color_attachment.storeOp)
                                 .expect("invalid store op for render pass color attachment"),
-                            depth_slice: Some(color_attachment.depthSlice),
+                            depth_slice: (color_attachment.depthSlice
+                                != native::WGPU_DEPTH_SLICE_UNDEFINED)
+                                .then_some(color_attachment.depthSlice),
                         }
                     })
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,16 @@
+#![allow(
+    clippy::missing_safety_doc,
+    clippy::arc_with_non_send_sync,
+    clippy::crate_in_macro_def,
+    clippy::manual_unwrap_or_default,
+    clippy::let_unit_value,
+    clippy::needless_return,
+    clippy::too_many_arguments,
+    clippy::collapsible_else_if,
+    clippy::manual_unwrap_or,
+    clippy::empty_line_after_doc_comments
+)] // TODO fix these warnings
+
 use conv::{
     from_u64_bits, map_adapter_type, map_backend_type, map_bind_group_entry,
     map_bind_group_layout_entry, map_device_descriptor, map_instance_backend_flags,
@@ -1194,6 +1207,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderBeginRenderPass(
                             .expect("invalid load op for render pass color attachment"),
                             store_op: conv::map_store_op(color_attachment.storeOp)
                                 .expect("invalid store op for render pass color attachment"),
+                            depth_slice: Some(color_attachment.depthSlice),
                         }
                     })
                 })
@@ -1277,7 +1291,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderCopyBufferToBuffer(
         source_offset,
         destination_buffer_id,
         destination_offset,
-        size,
+        Some(size),
     ) {
         handle_error(
             error_sink,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-#![allow(
-    clippy::missing_safety_doc, 
-    clippy::arc_with_non_send_sync // Need to investigate?
-)]
+#![allow(clippy::missing_safety_doc)]
 
 use conv::{
     from_u64_bits, map_adapter_type, map_backend_type, map_bind_group_entry,
@@ -19,7 +16,7 @@ use std::{
     fmt::Display,
     mem,
     num::NonZeroU64,
-    sync::{atomic, Arc},
+    sync::{atomic, Arc, Weak},
     thread,
 };
 use utils::{
@@ -495,16 +492,16 @@ struct ErrorSinkRaw {
     scopes: Vec<ErrorScope>,
     uncaptured_handler: UncapturedErrorCallback,
     device_lost_handler: DeviceLostCallback,
-    device: Option<native::WGPUDevice>,
+    device: Weak<WGPUDeviceImpl>,
 }
 
 impl ErrorSinkRaw {
-    fn new(device_lost_handler: DeviceLostCallback) -> ErrorSinkRaw {
+    fn new(device_lost_handler: DeviceLostCallback, device: Weak<WGPUDeviceImpl>) -> ErrorSinkRaw {
         ErrorSinkRaw {
             scopes: Vec::new(),
             uncaptured_handler: DEFAULT_UNCAPTURED_ERROR_HANDLER,
             device_lost_handler,
-            device: None,
+            device,
         }
     }
 
@@ -515,9 +512,10 @@ impl ErrorSinkRaw {
                 if let Some(callback) = self.device_lost_handler.callback {
                     let userdata = &self.device_lost_handler.userdata;
                     let msg = err.to_string();
+                    let device = self.device.as_ptr();
                     unsafe {
                         callback(
-                            &self.device.unwrap(),
+                            &device,
                             native::WGPUDeviceLostReason_Destroyed,
                             str_into_string_view(&msg),
                             userdata.get_1(),
@@ -552,9 +550,10 @@ impl ErrorSinkRaw {
                 if let Some(callback) = self.uncaptured_handler.callback {
                     let userdata = &self.uncaptured_handler.userdata;
                     let msg = err.to_string();
+                    let device = self.device.as_ptr();
                     unsafe {
                         callback(
-                            &self.device.unwrap(),
+                            &device,
                             typ,
                             str_into_string_view(&msg),
                             userdata.get_1(),
@@ -815,22 +814,23 @@ pub unsafe extern "C" fn wgpuAdapterRequestDevice(
     let result = context.adapter_request_device(adapter_id, &desc, None, None);
     match result {
         Ok((device_id, queue_id)) => {
-            let mut error_sink = ErrorSinkRaw::new(device_lost_handler);
-            if let Some(error_callback) = error_callback {
-                error_sink.uncaptured_handler = error_callback;
-            }
-
-            let error_sink = Arc::new(Mutex::new(error_sink));
-            let device = Arc::into_raw(Arc::new(WGPUDeviceImpl {
-                context: context.clone(),
-                id: device_id,
-                queue: Arc::new(QueueId {
+            let device_impl = Arc::new_cyclic(|device| {
+                let mut error_sink = ErrorSinkRaw::new(device_lost_handler, device.clone());
+                if let Some(error_callback) = error_callback {
+                    error_sink.uncaptured_handler = error_callback;
+                }
+                let error_sink = Arc::new(Mutex::new(error_sink));
+                WGPUDeviceImpl {
                     context: context.clone(),
-                    id: queue_id,
-                }),
-                error_sink: error_sink.clone(),
-            }));
-            error_sink.lock().device = Some(device);
+                    id: device_id,
+                    queue: Arc::new(QueueId {
+                        context: context.clone(),
+                        id: queue_id,
+                    }),
+                    error_sink: error_sink.clone(),
+                }
+            });
+            let device = Arc::into_raw(device_impl);
 
             callback(
                 native::WGPURequestDeviceStatus_Success,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -14,10 +14,7 @@ pub extern "C" fn wgpuGetVersion() -> std::os::raw::c_uint {
     };
     let mut version: u32 = 0;
     for (index, part) in (0..).zip(static_str.split('.')) {
-        let versionpart: u32 = match part.parse::<u32>() {
-            Ok(n) => n,
-            Err(_e) => 0,
-        };
+        let versionpart = part.parse::<u32>().unwrap_or_default();
         let shift: i32 = 8 * (3 - index);
         if shift < 0 {
             break;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,7 +30,7 @@ impl Userdata {
 #[macro_export]
 macro_rules! new_userdata {
     ($var:expr) => {
-        crate::utils::Userdata::new($var.userdata1, $var.userdata2)
+        $crate::utils::Userdata::new($var.userdata1, $var.userdata2)
     };
 }
 
@@ -93,11 +93,11 @@ pub fn get_base_device_limits_from_adapter_limits(adapter_limits: &wgt::Limits) 
 }
 
 pub fn texture_format_has_depth(format: wgt::TextureFormat) -> bool {
-    return format == wgt::TextureFormat::Depth16Unorm
+    format == wgt::TextureFormat::Depth16Unorm
         || format == wgt::TextureFormat::Depth24Plus
         || format == wgt::TextureFormat::Depth24PlusStencil8
         || format == wgt::TextureFormat::Depth32Float
-        || format == wgt::TextureFormat::Depth32FloatStencil8;
+        || format == wgt::TextureFormat::Depth32FloatStencil8
 }
 
 /// Follow a chain of next pointers and automatically resolve them to the underlying structs.
@@ -129,7 +129,6 @@ pub fn texture_format_has_depth(format: wgt::TextureFormat) -> bool {
 ///
 /// Given two or more extension structs of the same `SType` in the same chain, this macro will favor the latter most. There should
 /// not be more than one extension struct with the same `SType` in a chain anyway, so this behavior should be unproblematic.
-
 #[macro_export]
 macro_rules! follow_chain {
     ($func:ident(($base:expr) $(, $stype:ident => $ty:ty)*)) => {{


### PR DESCRIPTION
Updates wgpu-native to wgpu v27.0.0!
I also implemented some features commented out in `wgpu.h` but I plan to add more later after splitting up wgpu-native so `lib.rs` and `conv.rs` aren't so long

This PR was originally designed around v26, but v27 just released so I went ahead and updated it.
v27 support needs some work still- some of the new functionality in v27 needs to be exposed in `wgpu.h`. I'd like to do that in another PR after I've split up `conv.rs` and `lib.rs`