### PR TITLE
Fix setting instance validation flags (fixed #533)

### DIFF
--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -84,10 +84,18 @@ static const WGPUInstanceBackend WGPUInstanceBackend_Secondary = (1 << 1) | (1 <
 static const WGPUInstanceBackend WGPUInstanceBackend_Force32 = 0x7FFFFFFF;
 
 typedef WGPUFlags WGPUInstanceFlag;
-static const WGPUInstanceFlag WGPUInstanceFlag_Default = 0x00000000;
+static const WGPUInstanceFlag WGPUInstanceFlag_Empty = 0x00000000;
 static const WGPUInstanceFlag WGPUInstanceFlag_Debug = 1 << 0;
 static const WGPUInstanceFlag WGPUInstanceFlag_Validation = 1 << 1;
 static const WGPUInstanceFlag WGPUInstanceFlag_DiscardHalLabels = 1 << 2;
+static const WGPUInstanceFlag WGPUInstanceFlag_AllowUnderlyingNoncompliantAdapter = 1 << 3;
+static const WGPUInstanceFlag WGPUInstanceFlag_GPUBasedValidation = 1 << 4;
+static const WGPUInstanceFlag WGPUInstanceFlag_ValidationIndirectCall = 1 << 5;
+static const WGPUInstanceFlag WGPUInstanceFlag_AutomaticTimestampNormalization = 1 << 6;
+static const WGPUInstanceFlag WGPUInstanceFlag_Default = 1 << 24;
+static const WGPUInstanceFlag WGPUInstanceFlag_Debugging = 1 << 25;
+static const WGPUInstanceFlag WGPUInstanceFlag_AdvancedDebugging = 1 << 26;
+static const WGPUInstanceFlag WGPUInstanceFlag_WithEnv = 1 << 27;
 static const WGPUInstanceFlag WGPUInstanceFlag_Force32 = 0x7FFFFFFF;
 
 typedef enum WGPUDx12Compiler {

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -278,6 +278,8 @@ pub fn map_instance_backend_flags(flags: native::WGPUInstanceBackend) -> wgt::Ba
 #[inline]
 pub fn map_instance_flags(flags: native::WGPUInstanceFlag) -> wgt::InstanceFlags {
     let mut result = wgt::InstanceFlags::empty();
+
+    // Actual single-bit flags
     if (flags & native::WGPUInstanceFlag_Debug) != 0 {
         result.insert(wgt::InstanceFlags::DEBUG);
     }
@@ -287,6 +289,33 @@ pub fn map_instance_flags(flags: native::WGPUInstanceFlag) -> wgt::InstanceFlags
     if (flags & native::WGPUInstanceFlag_DiscardHalLabels) != 0 {
         result.insert(wgt::InstanceFlags::DISCARD_HAL_LABELS);
     }
+    if (flags & native::WGPUInstanceFlag_AllowUnderlyingNoncompliantAdapter) != 0 {
+        result.insert(wgt::InstanceFlags::ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER);
+    }
+    if (flags & native::WGPUInstanceFlag_GPUBasedValidation) != 0 {
+        result.insert(wgt::InstanceFlags::GPU_BASED_VALIDATION);
+    }
+    if (flags & native::WGPUInstanceFlag_ValidationIndirectCall) != 0 {
+        result.insert(wgt::InstanceFlags::VALIDATION_INDIRECT_CALL);
+    }
+    if (flags & native::WGPUInstanceFlag_AutomaticTimestampNormalization) != 0 {
+        result.insert(wgt::InstanceFlags::AUTOMATIC_TIMESTAMP_NORMALIZATION);
+    }
+
+    // Convenience helpers
+    if (flags & native::WGPUInstanceFlag_Default) != 0 {
+        result.insert(wgt::InstanceFlags::default());
+    }
+    if (flags & native::WGPUInstanceFlag_Debugging) != 0 {
+        result.insert(wgt::InstanceFlags::debugging());
+    }
+    if (flags & native::WGPUInstanceFlag_AdvancedDebugging) != 0 {
+        result.insert(wgt::InstanceFlags::advanced_debugging());
+    }
+    if (flags & native::WGPUInstanceFlag_WithEnv) != 0 {
+        result.insert(wgt::InstanceFlags::empty().with_env());
+    }
+
     result
 }
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -384,10 +384,7 @@ pub unsafe fn map_instance_descriptor(
                 },
                 noop: Default::default(),
             },
-            flags: match extras.flags {
-                native::WGPUInstanceFlag_Default => wgt::InstanceFlags::default(),
-                flags => map_instance_flags(flags),
-            },
+            flags: map_instance_flags(extras.flags),
             memory_budget_thresholds: wgt::MemoryBudgetThresholds {
                 for_device_loss,
                 for_resource_creation,


### PR DESCRIPTION
## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [ ] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [ ] Add credit to yourself for each change: `Added new functionality. @githubname`

I couldn't find the `CHANGELOG.md` file. Should I create it?
Also, it seems that the correct command is not `cargo deny`, but `cargo deny check`.

## Description

This changes how instance flags are mapped to wgt::InstanceFlags. The behavior of old flags doesn't change, but now
* An instance can actually be created with empty flags
* Some new flags supported by wgt::InstanceFlags were added that were previously missing
* Extra convenience bitfields were added that map to wgt::InstanceFlags::debugging()/advanced_debugging()/with_env()

## Related issues

This fixes #533.