### PR TITLE
Use Unifed Repository Procedures

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->
+
+## Checklist
+
+- [ ] `cargo clippy` reports no issues
+- [ ] `cargo doc` reports no issues
+- [ ] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
+- [ ] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
+  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
+  - [ ] Add credit to yourself for each change: `Added new functionality. @githubname`
+
+## Description
+
+## Related Issues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,13 @@ on:
     branches-ignore: []
 
 env:
+  CI_RUST_VERSION: "1.91"
+  CI_RUST_MSRV: "1.82"
   CARGO_INCREMENTAL: false
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
   CACHE_SUFFIX: a
   WGPU_ANDROID_NDK_VERSION: r29 # 29.0.14206865"
 
@@ -37,13 +41,33 @@ jobs:
         with:
           submodules: true
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: cwfitzgerald/repo-common/.github/actions/install-rust@trunk
         with:
-          target: ${{ matrix.target }}
+          version: ${{ env.CI_RUST_VERSION }}
           components: rustfmt
       - name: Run rustfmt
         run: |
           cargo fmt -- --check
+
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: ""
+      RUSTDOCFLAGS: ""
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Install Rust toolchain
+        uses: cwfitzgerald/repo-common/.github/actions/install-rust@trunk
+        with:
+          version: ${{ env.CI_RUST_MSRV }}
+      - name: Check with default features
+        run: cargo check
+      - name: Check without default features
+        run: cargo check --no-default-features
 
   clippy:
     name: Clippy ${{ matrix.name }}
@@ -122,10 +146,11 @@ jobs:
         with:
           submodules: true
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: cwfitzgerald/repo-common/.github/actions/install-rust@trunk
         with:
-          target: ${{ matrix.target }}
+          version: ${{ env.CI_RUST_VERSION }}
           components: clippy
+          targets: ${{ matrix.target }}
       - name: Setup caching
         uses: Swatinem/rust-cache@v2
         with:
@@ -205,9 +230,10 @@ jobs:
             rust:p
       - if: "!contains(matrix.target, 'windows-gnu')"
         name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: cwfitzgerald/repo-common/.github/actions/install-rust@trunk
         with:
-          target: ${{ matrix.target }}
+          version: ${{ env.CI_RUST_VERSION }}
+          targets: ${{ matrix.target }}
       - name: Setup caching
         uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,12 @@ authors = [
 	"Rajesh Malviya <rajveer0malviya@gmail.com>",
 ]
 edition = "2021"
+rust-version = "1.82"
 description = "Native WebGPU implementation based on wgpu-core"
 homepage = "https://github.com/gfx-rs/wgpu-native"
 repository = "https://github.com/gfx-rs/wgpu-native"
 keywords = ["graphics"]
+categories = ["graphics", "rendering"]
 license = "MIT OR Apache-2.0"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ Automated 32 and 64-bit builds for MacOS, Windows and Linux are available as Git
 This repository contains C-language examples that link to the native library targets and perform basic rendering and computation. Please refer to our [Getting Started](https://github.com/gfx-rs/wgpu-native/wiki/Getting-Started) page at the wiki for more information.
 
 There's also a (small) [contributor guide](https://github.com/gfx-rs/wgpu-native/wiki/Contributing).
+
+## Minimum Supported Rust Version
+
+The minimum supported Rust version (MSRV) for wgpu-native is **1.82**. MSRV bumps are considered breaking changes.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,33 @@
+[licenses]
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+[bans]
+multiple-versions = "deny"
+skip = [
+    # Upstream wgpu dependency tree hasn't fully migrated yet
+    { crate = "foldhash@0.1", reason = "hashbrown 0.15 vs 0.16 in wgpu deps" },
+    { crate = "hashbrown@0.15", reason = "gpu-descriptor and petgraph lag behind" },
+    { crate = "rustc-hash@1", reason = "wgpu deps still use v1" },
+    { crate = "thiserror@1", reason = "wgpu deps still use v1" },
+    { crate = "thiserror-impl@1", reason = "wgpu deps still use v1" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "allow"
+
+[advisories]
+ignore = [
+    # paste is unmaintained but has no replacement yet and is widely used
+    "RUSTSEC-2024-0436",
+]

--- a/renovate.json
+++ b/renovate.json
@@ -1,34 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "schedule:weekly"],
-  "dependencyDashboard": true,
-  "prConcurrentLimit": 20,
-  "prHourlyLimit": 200,
-  "configMigration": true,
-  "labels": ["dependencies"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "recreateWhen": "always",
-    "rebaseWhen": "conflicted",
-    "branchTopic": "Cargo.lock update",
-    "commitMessageAction": "Update Cargo.lock",
-    "schedule": ["before 4am on monday"],
-    "prBodyDefinitions": {
-      "Change": "All locks refreshed"
-    }
-  },
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["patch"],
-      "matchCurrentVersion": "<1.0.0",
-      "enabled": false,
-      "description": "Patch updates to 0.x.y crates are compatible and handled by lockFileMaintenance"
-    },
-    {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": ">=1.0.0",
-      "enabled": false,
-      "description": "Minor and patch updates to x.y.z crates are compatible and handled by lockFileMaintenance"
-    }
-  ]
+  "extends": ["github>cwfitzgerald/repo-common"],
+  "configMigration": true
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.91"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ use conv::{
     map_query_set_index, map_shader_module, map_surface, map_surface_configuration,
     CreateSurfaceParams,
 };
-use core::slice;
 use parking_lot::Mutex;
 use smallvec::SmallVec;
 use std::{
@@ -2501,7 +2500,7 @@ pub unsafe extern "C" fn wgpuSupportedFeaturesFreeMembers(
     supported_features: native::WGPUSupportedFeatures,
 ) {
     if !supported_features.features.is_null() && supported_features.featureCount > 0 {
-        drop(Box::from_raw(slice::from_raw_parts_mut(
+        drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
             supported_features.features as *mut native::WGPUFeatureName,
             supported_features.featureCount,
         )))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -320,6 +320,7 @@ pub unsafe fn string_view_into_str<'a>(string_view: native::WGPUStringView) -> O
     } else {
         let bytes = match string_view.length {
             crate::conv::WGPU_STRLEN => CStr::from_ptr(string_view.data).to_bytes(),
+            #[allow(clippy::unnecessary_cast)] // On android, this is unnecessary.
             _ => make_slice(string_view.data as *const u8, string_view.length),
         };
 
@@ -358,7 +359,7 @@ pub unsafe fn drop_string_view(view: native::WGPUStringView) {
         return;
     }
 
-    drop(Box::from_raw(std::slice::from_raw_parts_mut(
+    drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
         view.data as *mut u8,
         view.length,
     )))


### PR DESCRIPTION
In an attempt to unify common logic across crates that I am responsible for, I have brought in a few extra features and switched us to common tooling.

I have added an MSRV of 1.82, as well as a cargo-deny file.