### PR TITLE
Implement wgpuCommandEncoderClearTexture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 - `WGPUNativeLimits::maxBindingArraySamplerElementsPerShaderStage` @lisyarus
 - `WGPUNativeLimits::maxMultiviewViewCount` @lisyarus
 - `WGPUNativeFeature_StorageTextureArrayNonUniformIndexing`, `WGPUNativeFeature_Multiview`, `WGPUNativeFeature_ShaderFloat32Atomic`, `WGPUNativeFeature_TextureAtomic`, `WGPUNativeFeature_TextureFormatP010`, `WGPUNativeFeature_PipelineCache`, `WGPUNativeFeature_ShaderInt64AtomicMinMax`, `WGPUNativeFeature_ShaderInt64AtomicAllOps`, `WGPUNativeFeature_TextureInt64Atomic`, `WGPUNativeFeature_ShaderBarycentrics`, `WGPUNativeFeature_SelectiveMultiview`, `WGPUNativeFeature_MultisampleArray`, `WGPUNativeFeature_CooperativeMatrix`, `WGPUNativeFeature_ShaderPerVertex`, `WGPUNativeFeature_ShaderDrawIndex`, `WGPUNativeFeature_AccelerationStructureBindingArray`, `WGPUNativeFeature_MemoryDecorationCoherent`, `WGPUNativeFeature_MemoryDecorationVolatile` @lisyarus
+- `wgpuCommandEncoderClearTexture` @lisyarus
 
 ### Removed
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -379,8 +379,15 @@ typedef enum WGPUNativeFeature
      * This is a native only feature.
      */
     WGPUNativeFeature_ConservativeRasterization = 0x00030015,
