### PR TITLE
Even easier Immediates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 #### Table of Contents
 
 - [Unreleased](#unreleased)
+- [v29.0.0.0](#v290000)
 - [Diffs](#diffs)
 
+
 ## Unreleased
+
+### Changed
+- Immediates no longer uses `WGPUPipelineLayoutExtras` chain, the `WGPUPipelineLayoutDescriptor` takes `uint32_t immediateSize` directily. @Vipitis
+
+
+## [v29.0.0.0](https://github.com/gfx-rs/wgpu-native/releases/tag/v29.0.0.0)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,13 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 #### Table of Contents
 
 - [Unreleased](#unreleased)
-- [v29.0.0.0](#v290000)
 - [Diffs](#diffs)
-
 
 ## Unreleased
 
-### Changed
-- Immediates no longer uses `WGPUPipelineLayoutExtras` chain, the `WGPUPipelineLayoutDescriptor` takes `uint32_t immediateSize` directily. @Vipitis
-
-
-## [v29.0.0.0](https://github.com/gfx-rs/wgpu-native/releases/tag/v29.0.0.0)
 
 ### Changed
-
+- Immediates no longer uses `WGPUPipelineLayoutExtras` chain, the `WGPUPipelineLayoutDescriptor` takes `uint32_t immediateSize` directily. By @Vipitis in [#583](https://github.com/gfx-rs/wgpu-native/pull/583).
 - Updated all wgpu crates to v29
 - MSRV bumped from 1.82 to 1.87.
 - **Push constants renamed to immediates.** This matches the upstream wgpu rename.

--- a/examples/immediates/main.c
+++ b/examples/immediates/main.c
@@ -100,14 +100,6 @@ int main(int argc, char *argv[]) {
               });
   assert(staging_buffer);
 
-  WGPUPipelineLayoutExtras pipeline_layout_extras = {
-      .chain =
-          {
-              .sType = WGPUSType_PipelineLayoutExtras,
-          },
-      .immediateDataSize = sizeof(uint32_t),
-  };
-
   WGPUBindGroupLayoutEntry bind_group_layout_entries[] = {
       {
           .binding = 0,
@@ -130,9 +122,10 @@ int main(int argc, char *argv[]) {
 
   WGPUPipelineLayoutDescriptor pipeline_layout_desc = {
       .label = {"pipeline_layout", WGPU_STRLEN},
-      .nextInChain = &pipeline_layout_extras.chain,
+      .nextInChain = NULL,
       .bindGroupLayouts = &bind_group_layout,
       .bindGroupLayoutCount = 1,
+      .immediateSize = sizeof(uint32_t),
   };
   WGPUPipelineLayout pipeline_layout =
       wgpuDeviceCreatePipelineLayout(device, &pipeline_layout_desc);

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -22,23 +22,23 @@ typedef enum WGPUNativeSType
     /** Identifies @ref WGPUNativeLimits. */
     WGPUSType_NativeLimits = 0x00030002,
     /** Identifies @ref WGPUShaderSourceGLSL. */
-    WGPUSType_ShaderSourceGLSL = 0x00030004,
+    WGPUSType_ShaderSourceGLSL = 0x00030003,
     /** Identifies @ref WGPUInstanceExtras. */
-    WGPUSType_InstanceExtras = 0x00030006,
+    WGPUSType_InstanceExtras = 0x00030004,
     /** Identifies @ref WGPUBindGroupEntryExtras. */
-    WGPUSType_BindGroupEntryExtras = 0x00030007,
+    WGPUSType_BindGroupEntryExtras = 0x00030005,
     /** Identifies @ref WGPUBindGroupLayoutEntryExtras. */
-    WGPUSType_BindGroupLayoutEntryExtras = 0x00030008,
+    WGPUSType_BindGroupLayoutEntryExtras = 0x00030006,
     /** Identifies @ref WGPUQuerySetDescriptorExtras. */
-    WGPUSType_QuerySetDescriptorExtras = 0x00030009,
+    WGPUSType_QuerySetDescriptorExtras = 0x00030007,
     /** Identifies @ref WGPUSurfaceConfigurationExtras. */
-    WGPUSType_SurfaceConfigurationExtras = 0x0003000A,
+    WGPUSType_SurfaceConfigurationExtras = 0x00030008,
     /** Identifies @ref WGPUSurfaceSourceSwapChainPanel. */
-    WGPUSType_SurfaceSourceSwapChainPanel = 0x0003000B,
+    WGPUSType_SurfaceSourceSwapChainPanel = 0x00030009,
     /** Identifies @ref WGPUPrimitiveStateExtras. */
-    WGPUSType_PrimitiveStateExtras = 0x0003000C,
+    WGPUSType_PrimitiveStateExtras = 0x0003000A,
     /** Identifies @ref WGPUSamplerDescriptorExtras. */
-    WGPUSType_SamplerDescriptorExtras = 0x0003000D,
+    WGPUSType_SamplerDescriptorExtras = 0x0003000B,
     WGPUNativeSType_Force32 = 0x7FFFFFFF
 } WGPUNativeSType;
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -21,8 +21,6 @@ typedef enum WGPUNativeSType
     WGPUSType_DeviceExtras = 0x00030001,
     /** Identifies @ref WGPUNativeLimits. */
     WGPUSType_NativeLimits = 0x00030002,
-    /** Identifies @ref WGPUPipelineLayoutExtras. */
-    WGPUSType_PipelineLayoutExtras = 0x00030003,
     /** Identifies @ref WGPUShaderSourceGLSL. */
     WGPUSType_ShaderSourceGLSL = 0x00030004,
     /** Identifies @ref WGPUInstanceExtras. */
@@ -98,8 +96,8 @@ typedef enum WGPUNativeFeature
      * Enables @ref wgpuRenderPassEncoderSetImmediates,
      * @ref wgpuComputePassEncoderSetImmediates,
      * @ref wgpuRenderBundleEncoderSetImmediates,
-     * non-zero @c immediateDataSize in @ref WGPUPipelineLayoutExtras,
-     * and non-zero @c maxImmediateSize in @ref WGPUNativeLimits.
+     * non-zero @c immediateSize in @ref WGPUPipelineLayout,
+     * and non-zero @c maxImmediateSize in @ref WGPULimits.
      *
      * A block of immediate data can be declared in WGSL with
      * @c var<immediate>:
@@ -1231,20 +1229,6 @@ typedef struct WGPUNativeLimits
     /*.maxBindingArraySamplerElementsPerShaderStage=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
     /*.maxMultiviewViewCount=*/WGPU_LIMIT_U32_UNDEFINED _wgpu_COMMA \
 })
-
-typedef struct WGPUPipelineLayoutExtras
-{
-    WGPUChainedStruct chain;
-    /**
-     * The number of bytes of immediate data allocated for use in shaders
-     * attached to this pipeline.
-     *
-     * The @c var<immediate> declarations in the shader must be equal or
-     * smaller than this size. If this value is non-zero,
-     * @ref WGPUNativeFeature_Immediates must be enabled.
-     */
-    uint32_t immediateDataSize;
-} WGPUPipelineLayoutExtras;
 
 /**
  * Identifier for a particular call to @ref wgpuQueueSubmitForIndex.

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -509,7 +509,6 @@ pub(crate) unsafe fn map_device_descriptor<'a>(
 #[inline]
 pub unsafe fn map_pipeline_layout_descriptor<'a>(
     des: &native::WGPUPipelineLayoutDescriptor,
-    extras: Option<&native::WGPUPipelineLayoutExtras>,
 ) -> wgc::binding_model::PipelineLayoutDescriptor<'a> {
     let bind_group_layouts = make_slice(des.bindGroupLayouts, des.bindGroupLayoutCount)
         .iter()
@@ -523,7 +522,7 @@ pub unsafe fn map_pipeline_layout_descriptor<'a>(
         })
         .collect::<Vec<_>>();
 
-    let immediate_size = extras.map_or(0, |extras| extras.immediateDataSize);
+    let immediate_size = des.immediateSize;
 
     wgc::binding_model::PipelineLayoutDescriptor {
         label: string_view_into_label(des.label),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2113,11 +2113,7 @@ pub unsafe extern "C" fn wgpuDeviceCreatePipelineLayout(
     };
     let descriptor = descriptor.expect("invalid descriptor");
 
-    let desc = follow_chain!(
-        map_pipeline_layout_descriptor(
-            (descriptor),
-            WGPUSType_PipelineLayoutExtras => native::WGPUPipelineLayoutExtras)
-    );
+    let desc = map_pipeline_layout_descriptor(descriptor);
     let (pipeline_layout_id, error) = context.device_create_pipeline_layout(device_id, &desc, None);
     if let Some(cause) = error {
         handle_error(


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

- [x] `cargo clippy` reports no issues
- [?] `cargo doc` reports no issues
- [ ] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality. @githubname`

## Description
While doing the v29 update for the python wrapper. I spotted that the descriptor already has a `immediateSize` field in `webgpu.h` https://github.com/webgpu-native/webgpu-headers/pull/529
Also saw the limits being simplified in #575 so this makes it even simpler, although you still need the native only feature. I updated the example and it still works, please let me know if the changes to the `wgpu.h` headers are fine like this.


## Related Issues
