### PR TITLE
Adds support for configuring the Dx12 presentation system

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -137,6 +137,13 @@ typedef enum WGPUGLFenceBehaviour {
     WGPUGLFenceBehaviour_Force32 = 0x7FFFFFFF
 } WGPUGLFenceBehaviour;
 
+typedef enum WGPUDx12SwapchainKind {
+    WGPUDx12SwapchainKind_Undefined = 0x00000000,
+    WGPUDx12SwapchainKind_DxgiFromHwnd = 0x00000001,
+    WGPUDx12SwapchainKind_DxgiFromVisual = 0x00000002,
+    WGPUDx12SwapchainKind_Force32 = 0x7FFFFFFF
+} WGPUDx12SwapchainKind;
+
 typedef struct WGPUInstanceExtras {
     WGPUChainedStruct chain;
     WGPUInstanceBackend backends;
@@ -146,6 +153,7 @@ typedef struct WGPUInstanceExtras {
     WGPUGLFenceBehaviour glFenceBehaviour;
     WGPUStringView dxcPath;
     WGPUDxcMaxShaderModel dxcMaxShaderModel;
+    WGPUDx12SwapchainKind dx12PresentationSystem;
 
     WGPU_NULLABLE const uint8_t* budgetForDeviceCreation;
     WGPU_NULLABLE const uint8_t* budgetForDeviceLoss;

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -332,6 +332,12 @@ pub unsafe fn map_instance_descriptor(
             _ => wgt::Dx12Compiler::default(),
         };
 
+        let dx12_presentation_system = match extras.dx12PresentationSystem {
+            native::WGPUDx12SwapchainKind_DxgiFromHwnd => wgt::Dx12SwapchainKind::DxgiFromHwnd,
+            native::WGPUDx12SwapchainKind_DxgiFromVisual => wgt::Dx12SwapchainKind::DxgiFromVisual,
+            _ => wgt::Dx12SwapchainKind::default(),
+        };
+
         let for_resource_creation = unsafe { extras.budgetForDeviceCreation.as_ref() }.copied();
         let for_device_loss = unsafe { extras.budgetForDeviceCreation.as_ref() }.copied();
 
@@ -344,6 +350,7 @@ pub unsafe fn map_instance_descriptor(
                 },
                 dx12: wgt::Dx12BackendOptions {
                     shader_compiler: dx12_shader_compiler,
+                    presentation_system: dx12_presentation_system,
                     ..Default::default()
                 },
                 noop: Default::default(),


### PR DESCRIPTION
This PR adds support for configuring the DirectX 12 presentation system (swapchain kind) through the `WGPUInstanceExtras` structure.

According to the wgpu documentation: 
https://docs.rs/wgpu-types/27.0.1/wgpu_types/instance/struct.Dx12BackendOptions.html, 
using DxgiFromVisual enables transparent window support.

Related: https://github.com/pygfx/wgpu-py/pull/775