### PR TITLE
Update native limits (fixes #507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 - MSRV bumped from 1.82 to 1.87.
 - **Push constants renamed to immediates.** This matches the upstream wgpu rename.
   - `WGPUNativeFeature_PushConstants` -> `WGPUNativeFeature_Immediates`
-  - `WGPUNativeLimits::maxPushConstantSize` -> `WGPUNativeLimits::maxImmediateSize`
+  - `WGPUNativeLimits::maxPushConstantSize` -> `WGPULimits::maxImmediateSize` @lisyarus
   - `WGPUPipelineLayoutExtras` no longer takes an array of `WGPUPushConstantRange`. It now takes a single `uint32_t immediateDataSize` representing the total size in bytes.
     ```c
     // Before
@@ -63,6 +63,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
   };
   ```
 - `WGPUSurfaceGetCurrentTextureStatus_Occluded` native extension value for `WGPUSurfaceGetCurrentTextureStatus`. Returned by `wgpuSurfaceGetCurrentTexture` when the window is not visible (e.g. minimized or fully behind another window). Currently only produced by the Metal backend on macOS, where acquiring a drawable while occluded would otherwise block for up to one second waiting for vsync. When you receive this status, no texture is returned and the surface remains valid -- skip rendering for the current frame and retry once the window becomes visible again. No reconfiguration is needed.
+  - `WGPUNativeLimits::maxBindingArraySamplerElementsPerShaderStage` @lisyarus
+  - `WGPUNativeLimits::maxMultiviewViewCount` @lisyarus
 
 ### Removed
 

--- a/examples/immediates/main.c
+++ b/examples/immediates/main.c
@@ -51,15 +51,8 @@ int main(int argc, char *argv[]) {
                              });
   assert(adapter);
 
-  WGPUNativeLimits supported_limits_extras = {
-      .chain =
-          {
-              .sType = WGPUSType_NativeLimits,
-          },
-      .maxImmediateSize = 0,
-  };
   WGPULimits supported_limits = {
-      .nextInChain = &supported_limits_extras.chain,
+      .maxImmediateSize = 0,
   };
   wgpuAdapterGetLimits(adapter, &supported_limits);
 

--- a/examples/texture_arrays/indexing.wgsl
+++ b/examples/texture_arrays/indexing.wgsl
@@ -35,7 +35,7 @@ struct Uniforms {
     index: u32,
 }
 
-@group(0) @binding(3)
+@group(1) @binding(0)
 var<uniform> uniforms: Uniforms;
 
 @fragment

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -262,10 +262,18 @@ int main(int argc, char *argv[]) {
     required_device_feature_count++;
   }
 