-    // TODO: requires wgpu.h api change
-    // WGPUNativeFeature_ClearTexture = 0x00030016,
+    /**
+     * Enables clear to zero for textures.
+     *
+     * Supported platforms:
+     * - All
+     *
+     * This is a native only feature.
+     */
+    WGPUNativeFeature_ClearTexture = 0x00030016,
     /**
      * Enables multiview render passes and `builtin(view_index)` in vertex/mesh shaders.
      * 
@@ -1456,6 +1463,14 @@ typedef enum WGPUNativeTextureFormat
     WGPUNativeTextureFormat_P010 = 0x00030008,
 } WGPUNativeTextureFormat;
 
+typedef struct WGPUImageSubresourceRange {
+    WGPUTextureAspect aspect;
+    uint32_t baseMipLevel;
+    uint32_t mipLevelCount;
+    uint32_t baseArrayLayer;
+    uint32_t arrayLayerCount;
+} WGPUImageSubresourceRange WGPU_STRUCTURE_ATTRIBUTE;
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -1525,6 +1540,8 @@ extern "C"
     // Returns true if the capture was successfully started, or false if it failed to start or is not supported on the current platform.
     WGPUBool wgpuDeviceStartGraphicsDebuggerCapture(WGPUDevice device);
     void wgpuDeviceStopGraphicsDebuggerCapture(WGPUDevice device);
+
+    void wgpuCommandEncoderClearTexture(WGPUCommandEncoder commandEncoder, WGPUTexture texture, WGPUImageSubresourceRange const * range);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1302,10 +1302,9 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::CONSERVATIVE_RASTERIZATION) {
         temp.push(native::WGPUNativeFeature_ConservativeRasterization);
     }
-    // TODO: requires wgpu.h api change
-    // if features.contains(wgt::Features::CLEAR_TEXTURE) {
-    //     temp.push(native::WGPUNativeFeature_ClearTexture);
-    // }
+    if features.contains(wgt::Features::CLEAR_TEXTURE) {
+        temp.push(native::WGPUNativeFeature_ClearTexture);
+    }
     if features.contains(wgt::Features::MULTIVIEW) {
         temp.push(native::WGPUNativeFeature_Multiview);
     }
@@ -1477,7 +1476,7 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUNativeFeature_PolygonModePoint => Some(Features::POLYGON_MODE_POINT),
         native::WGPUNativeFeature_ConservativeRasterization => Some(Features::CONSERVATIVE_RASTERIZATION),
         // TODO: requires wgpu.h api change
-        // native::WGPUNativeFeature_ClearTexture => Some(Features::CLEAR_TEXTURE),
+        native::WGPUNativeFeature_ClearTexture => Some(Features::CLEAR_TEXTURE),
         native::WGPUNativeFeature_Multiview => Some(Features::MULTIVIEW),
         native::WGPUNativeFeature_VertexAttribute64bit => Some(Features::VERTEX_ATTRIBUTE_64BIT),
         native::WGPUNativeFeature_TextureFormatNv12 => Some(Features::TEXTURE_FORMAT_NV12),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1301,6 +1301,51 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearBuffer(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wgpuCommandEncoderClearTexture(
+    command_encoder: native::WGPUCommandEncoder,
+    texture: native::WGPUTexture,
+    range: Option<&native::WGPUImageSubresourceRange>,
+) {
+    let (command_encoder_id, context, error_sink) = {
+        let command_encoder = command_encoder.as_ref().expect("invalid command encoder");
+        (
+            command_encoder.id,
+            &command_encoder.context,
+            &command_encoder.error_sink,
+        )
+    };
+    let texture_id = texture.as_ref().expect("invalid texture").id;
+
+    let subresource_range = match range {
+        Some(range) => wgt::ImageSubresourceRange {
+            aspect: conv::map_texture_aspect(range.aspect)
+                .unwrap_or(wgt::TextureAspect::All),
+            base_mip_level: range.baseMipLevel,
+            mip_level_count: match range.mipLevelCount {
+                0 => panic!("invalid mipLevelCount"),
+                native::WGPU_MIP_LEVEL_COUNT_UNDEFINED => None,
+                _ => Some(range.mipLevelCount),
+            },
+            base_array_layer: range.baseArrayLayer,
+            array_layer_count: match range.arrayLayerCount {
+                0 => panic!("invalid arrayLayerCount"),
+                native::WGPU_ARRAY_LAYER_COUNT_UNDEFINED => None,
+                _ => Some(range.arrayLayerCount),
+            },
+        },
+        None => wgt::ImageSubresourceRange::default(),
+    };
+
+    if let Err(cause) = context.command_encoder_clear_texture(
+        command_encoder_id,
+        texture_id,
+        &subresource_range
+    ) {
+        handle_error(error_sink, cause, None, "wgpuCommandEncoderClearTexture");
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wgpuCommandEncoderCopyBufferToBuffer(
     command_encoder: native::WGPUCommandEncoder,
     source: native::WGPUBuffer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1318,8 +1318,7 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearTexture(
 
     let subresource_range = match range {
         Some(range) => wgt::ImageSubresourceRange {
-            aspect: conv::map_texture_aspect(range.aspect)
-                .unwrap_or(wgt::TextureAspect::All),
+            aspect: conv::map_texture_aspect(range.aspect).unwrap_or(wgt::TextureAspect::All),
             base_mip_level: range.baseMipLevel,
             mip_level_count: match range.mipLevelCount {
                 0 => panic!("invalid mipLevelCount"),
@@ -1336,11 +1335,9 @@ pub unsafe extern "C" fn wgpuCommandEncoderClearTexture(
         None => wgt::ImageSubresourceRange::default(),
     };
 
-    if let Err(cause) = context.command_encoder_clear_texture(
-        command_encoder_id,
-        texture_id,
-        &subresource_range
-    ) {
+    if let Err(cause) =
+        context.command_encoder_clear_texture(command_encoder_id, texture_id, &subresource_range)
+    {
         handle_error(error_sink, cause, None, "wgpuCommandEncoderClearTexture");
     }
 }


### PR DESCRIPTION
## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality. @githubname`

## Description

Implemented `wgpuCommandEncoderClearTexture`, and uncommented the `ClearTexture` feature.
I added a `WGPUImageSubresourceRange` struct to `wgpu.h` which mimicks the [same struct in wgpu](https://docs.rs/wgpu/latest/wgpu/struct.ImageSubresourceRange.html). I didn't find anything else that has the same/similar fields (e.g. `WGPUTexelCopyTextureInfo` and such don't cut it), so I added a new struct.