### PR TITLE
Implement ClampToBorder (fixes #521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 - `WGPUNativeFeature_StorageTextureArrayNonUniformIndexing`, `WGPUNativeFeature_Multiview`, `WGPUNativeFeature_ShaderFloat32Atomic`, `WGPUNativeFeature_TextureAtomic`, `WGPUNativeFeature_TextureFormatP010`, `WGPUNativeFeature_PipelineCache`, `WGPUNativeFeature_ShaderInt64AtomicMinMax`, `WGPUNativeFeature_ShaderInt64AtomicAllOps`, `WGPUNativeFeature_TextureInt64Atomic`, `WGPUNativeFeature_ShaderBarycentrics`, `WGPUNativeFeature_SelectiveMultiview`, `WGPUNativeFeature_MultisampleArray`, `WGPUNativeFeature_CooperativeMatrix`, `WGPUNativeFeature_ShaderPerVertex`, `WGPUNativeFeature_ShaderDrawIndex`, `WGPUNativeFeature_AccelerationStructureBindingArray`, `WGPUNativeFeature_MemoryDecorationCoherent`, `WGPUNativeFeature_MemoryDecorationVolatile` @lisyarus
 - `wgpuCommandEncoderClearTexture` @lisyarus
 - `wgpuDeviceCreateShaderModuleTrusted` @lisyarus
+- Sampler address modes ClampToBorder and ClampToZero supported: @lisyarus
+  - `WGPUNativeAddressMode_ClampToBorder` address mode
+  - `WGPUSamplerBorderColor` enum
+  - `WGPUSamplerDescriptorExtras` struct to be chained in `WGPUSamplerDescriptor`
 
 ### Removed
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -39,6 +39,8 @@ typedef enum WGPUNativeSType
     WGPUSType_SurfaceSourceSwapChainPanel = 0x0003000B,
     /** Identifies @ref WGPUPrimitiveStateExtras. */
     WGPUSType_PrimitiveStateExtras = 0x0003000C,
+    /** Identifies @ref WGPUSamplerDescriptorExtras. */
+    WGPUSType_SamplerDescriptorExtras = 0x0003000D,
     WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeSType;
 
@@ -335,9 +337,8 @@ typedef enum WGPUNativeFeature
      * This is a native only feature.
      */
     WGPUNativeFeature_StorageTextureArrayNonUniformIndexing = 0x00030010,
-    // TODO: requires wgpu.h api change
-    // WGPUNativeFeature_AddressModeClampToZero = 0x00030011,
-    // WGPUNativeFeature_AddressModeClampToBorder = 0x00030012,
+    WGPUNativeFeature_AddressModeClampToZero = 0x00030011,
+    WGPUNativeFeature_AddressModeClampToBorder = 0x00030012,
     /**
      * Allows the user to set @ref WGPUPolygonMode_Line in
      * @ref WGPUPrimitiveStateExtras::polygonMode.
@@ -1499,6 +1500,27 @@ static const WGPUShaderRuntimeChecks WGPUShaderRuntimeChecks_TaskShaderDispatchT
  * undefined behavior and arbitrary memory access.
  */
 static const WGPUShaderRuntimeChecks WGPUShaderRuntimeChecks_MeshShaderPrimitiveIndicesClamp = 0x0000000000000010;
+
+typedef enum WGPUNativeAddressMode
+{
+    WGPUNativeAddressMode_ClampToBorder = 0x00000004,
+    WGPUNativeAddressMode_Force32 = 0x7FFFFFFF
+} WGPUNativeAddressMode WGPU_ENUM_ATTRIBUTE;
+
+typedef enum WGPUSamplerBorderColor
+{
+    WGPUSamplerBorderColor_Undefined = 0x00000000,
+    WGPUSamplerBorderColor_TransparentBlack = 0x00000001,
+    WGPUSamplerBorderColor_OpaqueBlack = 0x00000002,
+    WGPUSamplerBorderColor_OpaqueWhite = 0x00000003,
+    WGPUSamplerBorderColor_Zero = 0x00000004,
+    WGPUSamplerBorderColor_Force32 = 0x7FFFFFFF
+} WGPUSamplerBorderColor;
+
+typedef struct WGPUSamplerDescriptorExtras {
+    WGPUChainedStruct chain;
+    WGPUSamplerBorderColor samplerBorderColor;
+} WGPUSamplerDescriptorExtras WGPU_STRUCTURE_ATTRIBUTE;
 
 #ifdef __cplusplus
 extern "C"

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -39,15 +39,6 @@ map_enum_with_undefined!(
     Store
 );
 map_enum_with_undefined!(
-    map_address_mode,
-    WGPUAddressMode,
-    wgt::AddressMode,
-    "Unknown address mode",
-    ClampToEdge,
-    Repeat,
-    MirrorRepeat
-);
-map_enum_with_undefined!(
     map_filter_mode,
     WGPUFilterMode,
     wgt::FilterMode,
@@ -249,6 +240,17 @@ map_enum_with_undefined!(
     ReadWrite
 );
 
+map_enum_with_undefined!(
+    map_sampler_border_color,
+    WGPUSamplerBorderColor,
+    wgt::SamplerBorderColor,
+    "Unknown sampler border color",
+    TransparentBlack,
+    OpaqueBlack,
+    OpaqueWhite,
+    Zero
+);
+
 // These are defined as UINT64_MAX in the header, but bindgen currently can't process that define.
 // See https://github.com/rust-lang/rust-bindgen/issues/2822
 pub const WGPU_WHOLE_SIZE: u64 = u64::MAX;
@@ -272,6 +274,18 @@ pub fn map_origin3d(native: &native::WGPUOrigin3D) -> wgt::Origin3d {
         x: native.x,
         y: native.y,
         z: native.z,
+    }
+}
+
+#[inline]
+pub fn map_address_mode(mode: native::WGPUAddressMode) -> Option<wgt::AddressMode> {
+    match mode {
+        native::WGPUAddressMode_Undefined => None,
+        native::WGPUAddressMode_ClampToEdge => Some(wgt::AddressMode::ClampToEdge),
+        native::WGPUAddressMode_Repeat => Some(wgt::AddressMode::Repeat),
+        native::WGPUAddressMode_MirrorRepeat => Some(wgt::AddressMode::MirrorRepeat),
+        native::WGPUNativeAddressMode_ClampToBorder => Some(wgt::AddressMode::ClampToBorder),
+        _ => panic!("Unknown address mode"),
     }
 }
 
@@ -1286,13 +1300,12 @@ pub fn features_to_native(features: wgt::Features) -> Vec<native::WGPUFeatureNam
     if features.contains(wgt::Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING) {
         temp.push(native::WGPUNativeFeature_StorageTextureArrayNonUniformIndexing);
     }
-    // TODO: requires wgpu.h api change
-    // if features.contains(wgt::Features::ADDRESS_MODE_CLAMP_TO_ZERO) {
-    //     temp.push(native::WGPUNativeFeature_AddressModeClampToZero);
-    // }
-    // if features.contains(wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER) {
-    //     temp.push(native::WGPUNativeFeature_AddressModeClampToBorder);
-    // }
+    if features.contains(wgt::Features::ADDRESS_MODE_CLAMP_TO_ZERO) {
+        temp.push(native::WGPUNativeFeature_AddressModeClampToZero);
+    }
+    if features.contains(wgt::Features::ADDRESS_MODE_CLAMP_TO_BORDER) {
+        temp.push(native::WGPUNativeFeature_AddressModeClampToBorder);
+    }
     if features.contains(wgt::Features::POLYGON_MODE_LINE) {
         temp.push(native::WGPUNativeFeature_PolygonModeLine);
     }
@@ -1469,9 +1482,8 @@ pub fn map_feature(feature: native::WGPUFeatureName) -> Option<wgt::Features> {
         native::WGPUNativeFeature_MappablePrimaryBuffers => Some(Features::MAPPABLE_PRIMARY_BUFFERS),
         native::WGPUNativeFeature_BufferBindingArray => Some(Features::BUFFER_BINDING_ARRAY),
         native::WGPUNativeFeature_StorageTextureArrayNonUniformIndexing => Some(Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING),
-        // TODO: requires wgpu.h api change
-        // native::WGPUNativeFeature_AddressModeClampToZero => Some(Features::ADDRESS_MODE_CLAMP_TO_ZERO),
-        // native::WGPUNativeFeature_AddressModeClampToBorder => Some(Features::ADDRESS_MODE_CLAMP_TO_BORDER),
+        native::WGPUNativeFeature_AddressModeClampToZero => Some(Features::ADDRESS_MODE_CLAMP_TO_ZERO),
+        native::WGPUNativeFeature_AddressModeClampToBorder => Some(Features::ADDRESS_MODE_CLAMP_TO_BORDER),
         native::WGPUNativeFeature_PolygonModeLine => Some(Features::POLYGON_MODE_LINE),
         native::WGPUNativeFeature_PolygonModePoint => Some(Features::POLYGON_MODE_POINT),
         native::WGPUNativeFeature_ConservativeRasterization => Some(Features::CONSERVATIVE_RASTERIZATION),
@@ -2032,6 +2044,16 @@ pub fn map_shader_runtime_checks(
         mesh_shader_primitive_indices_clamp: (value
             & native::WGPUShaderRuntimeChecks_MeshShaderPrimitiveIndicesClamp)
             != 0,
+    }
+}
+
+pub fn map_sampler_border_color_extras(
+    _descriptor: native::WGPUSamplerDescriptor,
+    extras: Option<&native::WGPUSamplerDescriptorExtras>,
+) -> Option<wgt::SamplerBorderColor> {
+    match extras {
+        Some(extras) => map_sampler_border_color(extras.samplerBorderColor),
+        None => None,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@ use conv::{
     from_u64_bits, map_adapter_type, map_backend_type, map_bind_group_entry,
     map_bind_group_layout_entry, map_device_descriptor, map_instance_backend_flags,
     map_instance_descriptor, map_pipeline_layout_descriptor, map_query_set_descriptor,
-    map_query_set_index, map_shader_module, map_shader_runtime_checks, map_surface,
-    map_surface_configuration, CreateSurfaceParams,
+    map_query_set_index, map_sampler_border_color_extras, map_shader_module,
+    map_shader_runtime_checks, map_surface, map_surface_configuration, CreateSurfaceParams,
 };
 use parking_lot::Mutex;
 use smallvec::SmallVec;
@@ -2418,8 +2418,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateSampler(
             compare: conv::map_compare_function(descriptor.compare)
                 .expect("Invalid compare function"),
             anisotropy_clamp: descriptor.maxAnisotropy,
-            // TODO(wgpu.h)
-            border_color: None,
+            border_color: follow_chain!(map_sampler_border_color_extras((*descriptor), WGPUSType_SamplerDescriptorExtras => native::WGPUSamplerDescriptorExtras)),
         },
         // wgpu-core doesn't have Default implementation for SamplerDescriptor,
         // use defaults from spec.


### PR DESCRIPTION
## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality. @githubname`

## Description

Uncommencted the `ClampToBorder` and `ClampToZero` features. Since these aren't present in `webgpu.h`, I had to add a few things to `wgpu.h` API:

* Add `WGPUNativeAddressMode` enum with `WGPUNativeAddressMode_ClampToBorder` value, which is supposed to be used in places where `WGPUAddressMode` is expected
* Add `WGPUSamplerBorderColor` enum that mimicks the [corresponding wgpu enum](https://wgpu.rs/doc/wgpu_types/texture/enum.SamplerBorderColor.html)
* Add `WGPUSamplerDescriptorExtras` struct to be chained in `WGPUSamplerDescriptor`, which provides the `WGPUSamplerBorderColor` value.

I had to rewrite the `map_address_mode` function in `conv.rs`: preciously it was generated using the `map_enum_with_undefined` macro, but since now it mixes values from two native enums, I had to rewrite it by hand.

Currently, if `WGPUNativeAddressMode_ClampToBorder` is used but the `WGPUSamplerDescriptorExtras` isn't provided, it sets the `borderColor` in [`SamplerDescriptor`](https://docs.rs/wgpu/latest/wgpu/type.SamplerDescriptor.html) to `None`, and the wgpu itself is supposed to handle this case. We could alternatively check that explicitly in `wgpuDeviceCreateSampler`, I'm not sure what the correct thing to do would be here.

## Related Issues

This PR fixes #521