+  WGPUNativeLimits required_device_native_limits = WGPU_NATIVE_LIMITS_INIT;
+  required_device_native_limits.maxBindingArrayElementsPerShaderStage = 6;
+  required_device_native_limits.maxBindingArraySamplerElementsPerShaderStage = 2;
+
+  WGPULimits required_device_limits = WGPU_LIMITS_INIT;
+  required_device_limits.nextInChain = (const WGPUChainedStruct *)&required_device_native_limits;
+
   wgpuAdapterRequestDevice(demo.adapter,
                            &(const WGPUDeviceDescriptor){
                                .requiredFeatureCount = required_device_feature_count,
                                .requiredFeatures = required_device_features,
+                               .requiredLimits = &required_device_limits,
                            }, 
                            (const WGPURequestDeviceCallbackInfo){ 
                                .callback = handle_request_device,
@@ -503,16 +511,6 @@ int main(int argc, char *argv[]) {
                   .count = 2,
               },
       },
-      (const WGPUBindGroupLayoutEntry){
-          .binding = 3,
-          .visibility = WGPUShaderStage_Fragment,
-          .buffer =
-              (const WGPUBufferBindingLayout){
-                  .type = WGPUBufferBindingType_Uniform,
-                  .hasDynamicOffset = true,
-                  .minBindingSize = 4,
-              },
-      },
   };
   WGPUBindGroupLayout bind_group_layout = wgpuDeviceCreateBindGroupLayout(
       demo.device, &(const WGPUBindGroupLayoutDescriptor){
@@ -522,6 +520,27 @@ int main(int argc, char *argv[]) {
                        .entries = bind_group_layout_entries,
                    });
   assert(bind_group_layout);
+
+  const WGPUBindGroupLayoutEntry uniforms_bind_group_layout_entries[] = {
+      (const WGPUBindGroupLayoutEntry){
+          .binding = 0,
+          .visibility = WGPUShaderStage_Fragment,
+          .buffer =
+              (const WGPUBufferBindingLayout){
+                  .type = WGPUBufferBindingType_Uniform,
+                  .hasDynamicOffset = true,
+                  .minBindingSize = 4,
+              },
+      },
+  };
+  WGPUBindGroupLayout uniforms_bind_group_layout = wgpuDeviceCreateBindGroupLayout(
+      demo.device, &(const WGPUBindGroupLayoutDescriptor){
+                       .label = {"uniforms bind group layout", WGPU_STRLEN},
+                       .entryCount = sizeof(uniforms_bind_group_layout_entries) /
+                                     sizeof(uniforms_bind_group_layout_entries[0]),
+                       .entries = uniforms_bind_group_layout_entries,
+                   });
+  assert(uniforms_bind_group_layout);
 
   const WGPUBindGroupEntry bind_group_entries[] = {
       (const WGPUBindGroupEntry){
@@ -572,12 +591,6 @@ int main(int argc, char *argv[]) {
                       },
               },
       },
-      (const WGPUBindGroupEntry){
-          .binding = 3,
-          .buffer = texture_index_buffer,
-          .offset = 0,
-          .size = 4,
-      },
   };
   WGPUBindGroup bind_group = wgpuDeviceCreateBindGroup(
       demo.device, &(const WGPUBindGroupDescriptor){
@@ -589,13 +602,32 @@ int main(int argc, char *argv[]) {
                    });
   assert(bind_group);
 
+  const WGPUBindGroupEntry uniforms_bind_group_entries[] = {
+      (const WGPUBindGroupEntry){
+          .binding = 0,
+          .buffer = texture_index_buffer,
+          .offset = 0,
+          .size = 4,
+      },
+  };
+  WGPUBindGroup uniforms_bind_group = wgpuDeviceCreateBindGroup(
+      demo.device, &(const WGPUBindGroupDescriptor){
+                       .layout = uniforms_bind_group_layout,
+                       .label = {"uniforms bind group", WGPU_STRLEN},
+                       .entryCount = sizeof(uniforms_bind_group_entries) /
+                                     sizeof(uniforms_bind_group_entries[0]),
+                       .entries = uniforms_bind_group_entries,
+                   });
+  assert(uniforms_bind_group);
+
   WGPUPipelineLayout pipeline_layout = wgpuDeviceCreatePipelineLayout(
       demo.device, &(const WGPUPipelineLayoutDescriptor){
                        .label = {"main", WGPU_STRLEN},
-                       .bindGroupLayoutCount = 1,
+                       .bindGroupLayoutCount = 2,
                        .bindGroupLayouts =
                            (const WGPUBindGroupLayout[]){
                                bind_group_layout,
+                               uniforms_bind_group_layout
                            },
                    });
   assert(pipeline_layout);
@@ -723,14 +755,16 @@ int main(int argc, char *argv[]) {
     wgpuRenderPassEncoderSetIndexBuffer(render_pass_encoder, index_buffer,
                                         index_format, 0, WGPU_WHOLE_SIZE);
     if (use_uniform_workaround) {
-      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 0, bind_group, 1,
+      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 0, bind_group, 0, NULL);
+      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 1, uniforms_bind_group, 1,
                                         (const uint32_t[]){0});
       wgpuRenderPassEncoderDrawIndexed(render_pass_encoder, 6, 1, 0, 0, 0);
-      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 0, bind_group, 1,
+      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 1, uniforms_bind_group, 1,
                                         (const uint32_t[]){256});
       wgpuRenderPassEncoderDrawIndexed(render_pass_encoder, 6, 1, 6, 0, 0);
     } else {
-      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 0, bind_group, 1,
+      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 0, bind_group, 0, NULL);
+      wgpuRenderPassEncoderSetBindGroup(render_pass_encoder, 1, uniforms_bind_group, 1,
                                         (const uint32_t[]){0});
       wgpuRenderPassEncoderDrawIndexed(render_pass_encoder, 12, 1, 0, 0, 0);
     }

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -996,18 +996,6 @@ typedef struct WGPUNativeLimits
     /** This struct chain is used as mutable in some places and immutable in others. */
     WGPUChainedStruct chain;
     /**
-     * Amount of storage available for immediate data, in bytes.
-     *
-     * Defaults to 0. A non-zero value requires
-     * @ref WGPUNativeFeature_Immediates. Expected maximum sizes vary by
-     * backend:
-     * - Vulkan: 128-256 bytes
-     * - DX12: 128 bytes
-     * - Metal: 4096 bytes
-     * - OpenGL: ~256 bytes (emulated with uniforms)
-     */
-    uint32_t maxImmediateSize;
-    /**
      * Maximum number of live non-sampler bindings.
      *
      * Default is 1,000,000. Only meaningful on D3D12.
@@ -1017,10 +1005,19 @@ typedef struct WGPUNativeLimits
      */
     uint32_t maxNonSamplerBindings;
     /**
-     * Maximum number of individual resources within binding arrays per
-     * shader stage.
+     * Maximum number of individual resources within binding arrays that can be accessed
+     * in a single shader stage. Applies to all types of bindings except samplers.
      */
     uint32_t maxBindingArrayElementsPerShaderStage;
