### PR TITLE
Sync native features with wgpu-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,14 +63,16 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
   };
   ```
 - `WGPUSurfaceGetCurrentTextureStatus_Occluded` native extension value for `WGPUSurfaceGetCurrentTextureStatus`. Returned by `wgpuSurfaceGetCurrentTexture` when the window is not visible (e.g. minimized or fully behind another window). Currently only produced by the Metal backend on macOS, where acquiring a drawable while occluded would otherwise block for up to one second waiting for vsync. When you receive this status, no texture is returned and the surface remains valid -- skip rendering for the current frame and retry once the window becomes visible again. No reconfiguration is needed.
-  - `WGPUNativeLimits::maxBindingArraySamplerElementsPerShaderStage` @lisyarus
-  - `WGPUNativeLimits::maxMultiviewViewCount` @lisyarus
+- `WGPUNativeLimits::maxBindingArraySamplerElementsPerShaderStage` @lisyarus
+- `WGPUNativeLimits::maxMultiviewViewCount` @lisyarus
+- `WGPUNativeFeature_StorageTextureArrayNonUniformIndexing`, `WGPUNativeFeature_Multiview`, `WGPUNativeFeature_ShaderFloat32Atomic`, `WGPUNativeFeature_TextureAtomic`, `WGPUNativeFeature_TextureFormatP010`, `WGPUNativeFeature_PipelineCache`, `WGPUNativeFeature_ShaderInt64AtomicMinMax`, `WGPUNativeFeature_ShaderInt64AtomicAllOps`, `WGPUNativeFeature_TextureInt64Atomic`, `WGPUNativeFeature_ShaderBarycentrics`, `WGPUNativeFeature_SelectiveMultiview`, `WGPUNativeFeature_MultisampleArray`, `WGPUNativeFeature_CooperativeMatrix`, `WGPUNativeFeature_ShaderPerVertex`, `WGPUNativeFeature_ShaderDrawIndex`, `WGPUNativeFeature_AccelerationStructureBindingArray`, `WGPUNativeFeature_MemoryDecorationCoherent`, `WGPUNativeFeature_MemoryDecorationVolatile` @lisyarus
 
 ### Removed
 
 - `WGPUPushConstantRange` struct.
 - `foreign-types-shared` dependency (no longer needed after Metal backend switched to `objc2`).
 - `raw-window-handle` feature on `wgpu-core` dependency (removed upstream).
+- `WGPUNativeFeature_UniformBufferAndStorageTextureArrayNonUniformIndexing` and `WGPUNativeFeature_SpirvShaderPassthrough` removed @lisyarus
 
 ## Diffs
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -329,12 +329,12 @@ typedef enum WGPUNativeFeature
      */
     WGPUNativeFeature_BufferBindingArray = 0x0003000F,
     /**
-     * Allows shaders to index uniform buffer and storage texture resource
+     * Allows shaders to index storage texture resource
      * arrays with dynamically non-uniform values.
      *
      * This is a native only feature.
      */
-    WGPUNativeFeature_UniformBufferAndStorageTextureArrayNonUniformIndexing = 0x00030010,
+    WGPUNativeFeature_StorageTextureArrayNonUniformIndexing = 0x00030010,
     // TODO: requires wgpu.h api change
     // WGPUNativeFeature_AddressModeClampToZero = 0x00030011,
     // WGPUNativeFeature_AddressModeClampToBorder = 0x00030012,
@@ -379,24 +379,20 @@ typedef enum WGPUNativeFeature
      * This is a native only feature.
      */
     WGPUNativeFeature_ConservativeRasterization = 0x00030015,
+    // TODO: requires wgpu.h api change
     // WGPUNativeFeature_ClearTexture = 0x00030016,
     /**
-     * Enables creating shader modules from pre-compiled SPIR-V binary via
-     * @ref wgpuDeviceCreateShaderModuleSpirV.
-     *
-     * Shader code isn't parsed or interpreted in any way. It is the caller's
-     * responsibility to ensure the code is correct.
-     *
+     * Enables multiview render passes and `builtin(view_index)` in vertex/mesh shaders.
+     * 
      * Supported platforms:
      * - Vulkan
-     * - DX12
      * - Metal
-     * - WebGPU
-     *
+     * - DX12
+     * - OpenGL (web only)
+     * 
      * This is a native only feature.
      */
-    WGPUNativeFeature_SpirvShaderPassthrough = 0x00030017,
-    // WGPUNativeFeature_Multiview = 0x00030018,
+    WGPUNativeFeature_Multiview = 0x00030018,
     /**
      * Enables using 64-bit types for vertex attributes.
      *
@@ -552,6 +548,203 @@ typedef enum WGPUNativeFeature
      * This is a native only feature.
      */
     WGPUNativeFeature_ShaderInt64 = 0x00030026,
+    /**
+     * Allows shaders to use f32 atomic load, store, add, sub, and exchange.
+     * 
+     * Supported platforms:
+     * - Metal (with MSL 3.0+ and Apple7+/Mac2)
+     * - Vulkan (with [VK_EXT_shader_atomic_float])
+     *  
+     * This is a native only feature.
+    */
+    WGPUNativeFeature_ShaderFloat32Atomic = 0x00030027,
+    /**
+     * Enables image atomic fetch add, and, xor, or, min, and max for R32Uint and R32Sint textures.
+     * 
+     * Supported platforms:
+     * - Vulkan
+     * - DX12
+     * - Metal (with MSL 3.1+)
+     * 
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_TextureAtomic = 0x00030028,
+    /**
+     * Allows for creation of textures of format
+     * @ref WGPUNativeTextureFormat_P010.
+     *
+     * Supported platforms:
+     * - DX12
+     * - Vulkan
+     *
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_TextureFormatP010 = 0x00030029,
+    // TODO: requires wgpu.h api change
+    // WGPUNativeFeature_ExternalTexture = 0x0003002A,
+    /**
+     * Allows the use of pipeline cache objects
+     * 
+     * Supported platforms:
+     * - Vulkan
+     * 
+     * Unimplemented Platforms:
+     * - DX12
+     * - Metal
+     */
+    WGPUNativeFeature_PipelineCache = 0x0003002B,
+    /**
+     * Allows shaders to use i64 and u64 atomic min and max.
+     *
+     * Supported platforms:
+     * - Vulkan (with VK_KHR_shader_atomic_int64)
+     * - DX12 (with SM 6.6+)
+     * - Metal (with MSL 2.4+)
+     *
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_ShaderInt64AtomicMinMax = 0x0003002C,
+    /**
+     * Allows shaders to use all i64 and u64 atomic operations.
+     *
+     * Supported platforms:
+     * - Vulkan (with VK_KHR_shader_atomic_int64)
+     * - DX12 (with SM 6.6+)
+     *
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_ShaderInt64AtomicAllOps = 0x0003002D,
+    // TODO: requires wgpu.h api change
+    // WGPUNativeFeature_VulkanGoogleDisplayTiming = 0x0003002E,
+    // WGPUNativeFeature_VulkanExternalMemoryWin32 = 0x0003002F,
+    /**
+     * Enables R64Uint image atomic min and max.
+     * 
+     * Supported platforms:
+     * - Vulkan (with VK_EXT_shader_image_atomic_int64)
+     * - DX12 (with SM 6.6+)
+     * - Metal (with MSL 3.1+)
+     * 
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_TextureInt64Atomic = 0x00030030,
+    // TODO: not implemented yet, see https://github.com/gfx-rs/wgpu/issues/7149
+    // WGPUNativeFeature_UniformBufferBindingArrays = 0x00030031,
+    // TODO: requires wgpu.h api change
+    // WGPUNativeFeature_MeshShader = 0x00030032,
+    // WGPUNativeFeature_RayHitVertexReturn = 0x00030033,
+    // WGPUNativeFeature_MeshShaderMultiview = 0x00030034,
+    // WGPUNativeFeature_ExtendedAccelerationStructureVertexFormats = 0x00030035,
+    // WGPUNativeFeature_PassthroughShaders = 0x00030036,
+    /**
+     * Enables shader barycentric coordinates.
+     * 
+     * Supported platforms:
+     * - Vulkan (with VK_KHR_fragment_shader_barycentric)
+     * - DX12 (with SM 6.1+)
+     * - Metal (with MSL 2.2+)
+     * 
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_ShaderBarycentrics = 0x00030037,
+    /**
+     * Enables using multiview where not all texture array layers are rendered to in a single render pass/render pipeline. Making
+     * use of this feature also requires enabling `Features::MULTIVIEW`.
+     * 
+     * Supported platforms
+     * - Vulkan
+     * - DX12
+     * 
+     * While metal supports this in theory, the behavior of `view_index` differs from vulkan and dx12 so the feature isn't exposed.
+     */
+    WGPUNativeFeature_SelectiveMultiview = 0x00030038,
+    // TODO: requires wgpu.h api change
+    // WGPUNativeFeature_MeshShaderPoints = 0x00030039,
+    WGPUNativeFeature_MultisampleArray = 0x0003003A,
+    /**
+     * Enables cooperative matrix operations (also known as tensor cores on NVIDIA GPUs
+     * or simdgroup matrix operations on Apple GPUs).
+     * 
+     * Cooperative matrices allow a workgroup to collectively load, store, and perform
+     * matrix multiply-accumulate operations on small tiles of data, enabling
+     * hardware-accelerated matrix math.
+     *
+     * @b EXPERIMENTAL: Features enabled by this may have major bugs and are
+     * expected to be subject to breaking changes.
+     * 
+     * **Current limitations:** The implementation currently only supports 8x8 f32 matrices.
+     * On Vulkan, support is determined by querying `vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR`
+     * for configurations matching 8x8x8 f32. Most Vulkan implementations (NVIDIA, AMD) primarily
+     * support f16 inputs at larger sizes (e.g., 16x16), so Vulkan support may be limited.
+     * 
+     * Supported platforms:
+     * - Metal (with MSL 2.3+ and Apple7+/Mac2+, using simdgroup matrix operations)
+     * - Vulkan (with [VK_KHR_cooperative_matrix](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_cooperative_matrix.html), if 8x8 f32 is supported)
+     * 
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_CooperativeMatrix = 0x0003003B,
+    /**
+     * Enables shader per-vertex attributes.
+     * 
+     * Supported platforms:
+     * - Vulkan (with VK_KHR_fragment_shader_barycentric)
+     * 
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_ShaderPerVertex = 0x0003003C,
+    /**
+     * Enables shader `draw_index` builtin.
+     * 
+     * Supported platforms:
+     * - GLES
+     * - Vulkan
+     * 
+     * Potential platforms:
+     * - DX12
+     * - Metal
+     * 
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_ShaderDrawIndex = 0x0003003D,
+    /**
+     * Allows the user to create arrays of acceleration structures in shaders:
+     * 
+     * ex.
+     * - `var tlas: binding_array<acceleration_structure, 10>` (WGSL)
+     * 
+     * This capability allows them to exist and to be indexed by dynamically uniform values.
+     * 
+     * Supported platforms:
+     * - DX12
+     * - Vulkan
+     * 
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_AccelerationStructureBindingArray = 0x0003003E,
+    /**
+     * Enables the `@coherent` memory decoration on storage buffer variables.
+     * 
+     * Backend mapping:
+     * - Vulkan
+     * - DX12
+     * - Metal (3.2+)
+     * - GLES (ES 3.1+ / GL 4.3+)
+     * 
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_MemoryDecorationCoherent = 0x0003003F,
+    /**
+     * Enables the `@volatile` memory decoration on storage buffer variables.
+     * 
+     * Backend mapping:
+     * - Vulkan
+     * - GLES (ES 3.1+ / GL 4.3+)
+     * 
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_MemoryDecorationVolatile = 0x00030040,
+
     WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1198,11 +1198,17 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::TEXTURE_COMPRESSION_BC) {
         temp.push(native::WGPUFeatureName_TextureCompressionBC);
     }
+    if features.contains(wgt::Features::TEXTURE_COMPRESSION_BC_SLICED_3D) {
+        temp.push(native::WGPUFeatureName_TextureCompressionBCSliced3D);
+    }
     if features.contains(wgt::Features::TEXTURE_COMPRESSION_ETC2) {
         temp.push(native::WGPUFeatureName_TextureCompressionETC2);
     }
     if features.contains(wgt::Features::TEXTURE_COMPRESSION_ASTC) {
         temp.push(native::WGPUFeatureName_TextureCompressionASTC);
+    }
+    if features.contains(wgt::Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D) {
+        temp.push(native::WGPUFeatureName_TextureCompressionASTCSliced3D);
     }
     if features.contains(wgt::Features::TIMESTAMP_QUERY) {
         temp.push(native::WGPUFeatureName_TimestampQuery);
@@ -1222,9 +1228,19 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::FLOAT32_FILTERABLE) {
         temp.push(native::WGPUFeatureName_Float32Filterable);
     }
+    if features.contains(wgt::Features::FLOAT32_BLENDABLE) {
+        temp.push(native::WGPUFeatureName_Float32Blendable);
+    }
+    if features.contains(wgt::Features::CLIP_DISTANCES) {
+        temp.push(native::WGPUFeatureName_ClipDistances);
+    }
     if features.contains(wgt::Features::DUAL_SOURCE_BLENDING) {
         temp.push(native::WGPUFeatureName_DualSourceBlending);
     }
+    if features.contains(wgt::Features::PRIMITIVE_INDEX) {
+        temp.push(native::WGPUFeatureName_PrimitiveIndex);
+    }
+
     // wgpu-rs only features
     if features.contains(wgt::Features::IMMEDIATES) {
         temp.push(native::WGPUNativeFeature_Immediates);
@@ -1261,24 +1277,16 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::TEXTURE_COMPRESSION_ASTC_HDR) {
         temp.push(native::WGPUNativeFeature_TextureCompressionAstcHdr);
     }
-    if features.contains(wgt::Features::TIMESTAMP_QUERY_INSIDE_PASSES) {
-        temp.push(native::WGPUNativeFeature_TimestampQueryInsidePasses);
-    }
-    if features.contains(wgt::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS) {
-        temp.push(native::WGPUNativeFeature_TimestampQueryInsideEncoders);
-    }
     if features.contains(wgt::Features::MAPPABLE_PRIMARY_BUFFERS) {
         temp.push(native::WGPUNativeFeature_MappablePrimaryBuffers);
     }
     if features.contains(wgt::Features::BUFFER_BINDING_ARRAY) {
         temp.push(native::WGPUNativeFeature_BufferBindingArray);
     }
-    // TODO: fix this, UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING is not supported anymore https://github.com/gfx-rs/wgpu/issues/4407
-    // if features
-    //     .contains(wgt::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING)
-    // {
-    //     temp.push(native::WGPUNativeFeature_UniformBufferAndStorageTextureArrayNonUniformIndexing);
-    // }
+    if features.contains(wgt::Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING)
+    {
+        temp.push(native::WGPUNativeFeature_StorageTextureArrayNonUniformIndexing);
+    }
     // TODO: requires wgpu.h api change
     // if features.contains(wgt::Features::ADDRESS_MODE_CLAMP_TO_ZERO) {
     //     temp.push(native::WGPUNativeFeature_AddressModeClampToZero);
@@ -1295,12 +1303,13 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::CONSERVATIVE_RASTERIZATION) {
         temp.push(native::WGPUNativeFeature_ConservativeRasterization);
     }
+    // TODO: requires wgpu.h api change
     // if features.contains(wgt::Features::CLEAR_TEXTURE) {
     //     temp.push(native::WGPUNativeFeature_ClearTexture);
     // }
-    // if features.contains(wgt::Features::MULTIVIEW) {
-    //     temp.push(native::WGPUNativeFeature_Multiview);
-    // }
+    if features.contains(wgt::Features::MULTIVIEW) {
+        temp.push(native::WGPUNativeFeature_Multiview);
+    }
     if features.contains(wgt::Features::VERTEX_ATTRIBUTE_64BIT) {
         temp.push(native::WGPUNativeFeature_VertexAttribute64bit);
     }
@@ -1313,14 +1322,8 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::SHADER_F64) {
         temp.push(native::WGPUNativeFeature_ShaderF64);
     }
-    if features.contains(wgt::Features::SHADER_INT64) {
-        temp.push(native::WGPUNativeFeature_ShaderInt64);
-    }
     if features.contains(wgt::Features::SHADER_I16) {
         temp.push(native::WGPUNativeFeature_ShaderI16);
-    }
-    if features.contains(wgt::Features::PRIMITIVE_INDEX) {
-        temp.push(native::WGPUFeatureName_PrimitiveIndex);
     }
     if features.contains(wgt::Features::SHADER_EARLY_DEPTH_TEST) {
         temp.push(native::WGPUNativeFeature_ShaderEarlyDepthTest);
@@ -1333,6 +1336,97 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     }
     if features.contains(wgt::Features::SUBGROUP_BARRIER) {
         temp.push(native::WGPUNativeFeature_SubgroupBarrier);
+    }
+    if features.contains(wgt::Features::TIMESTAMP_QUERY_INSIDE_PASSES) {
+        temp.push(native::WGPUNativeFeature_TimestampQueryInsidePasses);
+    }
+    if features.contains(wgt::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS) {
+        temp.push(native::WGPUNativeFeature_TimestampQueryInsideEncoders);
+    }
+    if features.contains(wgt::Features::SHADER_INT64) {
+        temp.push(native::WGPUNativeFeature_ShaderInt64);
+    }
+    if features.contains(wgt::Features::SHADER_FLOAT32_ATOMIC) {
+        temp.push(native::WGPUNativeFeature_ShaderFloat32Atomic);
+    }
+    if features.contains(wgt::Features::TEXTURE_ATOMIC) {
+        temp.push(native::WGPUNativeFeature_TextureAtomic);
+    }
+    if features.contains(wgt::Features::TEXTURE_FORMAT_P010) {
+        temp.push(native::WGPUNativeFeature_TextureFormatP010);
+    }
+    // TODO: requires wgpu.h api change
+    // if features.contains(wgt::Features::EXTERNAL_TEXTURE) {
+    //     temp.push(native::WGPUNativeFeature_ExternalTexture);
+    // }
+    if features.contains(wgt::Features::PIPELINE_CACHE) {
+        temp.push(native::WGPUNativeFeature_PipelineCache);
+    }
+    if features.contains(wgt::Features::SHADER_INT64_ATOMIC_MIN_MAX) {
+        temp.push(native::WGPUNativeFeature_ShaderInt64AtomicMinMax);
+    }
+    if features.contains(wgt::Features::SHADER_INT64_ATOMIC_ALL_OPS) {
+        temp.push(native::WGPUNativeFeature_ShaderInt64AtomicAllOps);
+    }
+    // TODO: requires wgpu.h api change
+    // if features.contains(wgt::Features::VULKAN_GOOGLE_DISPLAY_TIMING) {
+    //     temp.push(native::WGPUNativeFeature_VulkanGoogleDisplayTiming);
+    // }
+    // if features.contains(wgt::Features::VULKAN_EXTERNAL_MEMORY_WIN32) {
+    //     temp.push(native::WGPUNativeFeature_VulkanExternalMemoryWin32);
+    // }
+    if features.contains(wgt::Features::TEXTURE_INT64_ATOMIC) {
+        temp.push(native::WGPUNativeFeature_TextureInt64Atomic);
+    }
+    // TODO: requires wgpu.h api change
+    // if features.contains(wgt::Features::UNIFORM_BUFFER_BINDING_ARRAYS) {
+    //     temp.push(native::WGPUNativeFeature_UniformBufferBindingArrays);
+    // }
+    // if features.contains(wgt::Features::EXPERIMENTAL_MESH_SHADER) {
+    //     temp.push(native::WGPUNativeFeature_MeshShader);
+    // }
+    // if features.contains(wgt::Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN) {
+    //     temp.push(native::WGPUNativeFeature_RayHitVertexReturn);
+    // }
+    // if features.contains(wgt::Features::EXPERIMENTAL_MESH_SHADER_MULTIVIEW) {
+    //     temp.push(native::WGPUNativeFeature_MeshShaderMultiview);
+    // }
+    // if features.contains(wgt::Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS) {
+    //     temp.push(native::WGPUNativeFeature_ExtendedAccelerationStructureVertexFormats);
+    // }
+    // if features.contains(wgt::Features::PASSTHROUGH_SHADERS) {
+    //     temp.push(native::WGPUNativeFeature_PassthroughShaders);
+    // }
+    if features.contains(wgt::Features::SHADER_BARYCENTRICS) {
+        temp.push(native::WGPUNativeFeature_ShaderBarycentrics);
+    }
+    if features.contains(wgt::Features::SELECTIVE_MULTIVIEW) {
+        temp.push(native::WGPUNativeFeature_SelectiveMultiview);
+    }
+    // TODO: requires wgpu.h api change
+    // if features.contains(wgt::Features::EXPERIMENTAL_MESH_SHADER_POINTS) {
+    //     temp.push(native::WGPUNativeFeature_MeshShaderPoints);
+    // }
+    if features.contains(wgt::Features::MULTISAMPLE_ARRAY) {
+        temp.push(native::WGPUNativeFeature_MultisampleArray);
+    }
+    if features.contains(wgt::Features::EXPERIMENTAL_COOPERATIVE_MATRIX) {
+        temp.push(native::WGPUNativeFeature_CooperativeMatrix);
+    }
+    if features.contains(wgt::Features::SHADER_PER_VERTEX) {
+        temp.push(native::WGPUNativeFeature_ShaderPerVertex);
+    }
+    if features.contains(wgt::Features::SHADER_DRAW_INDEX) {
+        temp.push(native::WGPUNativeFeature_ShaderDrawIndex);
+    }
+    if features.contains(wgt::Features::ACCELERATION_STRUCTURE_BINDING_ARRAY) {
+        temp.push(native::WGPUNativeFeature_AccelerationStructureBindingArray);
+    }
+    if features.contains(wgt::Features::MEMORY_DECORATION_COHERENT) {
+        temp.push(native::WGPUNativeFeature_MemoryDecorationCoherent);
+    }
+    if features.contains(wgt::Features::MEMORY_DECORATION_VOLATILE) {
+        temp.push(native::WGPUNativeFeature_MemoryDecorationVolatile);
     }
 
     temp
@@ -1347,18 +1441,18 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUFeatureName_DepthClipControl => Some(Features::DEPTH_CLIP_CONTROL),
         native::WGPUFeatureName_Depth32FloatStencil8 => Some(Features::DEPTH32FLOAT_STENCIL8),
         native::WGPUFeatureName_TextureCompressionBC => Some(Features::TEXTURE_COMPRESSION_BC),
-        // TODO: WGPUFeatureName_TextureCompressionBCSliced3D
+        native::WGPUFeatureName_TextureCompressionBCSliced3D => Some(Features::TEXTURE_COMPRESSION_BC_SLICED_3D),
         native::WGPUFeatureName_TextureCompressionETC2 => Some(Features::TEXTURE_COMPRESSION_ETC2),
         native::WGPUFeatureName_TextureCompressionASTC => Some(Features::TEXTURE_COMPRESSION_ASTC),
-        // TODO: WGPUFeatureName_TextureCompressionASTCSliced3D
+        native::WGPUFeatureName_TextureCompressionASTCSliced3D => Some(Features::TEXTURE_COMPRESSION_ASTC_SLICED_3D),
         native::WGPUFeatureName_TimestampQuery => Some(Features::TIMESTAMP_QUERY),
         native::WGPUFeatureName_IndirectFirstInstance => Some(Features::INDIRECT_FIRST_INSTANCE),
         native::WGPUFeatureName_ShaderF16 => Some(Features::SHADER_F16),
         native::WGPUFeatureName_RG11B10UfloatRenderable => Some(Features::RG11B10UFLOAT_RENDERABLE),
         native::WGPUFeatureName_BGRA8UnormStorage => Some(Features::BGRA8UNORM_STORAGE),
-        // TODO: WGPUFeatureName_ClipDistances
-        // TODO: WGPUFeatureName_Float32Blendable
         native::WGPUFeatureName_Float32Filterable => Some(Features::FLOAT32_FILTERABLE),
+        native::WGPUFeatureName_Float32Blendable => Some(Features::FLOAT32_BLENDABLE),
+        native::WGPUFeatureName_ClipDistances => Some(Features::CLIP_DISTANCES),
         native::WGPUFeatureName_DualSourceBlending => Some(Features::DUAL_SOURCE_BLENDING),
         native::WGPUFeatureName_PrimitiveIndex => Some(Features::PRIMITIVE_INDEX),
 
@@ -1374,29 +1468,60 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUNativeFeature_PartiallyBoundBindingArray => Some(Features::PARTIALLY_BOUND_BINDING_ARRAY),
         native::WGPUNativeFeature_TextureFormat16bitNorm => Some(Features::TEXTURE_FORMAT_16BIT_NORM),
         native::WGPUNativeFeature_TextureCompressionAstcHdr => Some(Features::TEXTURE_COMPRESSION_ASTC_HDR),
-        native::WGPUNativeFeature_TimestampQueryInsidePasses => Some(Features::TIMESTAMP_QUERY_INSIDE_PASSES),
-        native::WGPUNativeFeature_TimestampQueryInsideEncoders => Some(Features::TIMESTAMP_QUERY_INSIDE_ENCODERS),
         native::WGPUNativeFeature_MappablePrimaryBuffers => Some(Features::MAPPABLE_PRIMARY_BUFFERS),
         native::WGPUNativeFeature_BufferBindingArray => Some(Features::BUFFER_BINDING_ARRAY),
-        // TODO: fix this, UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING is not supported anymore https://github.com/gfx-rs/wgpu/issues/4407
-        // native::WGPUNativeFeature_UniformBufferAndStorageTextureArrayNonUniformIndexing => Some(Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING),
+        native::WGPUNativeFeature_StorageTextureArrayNonUniformIndexing => Some(Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING),
         // TODO: requires wgpu.h api change
         // native::WGPUNativeFeature_AddressModeClampToZero => Some(Features::ADDRESS_MODE_CLAMP_TO_ZERO),
         // native::WGPUNativeFeature_AddressModeClampToBorder => Some(Features::ADDRESS_MODE_CLAMP_TO_BORDER),
         native::WGPUNativeFeature_PolygonModeLine => Some(Features::POLYGON_MODE_LINE),
         native::WGPUNativeFeature_PolygonModePoint => Some(Features::POLYGON_MODE_POINT),
         native::WGPUNativeFeature_ConservativeRasterization => Some(Features::CONSERVATIVE_RASTERIZATION),
+        // TODO: requires wgpu.h api change
         // native::WGPUNativeFeature_ClearTexture => Some(Features::CLEAR_TEXTURE),
-        // native::WGPUNativeFeature_Multiview => Some(Features::MULTIVIEW),
+        native::WGPUNativeFeature_Multiview => Some(Features::MULTIVIEW),
         native::WGPUNativeFeature_VertexAttribute64bit => Some(Features::VERTEX_ATTRIBUTE_64BIT),
         native::WGPUNativeFeature_TextureFormatNv12 => Some(Features::TEXTURE_FORMAT_NV12),
         native::WGPUNativeFeature_RayQuery => Some(Features::EXPERIMENTAL_RAY_QUERY),
         native::WGPUNativeFeature_ShaderF64 => Some(Features::SHADER_F64),
-        native::WGPUNativeFeature_ShaderInt64 => Some(Features::SHADER_INT64),
+        native::WGPUNativeFeature_ShaderI16 => Some(Features::SHADER_I16),
         native::WGPUNativeFeature_ShaderEarlyDepthTest => Some(Features::SHADER_EARLY_DEPTH_TEST),
         native::WGPUNativeFeature_Subgroup => Some(Features::SUBGROUP),
         native::WGPUNativeFeature_SubgroupVertex => Some(Features::SUBGROUP_VERTEX),
         native::WGPUNativeFeature_SubgroupBarrier => Some(Features::SUBGROUP_BARRIER),
+        native::WGPUNativeFeature_TimestampQueryInsideEncoders => Some(Features::TIMESTAMP_QUERY_INSIDE_ENCODERS),
+        native::WGPUNativeFeature_TimestampQueryInsidePasses => Some(Features::TIMESTAMP_QUERY_INSIDE_PASSES),
+        native::WGPUNativeFeature_ShaderInt64 => Some(Features::SHADER_INT64),
+        native::WGPUNativeFeature_ShaderFloat32Atomic => Some(Features::SHADER_FLOAT32_ATOMIC),
+        native::WGPUNativeFeature_TextureAtomic => Some(Features::TEXTURE_ATOMIC),
+        native::WGPUNativeFeature_TextureFormatP010 => Some(Features::TEXTURE_FORMAT_P010),
+        // TODO: requires wgpu.h api change
+        // native::WGPUNativeFeature_ExternalTexture => Some(Features::EXTERNAL_TEXTURE),
+        native::WGPUNativeFeature_PipelineCache => Some(Features::PIPELINE_CACHE),
+        native::WGPUNativeFeature_ShaderInt64AtomicMinMax => Some(Features::SHADER_INT64_ATOMIC_MIN_MAX),
+        native::WGPUNativeFeature_ShaderInt64AtomicAllOps => Some(Features::SHADER_INT64_ATOMIC_ALL_OPS),
+        // TODO: requires wgpu.h api change
+        // native::WGPUNativeFeature_VulkanGoogleDisplayTiming => Some(Features::VULKAN_GOOGLE_DISPLAY_TIMING),
+        // native::WGPUNativeFeature_VulkanExternalMemoryWin32 => Some(Features::VULKAN_EXTERNAL_MEMORY_WIN32),
+        native::WGPUNativeFeature_TextureInt64Atomic => Some(Features::TEXTURE_INT64_ATOMIC),
+        // TODO: requires wgpu.h api change
+        // native::WGPUNativeFeature_UniformBufferBindingArrays => Some(Features::UNIFORM_BUFFER_BINDING_ARRAYS),
+        // native::WGPUNativeFeature_MeshShader => Some(Features::EXPERIMENTAL_MESH_SHADER),
+        // native::WGPUNativeFeature_RayHitVertexReturn => Some(Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN),
+        // native::WGPUNativeFeature_MeshShaderMultiview => Some(Features::EXPERIMENTAL_MESH_SHADER_MULTIVIEW),
+        // native::WGPUNativeFeature_ExtendedAccelerationStructureVertexFormats => Some(Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS),
+        // native::WGPUNativeFeature_PassthroughShaders => Some(Features::PASSTHROUGH_SHADERS),
+        native::WGPUNativeFeature_ShaderBarycentrics => Some(Features::SHADER_BARYCENTRICS),
+        native::WGPUNativeFeature_SelectiveMultiview => Some(Features::SELECTIVE_MULTIVIEW),
+        // TODO: requires wgpu.h api change
+        // native::WGPUNativeFeature_MeshShaderPoints => Some(Features::EXPERIMENTAL_MESH_SHADER_POINTS),
+        native::WGPUNativeFeature_MultisampleArray => Some(Features::MULTISAMPLE_ARRAY),
+        native::WGPUNativeFeature_CooperativeMatrix => Some(Features::EXPERIMENTAL_COOPERATIVE_MATRIX),
+        native::WGPUNativeFeature_ShaderPerVertex => Some(Features::SHADER_PER_VERTEX),
+        native::WGPUNativeFeature_ShaderDrawIndex => Some(Features::SHADER_DRAW_INDEX),
+        native::WGPUNativeFeature_AccelerationStructureBindingArray => Some(Features::ACCELERATION_STRUCTURE_BINDING_ARRAY),
+        native::WGPUNativeFeature_MemoryDecorationCoherent => Some(Features::MEMORY_DECORATION_COHERENT),
+        native::WGPUNativeFeature_MemoryDecorationVolatile => Some(Features::MEMORY_DECORATION_VOLATILE),
         // fallback, probably not available in wgpu-core
         _ => None,
     }

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1283,8 +1283,7 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::BUFFER_BINDING_ARRAY) {
         temp.push(native::WGPUNativeFeature_BufferBindingArray);
     }
-    if features.contains(wgt::Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING)
-    {
+    if features.contains(wgt::Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING) {
         temp.push(native::WGPUNativeFeature_StorageTextureArrayNonUniformIndexing);
     }
     // TODO: requires wgpu.h api change


### PR DESCRIPTION
I've inspected the [`FeaturesWGPU` in `gfx-rs/wgpu`](https://github.com/gfx-rs/wgpu/blob/10ce22b2ea0a01766b39d462cc3a1fd9495a43b1/wgpu-types/src/features.rs#L609) against the current `WGPUNativeFeatures` enum, and put them mostly in sync:
* Renamed `WGPUNativeFeature_UniformBufferAndStorageTextureArrayNonUniformIndexing` -> `WGPUNativeFeature_StorageTextureArrayNonUniformIndexing` (see https://github.com/gfx-rs/wgpu/issues/4407)
* Removed `WGPUNativeFeature_SpirvShaderPassthrough` (I added a new `WGPUNativeFeature_PassthroughShaders`, but it is commented out, as it requires API changes)
* Added or uncommented enum values corresponding to a bunch of missing native features exposed in `wgpu`

I've updated the conversion code in `conv.rs` (in both directions). In cases when actually using a feature would require implementing new API, I've kept the feature enum value and the conversion code commented out for future (this means that for the most part the added extensions are relevant only in shaders).

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality. @githubname`