### PR TITLE
Expose graphics debugger capture functions in wgpu.h

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -345,6 +345,10 @@ void wgpuRenderPassEncoderEndPipelineStatisticsQuery(WGPURenderPassEncoder rende
 void wgpuComputePassEncoderWriteTimestamp(WGPUComputePassEncoder computePassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
 void wgpuRenderPassEncoderWriteTimestamp(WGPURenderPassEncoder renderPassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
 
+// Returns true if the capture was successfully started, or false if it failed to start or is not supported on the current platform.
+WGPUBool wgpuDeviceStartGraphicsDebuggerCapture(WGPUDevice device);
+void wgpuDeviceStopGraphicsDebuggerCapture(WGPUDevice device);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2497,6 +2497,30 @@ pub unsafe extern "C" fn wgpuDeviceGetFeatures(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wgpuDeviceStartGraphicsDebuggerCapture(
+    device: native::WGPUDevice
+) -> bool {
+    let (device_id, context) = {
+        let device = device.as_ref().expect("invalid device");
+        (device.id, &device.context)
+    };
+
+    // FIXME: wgpu-hal's start_graphics_debugger_capture returns a bool, but wgpu's doesn't
+    context.device_start_graphics_debugger_capture(device_id);
+    true
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuDeviceStopGraphicsDebuggerCapture(device: native::WGPUDevice) {
+    let (device_id, context) = {
+        let device = device.as_ref().expect("invalid device");
+        (device.id, &device.context)
+    };
+
+    context.device_stop_graphics_debugger_capture(device_id)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wgpuSupportedFeaturesFreeMembers(
     supported_features: native::WGPUSupportedFeatures,
 ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2497,7 +2497,7 @@ pub unsafe extern "C" fn wgpuDeviceGetFeatures(
 
 #[no_mangle]
 pub unsafe extern "C" fn wgpuDeviceStartGraphicsDebuggerCapture(
-    device: native::WGPUDevice
+    device: native::WGPUDevice,
 ) -> bool {
     let (device_id, context) = {
         let device = device.as_ref().expect("invalid device");


### PR DESCRIPTION
Quite useful when rendering to an off-screen buffer.

I would also like to extend the wgpu API to report whether a graphics debugger capture is **available** (and, if not, return a string indicating the reason, similar to `RenderDoc::NotAvailable`) and whether it's currently **active**, as it's currently up to the library's consumer to track; both RenderDoc and Metal expose such APIs, so it should be pretty straightforward to implement. Please let me know what you think.