### PR TITLE
Implement wgpuQueueGetTimestampPeriod

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -307,6 +307,7 @@ void wgpuGenerateReport(WGPUInstance instance, WGPUGlobalReport * report);
 size_t wgpuInstanceEnumerateAdapters(WGPUInstance instance, WGPU_NULLABLE WGPUInstanceEnumerateAdapterOptions const * options, WGPUAdapter * adapters);
 
 WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands);
+float wgpuQueueGetTimestampPeriod(WGPUQueue queue);
 
 // Returns true if the queue is empty, or false if there are more queue submissions still in flight.
 WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUSubmissionIndex const * submissionIndex);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2939,9 +2939,7 @@ pub unsafe extern "C" fn wgpuQueueSubmit(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuQueueGetTimestampPeriod(
-    queue: native::WGPUQueue
-) -> f32 {
+pub unsafe extern "C" fn wgpuQueueGetTimestampPeriod( queue: native::WGPUQueue) -> f32 {
     let (queue_id, context) = {
         let queue = queue.as_ref().expect("invalid queue");
         (queue.queue.id, &queue.queue.context)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2939,7 +2939,7 @@ pub unsafe extern "C" fn wgpuQueueSubmit(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wgpuQueueGetTimestampPeriod( queue: native::WGPUQueue) -> f32 {
+pub unsafe extern "C" fn wgpuQueueGetTimestampPeriod(queue: native::WGPUQueue) -> f32 {
     let (queue_id, context) = {
         let queue = queue.as_ref().expect("invalid queue");
         (queue.queue.id, &queue.queue.context)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2939,6 +2939,18 @@ pub unsafe extern "C" fn wgpuQueueSubmit(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wgpuQueueGetTimestampPeriod(
+    queue: native::WGPUQueue
+) -> f32 {
+    let (queue_id, context) = {
+        let queue = queue.as_ref().expect("invalid queue");
+        (queue.queue.id, &queue.queue.context)
+    };
+
+    context.queue_get_timestamp_period(queue_id)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wgpuQueueWriteBuffer(
     queue: native::WGPUQueue,
     buffer: native::WGPUBuffer,


### PR DESCRIPTION
As of now, timestamp queries are *technically* unusable since the timestamp period is unknown (although I guess it is quite often simply equal to 1). This pull request fixes that.

It **adds a new function** to `wgpu.h`. I haven't found info on the policy regarding extending the API, so I took the liberty to just add the function, since it's a small addition, and definitely not a breaking change :)