+    /**
+     * Maximum number of individual samplers within binding arrays that
+     * can be accessed in a single shader stage.
+     */
+    uint32_t maxBindingArraySamplerElementsPerShaderStage;
+    /**
+     * The maximum number of views that can be used in multiview rendering.
+     */
+    uint32_t maxMultiviewViewCount;
 } WGPUNativeLimits;
 
 typedef struct WGPUPipelineLayoutExtras

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1020,6 +1020,17 @@ typedef struct WGPUNativeLimits
     uint32_t maxMultiviewViewCount;
 } WGPUNativeLimits;
 
+#define WGPU_NATIVE_LIMITS_INIT _wgpu_MAKE_INIT_STRUCT(WGPUNativeLimits, { \
+    /*.chain=*/_wgpu_MAKE_INIT_STRUCT(WGPUChainedStruct, { \
+        /*.next=*/NULL _wgpu_COMMA \
+        /*.sType=*/(WGPUSType)WGPUSType_NativeLimits _wgpu_COMMA \
+    }) _wgpu_COMMA \
+    /*.maxNonSamplerBindings=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
+    /*.maxBindingArrayElementsPerShaderStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
+    /*.maxBindingArraySamplerElementsPerShaderStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
+    /*.maxMultiviewViewCount=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
+})
+
 typedef struct WGPUPipelineLayoutExtras
 {
     WGPUChainedStruct chain;

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -571,8 +571,7 @@ pub fn write_limits_struct(wgt_limits: wgt::Limits, limits: &mut native::WGPULim
                 wgt_limits.max_binding_array_elements_per_shader_stage;
             (*native_limits).maxBindingArraySamplerElementsPerShaderStage =
                 wgt_limits.max_binding_array_sampler_elements_per_shader_stage;
-            (*native_limits).maxMultiviewViewCount =
-                wgt_limits.max_multiview_view_count;
+            (*native_limits).maxMultiviewViewCount = wgt_limits.max_multiview_view_count;
         }
     };
 }
@@ -696,8 +695,7 @@ pub fn map_required_limits(
                 limits.maxBindingArraySamplerElementsPerShaderStage;
         }
         if limits.maxMultiviewViewCount != native::WGPU_LIMIT_U32_UNDEFINED {
-            wgt_limits.max_multiview_view_count =
-                limits.maxMultiviewViewCount;
+            wgt_limits.max_multiview_view_count = limits.maxMultiviewViewCount;
         }
     }
     wgt_limits

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -539,14 +539,13 @@ pub fn write_limits_struct(wgt_limits: wgt::Limits, limits: &mut native::WGPULim
     limits.maxUniformBuffersPerShaderStage = wgt_limits.max_uniform_buffers_per_shader_stage;
     limits.maxUniformBufferBindingSize = wgt_limits.max_uniform_buffer_binding_size as _;
     limits.maxStorageBufferBindingSize = wgt_limits.max_storage_buffer_binding_size as _;
+    limits.minUniformBufferOffsetAlignment = wgt_limits.min_uniform_buffer_offset_alignment;
+    limits.minStorageBufferOffsetAlignment = wgt_limits.min_storage_buffer_offset_alignment;
     limits.maxVertexBuffers = wgt_limits.max_vertex_buffers;
     limits.maxBufferSize = wgt_limits.max_buffer_size;
     limits.maxVertexAttributes = wgt_limits.max_vertex_attributes;
     limits.maxVertexBufferArrayStride = wgt_limits.max_vertex_buffer_array_stride;
-    limits.minUniformBufferOffsetAlignment = wgt_limits.min_uniform_buffer_offset_alignment;
-    limits.minStorageBufferOffsetAlignment = wgt_limits.min_storage_buffer_offset_alignment;
-    // TODO: not yet in wgt
-    // limits.maxInterStageShaderVariables = wgt_limits.max_inter_stage_shader_variables;
+    limits.maxInterStageShaderVariables = wgt_limits.max_inter_stage_shader_variables;
     limits.maxColorAttachments = wgt_limits.max_color_attachments;
     limits.maxColorAttachmentBytesPerSample = wgt_limits.max_color_attachment_bytes_per_sample;
     limits.maxComputeWorkgroupStorageSize = wgt_limits.max_compute_workgroup_storage_size;
@@ -555,6 +554,7 @@ pub fn write_limits_struct(wgt_limits: wgt::Limits, limits: &mut native::WGPULim
     limits.maxComputeWorkgroupSizeY = wgt_limits.max_compute_workgroup_size_y;
     limits.maxComputeWorkgroupSizeZ = wgt_limits.max_compute_workgroup_size_z;
     limits.maxComputeWorkgroupsPerDimension = wgt_limits.max_compute_workgroups_per_dimension;
+    limits.maxImmediateSize = wgt_limits.max_immediate_size;
 
     if let Some(native::WGPUChainedStruct {
         sType: native::WGPUSType_NativeLimits,
@@ -566,10 +566,13 @@ pub fn write_limits_struct(wgt_limits: wgt::Limits, limits: &mut native::WGPULim
                 *mut native::WGPUChainedStruct,
                 *mut native::WGPUNativeLimits,
             >(limits.nextInChain);
-            (*native_limits).maxImmediateSize = wgt_limits.max_immediate_size;
             (*native_limits).maxNonSamplerBindings = wgt_limits.max_non_sampler_bindings;
             (*native_limits).maxBindingArrayElementsPerShaderStage =
                 wgt_limits.max_binding_array_elements_per_shader_stage;
+            (*native_limits).maxBindingArraySamplerElementsPerShaderStage =
+                wgt_limits.max_binding_array_sampler_elements_per_shader_stage;
+            (*native_limits).maxMultiviewViewCount =
+                wgt_limits.max_multiview_view_count;
         }
     };
 }
@@ -650,10 +653,9 @@ pub fn map_required_limits(
     if limits.maxVertexBufferArrayStride != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_vertex_buffer_array_stride = limits.maxVertexBufferArrayStride;
     }
-    // TODO: not yet in wgt
-    // if limits.maxInterStageShaderVariables != native::WGPU_LIMIT_U32_UNDEFINED {
-    //     wgt_limits.max_inter_stage_shader_variables = limits.maxInterStageShaderVariables;
-    // }
+    if limits.maxInterStageShaderVariables != native::WGPU_LIMIT_U32_UNDEFINED {
+        wgt_limits.max_inter_stage_shader_variables = limits.maxInterStageShaderVariables;
+    }
     if limits.maxColorAttachments != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_color_attachments = limits.maxColorAttachments;
     }
@@ -678,16 +680,24 @@ pub fn map_required_limits(
     if limits.maxComputeWorkgroupsPerDimension != native::WGPU_LIMIT_U32_UNDEFINED {
         wgt_limits.max_compute_workgroups_per_dimension = limits.maxComputeWorkgroupsPerDimension;
     }
+    if limits.maxImmediateSize != native::WGPU_LIMIT_U32_UNDEFINED {
+        wgt_limits.max_immediate_size = limits.maxImmediateSize;
+    }
     if let Some(limits) = extras {
-        if limits.maxImmediateSize != native::WGPU_LIMIT_U32_UNDEFINED {
-            wgt_limits.max_immediate_size = limits.maxImmediateSize;
-        }
         if limits.maxNonSamplerBindings != native::WGPU_LIMIT_U32_UNDEFINED {
             wgt_limits.max_non_sampler_bindings = limits.maxNonSamplerBindings;
         }
         if limits.maxBindingArrayElementsPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
             wgt_limits.max_binding_array_elements_per_shader_stage =
                 limits.maxBindingArrayElementsPerShaderStage;
+        }
+        if limits.maxBindingArraySamplerElementsPerShaderStage != native::WGPU_LIMIT_U32_UNDEFINED {
+            wgt_limits.max_binding_array_sampler_elements_per_shader_stage =
+                limits.maxBindingArraySamplerElementsPerShaderStage;
+        }
+        if limits.maxMultiviewViewCount != native::WGPU_LIMIT_U32_UNDEFINED {
+            wgt_limits.max_multiview_view_count =
+                limits.maxMultiviewViewCount;
         }
     }
     wgt_limits


### PR DESCRIPTION
Updated the WGPUNativeLimits struct to reflect the changes in wgpu-core and webgpu-headers. Specifically,

* Removed `maxImmediateSize`, as it is now part of `WGPULimits`
* Added `maxBindingArraySamplerElementsPerShaderStage` and `maxMultiviewViewCount`

I've omitted the limits related to mesh shaders & ray query acceleration structres, as afaik the corresponding API is currently not exposed in wgpu-native anyway.

I've also fixed the `immediates` and `texture_arrays` examples. The latter one is what [sparked this PR](https://github.com/gfx-rs/wgpu-native/issues/507) in the first place; it had to be reworked a bit, as texture arrays cannot be present in the same bind group as buffers with dynamic offsets, thus I've split the bound group into two.

I've took the liberty of introducing a `WGPU_NATIVE_LIMITS_INIT` macro that mimicks the `WGPU_LIMITS_INIT` macro from `webgpu.h`.

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality. @githubname`