### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The bindings are based on the WebGPU-native header found at `ffi/webgpu-headers/
 - [dvijaha/WGPUNative.jl](https://github.com/dvijaha/WGPUNative.jl) - stable Julia wrapper
 - [kgpu/wgpuj](https://github.com/kgpu/kgpu/tree/master/wgpuj) - Java/Kotlin wrapper
 - [club-doki7/vulkan4j](https://github.com/club-doki7/vulkan4j) - Java wrapper (FFM-based)
+- [xpenatan/jWebGPU](https://github.com/xpenatan/jWebGPU) / [gdx-webgpu](https://github.com/MonstrousSoftware/gdx-webgpu) - Java/TeaVM wrapper for libGDX
 - [wgpu4k/wgpu4k](https://github.com/wgpu4k/wgpu4k) / [wgpu4k/wgpu4k-native](https://github.com/wgpu4k/wgpu4k-native) - Kotlin/Multiplatform wrappers
 - [karmakrafts/Multiplatform wgpu](https://git.karmakrafts.dev/kk/multiplatform-wgpu) - Kotlin/Native wrapper
 - [go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) - Go wrapper (Zero-CGO)


### PR DESCRIPTION
Add new Java JNI wrapper

This wrapper is also utilized in the libGDX extension **[gdx-webgpu](https://github.com/MonstrousSoftware/gdx-webgpu)**.

**Supported platforms:**
- Android
- Web
- Desktop (Windows, macOS, Linux)