### PR TITLE
Bump webgpu-native headers to make immediates easier again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 
 ### Changed
+- `...EncoderSetImmediates` removed from wgpu.h as it's now in webgpu.h with `size_bytes` renamed to `size`. By @Vipitis in [#592](https://github.com/gfx-rs/wgpu-native/pull/592).
 - Immediates no longer uses `WGPUPipelineLayoutExtras` chain, the `WGPUPipelineLayoutDescriptor` takes `uint32_t immediateSize` directily. By @Vipitis in [#583](https://github.com/gfx-rs/wgpu-native/pull/583).
 - Updated all wgpu crates to v29
 - MSRV bumped from 1.82 to 1.87.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 
 ### Changed
-- `...EncoderSetImmediates` removed from wgpu.h as it's now in webgpu.h with `size_bytes` renamed to `size`. By @Vipitis in [#592](https://github.com/gfx-rs/wgpu-native/pull/592).
+- `...EncoderSetImmediates` removed from wgpu.h as it's now in webgpu.h, with `size_bytes` renamed to `size` and argument order adjusted. By @Vipitis in [#592](https://github.com/gfx-rs/wgpu-native/pull/592).
 - Immediates no longer uses `WGPUPipelineLayoutExtras` chain, the `WGPUPipelineLayoutDescriptor` takes `uint32_t immediateSize` directily. By @Vipitis in [#583](https://github.com/gfx-rs/wgpu-native/pull/583).
 - Updated all wgpu crates to v29
 - MSRV bumped from 1.82 to 1.87.

--- a/examples/immediates/main.c
+++ b/examples/immediates/main.c
@@ -180,7 +180,7 @@ int main(int argc, char *argv[]) {
   for (uint32_t i = 0; i < numbers_length; i++) {
     uint32_t immediate = i;
     wgpuComputePassEncoderSetImmediates(compute_pass_encoder, 0,
-                                        sizeof(uint32_t), &immediate);
+                                        &immediate, sizeof(uint32_t));
 
     wgpuComputePassEncoderDispatchWorkgroups(compute_pass_encoder,
                                              numbers_length, 1, 1);

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1554,10 +1554,6 @@ extern "C"
      */
     void *wgpuTextureGetNativeMetalTexture(WGPUTexture texture);
 
-    void wgpuRenderPassEncoderSetImmediates(WGPURenderPassEncoder encoder, uint32_t offset, uint32_t sizeBytes, void const *data);
-    void wgpuComputePassEncoderSetImmediates(WGPUComputePassEncoder encoder, uint32_t offset, uint32_t sizeBytes, void const *data);
-    void wgpuRenderBundleEncoderSetImmediates(WGPURenderBundleEncoder encoder, uint32_t offset, uint32_t sizeBytes, void const *data);
-
     void wgpuRenderPassEncoderMultiDrawIndirect(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);
     void wgpuRenderPassEncoderMultiDrawIndexedIndirect(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4564,11 +4564,10 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetImmediates(
     let pass = pass.as_ref().expect("invalid render pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.render_pass_set_immediates(
-        encoder,
-        offset,
-        make_slice(data, size as usize),
-    ) {
+    match pass
+        .context
+        .render_pass_set_immediates(encoder, offset, make_slice(data, size as usize))
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,
@@ -4589,11 +4588,10 @@ pub unsafe extern "C" fn wgpuComputePassEncoderSetImmediates(
     let pass = pass.as_ref().expect("invalid compute pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
 
-    match pass.context.compute_pass_set_immediates(
-        encoder,
-        offset,
-        make_slice(data, size as usize),
-    ) {
+    match pass
+        .context
+        .compute_pass_set_immediates(encoder, offset, make_slice(data, size as usize))
+    {
         Ok(()) => (),
         Err(cause) => handle_error(
             &pass.error_sink,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4558,8 +4558,8 @@ pub unsafe extern "C" fn wgpuDeviceCreateShaderModuleSpirV(
 pub unsafe extern "C" fn wgpuRenderPassEncoderSetImmediates(
     pass: native::WGPURenderPassEncoder,
     offset: u32,
-    size_bytes: u32,
     data: *const u8,
+    size: u32,
 ) {
     let pass = pass.as_ref().expect("invalid render pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
@@ -4567,7 +4567,7 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetImmediates(
     match pass.context.render_pass_set_immediates(
         encoder,
         offset,
-        make_slice(data, size_bytes as usize),
+        make_slice(data, size as usize),
     ) {
         Ok(()) => (),
         Err(cause) => handle_error(
@@ -4583,8 +4583,8 @@ pub unsafe extern "C" fn wgpuRenderPassEncoderSetImmediates(
 pub unsafe extern "C" fn wgpuComputePassEncoderSetImmediates(
     pass: native::WGPUComputePassEncoder,
     offset: u32,
-    size_bytes: u32,
     data: *const u8,
+    size: u32,
 ) {
     let pass = pass.as_ref().expect("invalid compute pass");
     let encoder = pass.encoder.as_mut().expect("invalid compute pass encoder");
@@ -4592,7 +4592,7 @@ pub unsafe extern "C" fn wgpuComputePassEncoderSetImmediates(
     match pass.context.compute_pass_set_immediates(
         encoder,
         offset,
-        make_slice(data, size_bytes as usize),
+        make_slice(data, size as usize),
     ) {
         Ok(()) => (),
         Err(cause) => handle_error(
@@ -4608,15 +4608,15 @@ pub unsafe extern "C" fn wgpuComputePassEncoderSetImmediates(
 pub unsafe extern "C" fn wgpuRenderBundleEncoderSetImmediates(
     bundle: native::WGPURenderBundleEncoder,
     offset: u32,
-    size_bytes: u32,
     data: *const u8,
+    size: u32,
 ) {
     let bundle = bundle.as_ref().expect("invalid render bundle");
     let encoder = bundle.encoder.as_mut().expect("invalid render bundle");
     let encoder = encoder.expect("invalid render bundle");
     let encoder = encoder.as_mut().unwrap();
 
-    bundle_ffi::wgpu_render_bundle_set_immediates(encoder, offset, size_bytes, data);
+    bundle_ffi::wgpu_render_bundle_set_immediates(encoder, offset, size, data);
 }
 
 #[no_mangle]


### PR DESCRIPTION
bumps the headers for `webgpu.h` so the SetImmediates methods can be moved out of `wgpu.h`. The native feature is still required. With next wgpu release this should simplify once more.

there is one more commit for a new `WGPUWGSLLanguageFeatureName_LinearIndexing` in the diff but those are unimplemented here.

## Checklist

- [x] `cargo clippy` reports no issues
- [ ] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality. @githubname`

## Description

perhaps one question, Can the native feature go? according to the spec it's now a language extension - or do we need to wait for wgpu-core to drop the feature requirement?

## Related Issues
