### PR TITLE
fix: ensure command encoder cleanup always runs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub struct WGPUCommandEncoderImpl {
 }
 impl Drop for WGPUCommandEncoderImpl {
     fn drop(&mut self) {
-        if self.open.load(atomic::Ordering::SeqCst) && !thread::panicking() {
+        if !thread::panicking() {
             let context = &self.context;
             context.command_encoder_drop(self.id);
         }


### PR DESCRIPTION
### Summary

The Drop implementation for `WGPUCommandEncoderImpl` only ran cleanup when `self.open` was true, but `wgpuCommandEncoderFinish` set `open=false` before the encoder was released. This meant `command_encoder_drop()` was never called, causing memory to leak.

### The Bug

```rust
// In wgpuCommandEncoderFinish (line 1401):
command_encoder.open.store(false, atomic::Ordering::SeqCst);

// In Drop (line 129):
if self.open.load(atomic::Ordering::SeqCst) && !thread::panicking() {
    context.command_encoder_drop(self.id);  // Never reached!
}
```

### The Fix

Remove the `open` check from Drop - cleanup should always run when the encoder is released:

```rust
if !thread::panicking() {
    context.command_encoder_drop(self.id);
}
```

### Test Results

| Version | Memory at 0s | Memory at 180s | Behavior |
|---------|--------------|----------------|----------|
| Before fix | 23 MB | 33 MB | +0.5 MB every 10 seconds |
| After fix | 21 MB | 21 MB | Stable |

### Reproduction

Minimal C++ test that creates command encoders at 60fps:

```cpp
while (true) {
    WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(device, nullptr);
    WGPURenderPassEncoder pass = wgpuCommandEncoderBeginRenderPass(encoder, &passDesc);
    wgpuRenderPassEncoderEnd(pass);
    wgpuRenderPassEncoderRelease(pass);
    WGPUCommandBuffer cmdBuf = wgpuCommandEncoderFinish(encoder, nullptr);
    wgpuQueueSubmit(queue, 1, &cmdBuf);
    wgpuCommandBufferRelease(cmdBuf);
    wgpuCommandEncoderRelease(encoder);
    std::this_thread::sleep_for(std::chrono::milliseconds(16));
}
```

Fixes #541
Fixes #527

### Notes

- The `open` flag still serves a purpose in `wgpuCommandEncoderFinish` to prevent double-finishing
- This fix ensures cleanup happens regardless of whether `finish()` was called
- Tested on macOS Sequoia / Apple M4 Max with wgpu-native v27
