### PR TITLE
Implement wgpuDeviceCreateShaderModuleTrusted (fixes #396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 - `WGPUNativeLimits::maxMultiviewViewCount` @lisyarus
 - `WGPUNativeFeature_StorageTextureArrayNonUniformIndexing`, `WGPUNativeFeature_Multiview`, `WGPUNativeFeature_ShaderFloat32Atomic`, `WGPUNativeFeature_TextureAtomic`, `WGPUNativeFeature_TextureFormatP010`, `WGPUNativeFeature_PipelineCache`, `WGPUNativeFeature_ShaderInt64AtomicMinMax`, `WGPUNativeFeature_ShaderInt64AtomicAllOps`, `WGPUNativeFeature_TextureInt64Atomic`, `WGPUNativeFeature_ShaderBarycentrics`, `WGPUNativeFeature_SelectiveMultiview`, `WGPUNativeFeature_MultisampleArray`, `WGPUNativeFeature_CooperativeMatrix`, `WGPUNativeFeature_ShaderPerVertex`, `WGPUNativeFeature_ShaderDrawIndex`, `WGPUNativeFeature_AccelerationStructureBindingArray`, `WGPUNativeFeature_MemoryDecorationCoherent`, `WGPUNativeFeature_MemoryDecorationVolatile` @lisyarus
 - `wgpuCommandEncoderClearTexture` @lisyarus
+- `wgpuDeviceCreateShaderModuleTrusted` @lisyarus
 
 ### Removed
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1474,32 +1474,31 @@ typedef struct WGPUImageSubresourceRange {
 /**
  * Describes how shader bound checks should be performed.
  */
-typedef WGPUFlags WGPUNativeShaderRuntimeChecks;
+typedef WGPUFlags WGPUShaderRuntimeChecks;
 
-static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_None = 0x0000000000000000;
+static const WGPUShaderRuntimeChecks WGPUShaderRuntimeChecks_None = 0x0000000000000000;
 /**
  * Enforce bounds checks in shaders, even if the underlying driver doesn’t support doing so natively.
  */
-static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_BoundsChecks = 0x0000000000000001;
+static const WGPUShaderRuntimeChecks WGPUShaderRuntimeChecks_BoundsChecks = 0x0000000000000001;
 /**
  * If not set, the caller MUST ensure that all passed shaders do not contain any infinite loops.
  */
-static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_ForceLoopBounding = 0x0000000000000002;
+static const WGPUShaderRuntimeChecks WGPUShaderRuntimeChecks_ForceLoopBounding = 0x0000000000000002;
 /**
  * If not set, the caller MUST ensure that in all passed shaders every function operating on a ray
  * query must obey these rules (functions using wgsl naming).
  */
-static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_RayQueryInitializationTracking = 0x0000000000000004;
+static const WGPUShaderRuntimeChecks WGPUShaderRuntimeChecks_RayQueryInitializationTracking = 0x0000000000000004;
 /**
  * If not set, task shaders will not validate that the mesh shader grid they dispatch is within legal limits.
  */
-static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_TaskShaderDispatchTracking = 0x0000000000000008;
+static const WGPUShaderRuntimeChecks WGPUShaderRuntimeChecks_TaskShaderDispatchTracking = 0x0000000000000008;
 /**
  * If not set, mesh shaders won’t clamp the output primitives’ vertex indices, which can lead to
  * undefined behavior and arbitrary memory access.
  */
-static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_MeshShaderPrimitiveIndicesClamp = 0x0000000000000010;
->>>>>>> b26b8f3 (Implement wgpuDeviceCreateShaderModuleTrusted (fixes #396))
+static const WGPUShaderRuntimeChecks WGPUShaderRuntimeChecks_MeshShaderPrimitiveIndicesClamp = 0x0000000000000010;
 
 #ifdef __cplusplus
 extern "C"
@@ -1573,7 +1572,7 @@ extern "C"
 
     void wgpuCommandEncoderClearTexture(WGPUCommandEncoder commandEncoder, WGPUTexture texture, WGPUImageSubresourceRange const * range);
 
-    WGPUShaderModule wgpuDeviceCreateShaderModuleTrusted(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor, WGPUNativeShaderRuntimeChecks runtimeChecks);
+    WGPUShaderModule wgpuDeviceCreateShaderModuleTrusted(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor, WGPUShaderRuntimeChecks runtimeChecks);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1471,6 +1471,36 @@ typedef struct WGPUImageSubresourceRange {
     uint32_t arrayLayerCount;
 } WGPUImageSubresourceRange WGPU_STRUCTURE_ATTRIBUTE;
 
+/**
+ * Describes how shader bound checks should be performed.
+ */
+typedef WGPUFlags WGPUNativeShaderRuntimeChecks;
+
+static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_None = 0x0000000000000000;
+/**
+ * Enforce bounds checks in shaders, even if the underlying driver doesn’t support doing so natively.
+ */
+static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_BoundsChecks = 0x0000000000000001;
+/**
+ * If not set, the caller MUST ensure that all passed shaders do not contain any infinite loops.
+ */
+static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_ForceLoopBounding = 0x0000000000000002;
+/**
+ * If not set, the caller MUST ensure that in all passed shaders every function operating on a ray
+ * query must obey these rules (functions using wgsl naming).
+ */
+static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_RayQueryInitializationTracking = 0x0000000000000004;
+/**
+ * If not set, task shaders will not validate that the mesh shader grid they dispatch is within legal limits.
+ */
+static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_TaskShaderDispatchTracking = 0x0000000000000008;
+/**
+ * If not set, mesh shaders won’t clamp the output primitives’ vertex indices, which can lead to
+ * undefined behavior and arbitrary memory access.
+ */
+static const WGPUBufferUsage WGPUNativeShaderRuntimeChecks_MeshShaderPrimitiveIndicesClamp = 0x0000000000000010;
+>>>>>>> b26b8f3 (Implement wgpuDeviceCreateShaderModuleTrusted (fixes #396))
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -1542,6 +1572,8 @@ extern "C"
     void wgpuDeviceStopGraphicsDebuggerCapture(WGPUDevice device);
 
     void wgpuCommandEncoderClearTexture(WGPUCommandEncoder commandEncoder, WGPUTexture texture, WGPUImageSubresourceRange const * range);
+
+    WGPUShaderModule wgpuDeviceCreateShaderModuleTrusted(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor, WGPUNativeShaderRuntimeChecks runtimeChecks);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -2018,7 +2018,7 @@ pub fn map_primitive_state(
 }
 
 pub fn map_shader_runtime_checks(
-    value: native::WGPUNativeShaderRuntimeChecks
+    value: native::WGPUNativeShaderRuntimeChecks,
 ) -> wgt::ShaderRuntimeChecks {
     wgt::ShaderRuntimeChecks {
         bounds_checks: (value & native::WGPUNativeShaderRuntimeChecks_BoundsChecks) != 0,

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -2017,6 +2017,16 @@ pub fn map_primitive_state(
     }
 }
 
+pub fn map_shader_runtime_checks(value: native::WGPUNativeShaderRuntimeChecks) -> wgt::ShaderRuntimeChecks {
+    wgt::ShaderRuntimeChecks {
+        bounds_checks: (value & native::WGPUNativeShaderRuntimeChecks_BoundsChecks) != 0,
+        force_loop_bounding: (value & native::WGPUNativeShaderRuntimeChecks_ForceLoopBounding) != 0,
+        ray_query_initialization_tracking: (value & native::WGPUNativeShaderRuntimeChecks_RayQueryInitializationTracking) != 0,
+        task_shader_dispatch_tracking: (value & native::WGPUNativeShaderRuntimeChecks_TaskShaderDispatchTracking) != 0,
+        mesh_shader_primitive_indices_clamp: (value & native::WGPUNativeShaderRuntimeChecks_MeshShaderPrimitiveIndicesClamp) != 0,
+    }
+}
+
 pub fn from_u64_bits<T: bitflags::Flags<Bits = u32>>(value: u64) -> Option<T> {
     if value > u32::MAX.into() {
         return None;

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -2018,19 +2018,19 @@ pub fn map_primitive_state(
 }
 
 pub fn map_shader_runtime_checks(
-    value: native::WGPUNativeShaderRuntimeChecks,
+    value: native::WGPUShaderRuntimeChecks,
 ) -> wgt::ShaderRuntimeChecks {
     wgt::ShaderRuntimeChecks {
-        bounds_checks: (value & native::WGPUNativeShaderRuntimeChecks_BoundsChecks) != 0,
-        force_loop_bounding: (value & native::WGPUNativeShaderRuntimeChecks_ForceLoopBounding) != 0,
+        bounds_checks: (value & native::WGPUShaderRuntimeChecks_BoundsChecks) != 0,
+        force_loop_bounding: (value & native::WGPUShaderRuntimeChecks_ForceLoopBounding) != 0,
         ray_query_initialization_tracking: (value
-            & native::WGPUNativeShaderRuntimeChecks_RayQueryInitializationTracking)
+            & native::WGPUShaderRuntimeChecks_RayQueryInitializationTracking)
             != 0,
         task_shader_dispatch_tracking: (value
-            & native::WGPUNativeShaderRuntimeChecks_TaskShaderDispatchTracking)
+            & native::WGPUShaderRuntimeChecks_TaskShaderDispatchTracking)
             != 0,
         mesh_shader_primitive_indices_clamp: (value
-            & native::WGPUNativeShaderRuntimeChecks_MeshShaderPrimitiveIndicesClamp)
+            & native::WGPUShaderRuntimeChecks_MeshShaderPrimitiveIndicesClamp)
             != 0,
     }
 }

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -2017,13 +2017,21 @@ pub fn map_primitive_state(
     }
 }
 
-pub fn map_shader_runtime_checks(value: native::WGPUNativeShaderRuntimeChecks) -> wgt::ShaderRuntimeChecks {
+pub fn map_shader_runtime_checks(
+    value: native::WGPUNativeShaderRuntimeChecks
+) -> wgt::ShaderRuntimeChecks {
     wgt::ShaderRuntimeChecks {
         bounds_checks: (value & native::WGPUNativeShaderRuntimeChecks_BoundsChecks) != 0,
         force_loop_bounding: (value & native::WGPUNativeShaderRuntimeChecks_ForceLoopBounding) != 0,
-        ray_query_initialization_tracking: (value & native::WGPUNativeShaderRuntimeChecks_RayQueryInitializationTracking) != 0,
-        task_shader_dispatch_tracking: (value & native::WGPUNativeShaderRuntimeChecks_TaskShaderDispatchTracking) != 0,
-        mesh_shader_primitive_indices_clamp: (value & native::WGPUNativeShaderRuntimeChecks_MeshShaderPrimitiveIndicesClamp) != 0,
+        ray_query_initialization_tracking: (value
+            & native::WGPUNativeShaderRuntimeChecks_RayQueryInitializationTracking)
+            != 0,
+        task_shader_dispatch_tracking: (value
+            & native::WGPUNativeShaderRuntimeChecks_TaskShaderDispatchTracking)
+            != 0,
+        mesh_shader_primitive_indices_clamp: (value
+            & native::WGPUNativeShaderRuntimeChecks_MeshShaderPrimitiveIndicesClamp)
+            != 0,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2518,7 +2518,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModule(
 pub unsafe extern "C" fn wgpuDeviceCreateShaderModuleTrusted(
     device: native::WGPUDevice,
     descriptor: Option<&native::WGPUShaderModuleDescriptor>,
-    runtime_checks: native::WGPUNativeShaderRuntimeChecks,
+    runtime_checks: native::WGPUShaderRuntimeChecks,
 ) -> native::WGPUShaderModule {
     create_shader_module_impl(
         device,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use conv::{
     map_bind_group_layout_entry, map_device_descriptor, map_instance_backend_flags,
     map_instance_descriptor, map_pipeline_layout_descriptor, map_query_set_descriptor,
     map_query_set_index, map_shader_module, map_surface, map_surface_configuration,
-    CreateSurfaceParams,
+    map_shader_runtime_checks, CreateSurfaceParams,
 };
 use parking_lot::Mutex;
 use smallvec::SmallVec;
@@ -2453,10 +2453,10 @@ pub unsafe extern "C" fn wgpuDeviceCreateSampler(
     }))
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn wgpuDeviceCreateShaderModule(
+unsafe fn create_shader_module_impl(
     device: native::WGPUDevice,
     descriptor: Option<&native::WGPUShaderModuleDescriptor>,
+    runtime_checks: wgt::ShaderRuntimeChecks
 ) -> native::WGPUShaderModule {
     let (device_id, context, error_sink) = {
         let device = device.as_ref().expect("invalid device");
@@ -2490,7 +2490,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModule(
 
     let desc = wgc::pipeline::ShaderModuleDescriptor {
         label: desc_label,
-        runtime_checks: wgt::ShaderRuntimeChecks::default(),
+        runtime_checks,
     };
 
     let (shader_module_id, error) =
@@ -2508,6 +2508,23 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModule(
         context: context.clone(),
         id: Some(shader_module_id),
     }))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuDeviceCreateShaderModule(
+    device: native::WGPUDevice,
+    descriptor: Option<&native::WGPUShaderModuleDescriptor>,
+) -> native::WGPUShaderModule {
+    create_shader_module_impl(device, descriptor, wgt::ShaderRuntimeChecks::default())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wgpuDeviceCreateShaderModuleTrusted(
+    device: native::WGPUDevice,
+    descriptor: Option<&native::WGPUShaderModuleDescriptor>,
+    runtime_checks: native::WGPUNativeShaderRuntimeChecks,
+) -> native::WGPUShaderModule {
+    create_shader_module_impl(device, descriptor, map_shader_runtime_checks(runtime_checks))
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@ use conv::{
     from_u64_bits, map_adapter_type, map_backend_type, map_bind_group_entry,
     map_bind_group_layout_entry, map_device_descriptor, map_instance_backend_flags,
     map_instance_descriptor, map_pipeline_layout_descriptor, map_query_set_descriptor,
-    map_query_set_index, map_shader_module, map_surface, map_surface_configuration,
-    map_shader_runtime_checks, CreateSurfaceParams,
+    map_query_set_index, map_shader_module, map_shader_runtime_checks, map_surface,
+    map_surface_configuration, CreateSurfaceParams,
 };
 use parking_lot::Mutex;
 use smallvec::SmallVec;
@@ -2456,7 +2456,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateSampler(
 unsafe fn create_shader_module_impl(
     device: native::WGPUDevice,
     descriptor: Option<&native::WGPUShaderModuleDescriptor>,
-    runtime_checks: wgt::ShaderRuntimeChecks
+    runtime_checks: wgt::ShaderRuntimeChecks,
 ) -> native::WGPUShaderModule {
     let (device_id, context, error_sink) = {
         let device = device.as_ref().expect("invalid device");
@@ -2524,7 +2524,11 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModuleTrusted(
     descriptor: Option<&native::WGPUShaderModuleDescriptor>,
     runtime_checks: native::WGPUNativeShaderRuntimeChecks,
 ) -> native::WGPUShaderModule {
-    create_shader_module_impl(device, descriptor, map_shader_runtime_checks(runtime_checks))
+    create_shader_module_impl(
+        device,
+        descriptor,
+        map_shader_runtime_checks(runtime_checks),
+    )
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2458,7 +2458,6 @@ unsafe fn create_shader_module_impl(
     descriptor: Option<&native::WGPUShaderModuleDescriptor>,
     runtime_checks: wgt::ShaderRuntimeChecks,
     fn_ident: &'static str,
-
 ) -> native::WGPUShaderModule {
     let (device_id, context, error_sink) = {
         let device = device.as_ref().expect("invalid device");
@@ -2476,12 +2475,7 @@ unsafe fn create_shader_module_impl(
     ) {
         Ok(source) => source,
         Err(cause) => {
-            handle_error(
-                error_sink,
-                cause,
-                desc_label,
-                fn_ident,
-            );
+            handle_error(error_sink, cause, desc_label, fn_ident);
 
             return Arc::into_raw(Arc::new(WGPUShaderModuleImpl {
                 context: context.clone(),
@@ -2498,12 +2492,7 @@ unsafe fn create_shader_module_impl(
     let (shader_module_id, error) =
         context.device_create_shader_module(device_id, &desc, source, None);
     if let Some(cause) = error {
-        handle_error(
-            error_sink,
-            cause,
-            desc.label,
-            fn_ident,
-        );
+        handle_error(error_sink, cause, desc.label, fn_ident);
     }
 
     Arc::into_raw(Arc::new(WGPUShaderModuleImpl {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2457,6 +2457,8 @@ unsafe fn create_shader_module_impl(
     device: native::WGPUDevice,
     descriptor: Option<&native::WGPUShaderModuleDescriptor>,
     runtime_checks: wgt::ShaderRuntimeChecks,
+    fn_ident: &'static str,
+
 ) -> native::WGPUShaderModule {
     let (device_id, context, error_sink) = {
         let device = device.as_ref().expect("invalid device");
@@ -2478,7 +2480,7 @@ unsafe fn create_shader_module_impl(
                 error_sink,
                 cause,
                 desc_label,
-                "wgpuDeviceCreateShaderModule",
+                fn_ident,
             );
 
             return Arc::into_raw(Arc::new(WGPUShaderModuleImpl {
@@ -2500,7 +2502,7 @@ unsafe fn create_shader_module_impl(
             error_sink,
             cause,
             desc.label,
-            "wgpuDeviceCreateShaderModule",
+            fn_ident,
         );
     }
 
@@ -2515,7 +2517,12 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModule(
     device: native::WGPUDevice,
     descriptor: Option<&native::WGPUShaderModuleDescriptor>,
 ) -> native::WGPUShaderModule {
-    create_shader_module_impl(device, descriptor, wgt::ShaderRuntimeChecks::default())
+    create_shader_module_impl(
+        device,
+        descriptor,
+        wgt::ShaderRuntimeChecks::default(),
+        "wgpuDeviceCreateShaderModule",
+    )
 }
 
 #[no_mangle]
@@ -2528,6 +2535,7 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModuleTrusted(
         device,
         descriptor,
         map_shader_runtime_checks(runtime_checks),
+        "wgpuDeviceCreateShaderModuleTrusted",
     )
 }
 


### PR DESCRIPTION
## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality. @githubname`

## Description

Implemented `wgpuDeviceCreateShaderModuleTrusted`. It only differs from `wgpuDeviceCreateShaderModule` by a single `runtimeChecks` parameter, which takes the values of a new bit flag `WGPUShaderRuntimeChecks`. It isn't specified as a bitfield in wgpu, but it is a [struct containing just bools](https://docs.rs/wgpu/latest/wgpu/struct.ShaderRuntimeChecks.html), so I figured a bitmask on the native side is appropriate.

In the implementation, the two methods only differ in a single line, so I extracted a private `create_shader_module` function that both methods forward to.

## Related Issues

This PR fixes #396