### PR TITLE
docs: update Go binding to go-webgpu/webgpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The bindings are based on the WebGPU-native header found at `ffi/webgpu-headers/
 - [club-doki7/vulkan4j](https://github.com/club-doki7/vulkan4j) - Java wrapper (FFM-based)
 - [wgpu4k/wgpu4k](https://github.com/wgpu4k/wgpu4k) / [wgpu4k/wgpu4k-native](https://github.com/wgpu4k/wgpu4k-native) - Kotlin/Multiplatform wrappers
 - [karmakrafts/Multiplatform wgpu](https://git.karmakrafts.dev/kk/multiplatform-wgpu) - Kotlin/Native wrapper
-- [rajveermalviya/go-webgpu](https://github.com/rajveermalviya/go-webgpu) - Go wrapper
+- [go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) - Go wrapper (Zero-CGO)
 - [WebGPU-C++](https://github.com/eliemichel/WebGPU-Cpp) - Auto-generated C++ wrapper (developed for the [Learn WebGPU native](https://eliemichel.github.io/LearnWebGPU) course)
 - [jai_wgpu_native](https://github.com/SogoCZE/jai_wgpu_native) - Raw Jai bindings
 - [WebGPU::Direct](https://github.com/atrodo/WebGPU-Direct) - Perl wrapper ([package](https://metacpan.org/pod/WebGPU::Direct))


### PR DESCRIPTION
## Summary

Updates the Go binding reference in README:
- **Removes:** `rajveermalviya/go-webgpu` (archived since March 2025)
- **Adds:** `go-webgpu/webgpu` (active, Zero-CGO)

## Details

The previous Go binding ([rajveermalviya/go-webgpu](https://github.com/rajveermalviya/go-webgpu)) has been archived and is no longer maintained.

[go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) is an actively maintained alternative with:
- Zero-CGO (pure Go FFI via [goffi](https://github.com/go-webgpu/goffi))
- Support for wgpu-native v24.0.3.1
- 5 platforms: Windows/Linux/macOS (x64 + ARM64)

Closes #531