### PR TITLE
remove duplicate native texture formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ## Unreleased
 
+- moved 16bit norm textures into spec and out of wgpu.h `WGPUNativeTextureFormat_Rgba16Unorm` -> `WGPUTextureFormat_RGBA16Unorm`. by @Vipitis in [#tbd](tbd)
+
 ### Changed
 
 - Updated all wgpu crates to v29

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -115,7 +115,7 @@ static const uint16_t indices[] = {
 
 static const uint8_t red_texture_data[4] = {255, 0, 0, 255};
 static const uint8_t green_texture_data[4] = {0, 255, 0, 255};
-static const uint8_t blue_texture_data[4] = {0, 0, 255, 255};
+static const uint16_t blue_texture_data[4] = {0, 0, 0xFFFF, 0xFFF};
 static const uint8_t white_texture_data[4] = {255, 255, 255, 255};
 
 int main(int argc, char *argv[]) {
@@ -247,15 +247,17 @@ int main(int argc, char *argv[]) {
       adapter_has_optional_features = true;
       break;
     }
+    // TODO: check if the feature is supported by the device... (maybe just count up) 
   }
   assert(
           adapter_has_required_features /* Adapter must support WGPUNativeFeature_TextureBindingArray feature for this example */);
   wgpuSupportedFeaturesFreeMembers(adapter_features);
 
-  WGPUFeatureName required_device_features[2] = {
+  WGPUFeatureName required_device_features[3] = {
       (WGPUFeatureName)WGPUNativeFeature_TextureBindingArray,
+      (WGPUFeatureName)WGPUNativeFeature_TextureFormat16bitNorm,
   };
-  size_t required_device_feature_count = 1;
+  size_t required_device_feature_count = 2;
   if (adapter_has_optional_features) {
     required_device_features[required_device_feature_count] = (WGPUFeatureName)
         WGPUNativeFeature_SampledTextureAndStorageBufferArrayNonUniformIndexing;
@@ -373,6 +375,16 @@ int main(int argc, char *argv[]) {
   .usage = WGPUTextureUsage_TextureBinding | WGPUTextureUsage_CopyDst
   /* clang-format on */
 
+#define COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS_16                                 \
+  /* clang-format off */                                                       \
+  .size = extent_3d_default,                                                   \
+  .mipLevelCount = 1,                                                          \
+  .sampleCount = 1,                                                            \
+  .dimension = WGPUTextureDimension_2D,                                        \
+  .format = WGPUNativeTextureFormat_Rgba16Unorm,                               \
+  .usage = WGPUTextureUsage_TextureBinding | WGPUTextureUsage_CopyDst
+  /* clang-format on */
+
   WGPUTexture red_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
@@ -387,8 +399,8 @@ int main(int argc, char *argv[]) {
   assert(green_texture);
   WGPUTexture blue_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
-                       COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
-                       .label = {"blue", WGPU_STRLEN},
+                       COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS_16,
+                       .label = {"blue-16", WGPU_STRLEN},
                    });
   assert(blue_texture);
   WGPUTexture white_texture = wgpuDeviceCreateTexture(
@@ -443,7 +455,12 @@ int main(int argc, char *argv[]) {
                             COLOR_IMAGE_COPY_TEXTURE_COMMON_FIELDS,
                         },
                         blue_texture_data, sizeof(blue_texture_data),
-                        &texture_data_layout_common, &extent_3d_default);
+                        &(const WGPUTexelCopyBufferLayout){
+                            .offset = 0,
+                            .bytesPerRow = 8, // this also needs to match 4 channel 16 bit
+                            .rowsPerImage = WGPU_COPY_STRIDE_UNDEFINED,
+                        },
+                        &extent_3d_default);
   wgpuQueueWriteTexture(queue,
                         &(const WGPUTexelCopyTextureInfo){
                             .texture = white_texture,

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -115,7 +115,7 @@ static const uint16_t indices[] = {
 
 static const uint8_t red_texture_data[4] = {255, 0, 0, 255};
 static const uint8_t green_texture_data[4] = {0, 255, 0, 255};
-static const uint16_t blue_texture_data[4] = {0, 0, 0xFFFF, 0xFFF};
+static const uint8_t blue_texture_data[4] = {0, 0, 255, 255};
 static const uint8_t white_texture_data[4] = {255, 255, 255, 255};
 
 int main(int argc, char *argv[]) {
@@ -247,17 +247,15 @@ int main(int argc, char *argv[]) {
       adapter_has_optional_features = true;
       break;
     }
-    // TODO: check if the feature is supported by the device... (maybe just count up) 
   }
   assert(
           adapter_has_required_features /* Adapter must support WGPUNativeFeature_TextureBindingArray feature for this example */);
   wgpuSupportedFeaturesFreeMembers(adapter_features);
 
-  WGPUFeatureName required_device_features[3] = {
+  WGPUFeatureName required_device_features[2] = {
       (WGPUFeatureName)WGPUNativeFeature_TextureBindingArray,
-      (WGPUFeatureName)WGPUNativeFeature_TextureFormat16bitNorm,
   };
-  size_t required_device_feature_count = 2;
+  size_t required_device_feature_count = 1;
   if (adapter_has_optional_features) {
     required_device_features[required_device_feature_count] = (WGPUFeatureName)
         WGPUNativeFeature_SampledTextureAndStorageBufferArrayNonUniformIndexing;
@@ -375,16 +373,6 @@ int main(int argc, char *argv[]) {
   .usage = WGPUTextureUsage_TextureBinding | WGPUTextureUsage_CopyDst
   /* clang-format on */
 
-#define COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS_16                                 \
-  /* clang-format off */                                                       \
-  .size = extent_3d_default,                                                   \
-  .mipLevelCount = 1,                                                          \
-  .sampleCount = 1,                                                            \
-  .dimension = WGPUTextureDimension_2D,                                        \
-  .format = WGPUTextureFormat_RGBA16Unorm,                               \
-  .usage = WGPUTextureUsage_TextureBinding | WGPUTextureUsage_CopyDst
-  /* clang-format on */
-
   WGPUTexture red_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
                        COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
@@ -399,8 +387,8 @@ int main(int argc, char *argv[]) {
   assert(green_texture);
   WGPUTexture blue_texture = wgpuDeviceCreateTexture(
       demo.device, &(const WGPUTextureDescriptor){
-                       COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS_16,
-                       .label = {"blue-16", WGPU_STRLEN},
+                       COLOR_TEXTURE_DESCRIPTOR_COMMON_FIELDS,
+                       .label = {"blue", WGPU_STRLEN},
                    });
   assert(blue_texture);
   WGPUTexture white_texture = wgpuDeviceCreateTexture(
@@ -455,12 +443,7 @@ int main(int argc, char *argv[]) {
                             COLOR_IMAGE_COPY_TEXTURE_COMMON_FIELDS,
                         },
                         blue_texture_data, sizeof(blue_texture_data),
-                        &(const WGPUTexelCopyBufferLayout){
-                            .offset = 0,
-                            .bytesPerRow = 8, // this also needs to match 4 channel 16 bit
-                            .rowsPerImage = WGPU_COPY_STRIDE_UNDEFINED,
-                        },
-                        &extent_3d_default);
+                        &texture_data_layout_common, &extent_3d_default);
   wgpuQueueWriteTexture(queue,
                         &(const WGPUTexelCopyTextureInfo){
                             .texture = white_texture,

--- a/examples/texture_arrays/main.c
+++ b/examples/texture_arrays/main.c
@@ -381,7 +381,7 @@ int main(int argc, char *argv[]) {
   .mipLevelCount = 1,                                                          \
   .sampleCount = 1,                                                            \
   .dimension = WGPUTextureDimension_2D,                                        \
-  .format = WGPUNativeTextureFormat_Rgba16Unorm,                               \
+  .format = WGPUTextureFormat_RGBA16Unorm,                               \
   .usage = WGPUTextureUsage_TextureBinding | WGPUTextureUsage_CopyDst
   /* clang-format on */
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -261,9 +261,9 @@ typedef enum WGPUNativeFeature
     WGPUNativeFeature_PartiallyBoundBindingArray = 0x0003000A,
     /**
      * Enables normalized 16-bit texture formats:
-     * @ref WGPUNativeTextureFormat_R16Unorm, @ref WGPUNativeTextureFormat_R16Snorm,
-     * @ref WGPUNativeTextureFormat_Rg16Unorm, @ref WGPUNativeTextureFormat_Rg16Snorm,
-     * @ref WGPUNativeTextureFormat_Rgba16Unorm, @ref WGPUNativeTextureFormat_Rgba16Snorm.
+     * @ref WGPUTextureFormat_R16Unorm, @ref WGPUTextureFormat_R16Snorm,
+     * @ref WGPUTextureFormat_RG16Unorm, @ref WGPUTextureFormat_RG16Snorm,
+     * @ref WGPUTextureFormat_RGBA16Unorm, @ref WGPUTextureFormat_RGBA16Snorm.
      *
      * Supported platforms:
      * - Vulkan
@@ -1416,38 +1416,6 @@ typedef void (*WGPULogCallback)(WGPULogLevel level, WGPUStringView message, void
 
 typedef enum WGPUNativeTextureFormat
 {
-    // From Features::TEXTURE_FORMAT_16BIT_NORM
-    WGPUNativeTextureFormat_R16Unorm = 0x00030001,
-    /**
-     * Red channel only. 16-bit signed integer per channel.
-     * [-32767, 32767] converted to/from float [-1, 1] in shader.
-     * Requires @ref WGPUNativeFeature_TextureFormat16bitNorm.
-     */
-    WGPUNativeTextureFormat_R16Snorm = 0x00030002,
-    /**
-     * Red and green channels. 16-bit unsigned integer per channel.
-     * [0, 65535] converted to/from float [0, 1] in shader.
-     * Requires @ref WGPUNativeFeature_TextureFormat16bitNorm.
-     */
-    WGPUNativeTextureFormat_Rg16Unorm = 0x00030003,
-    /**
-     * Red and green channels. 16-bit signed integer per channel.
-     * [-32767, 32767] converted to/from float [-1, 1] in shader.
-     * Requires @ref WGPUNativeFeature_TextureFormat16bitNorm.
-     */
-    WGPUNativeTextureFormat_Rg16Snorm = 0x00030004,
-    /**
-     * Red, green, blue, and alpha channels. 16-bit unsigned integer per channel.
-     * [0, 65535] converted to/from float [0, 1] in shader.
-     * Requires @ref WGPUNativeFeature_TextureFormat16bitNorm.
-     */
-    WGPUNativeTextureFormat_Rgba16Unorm = 0x00030005,
-    /**
-     * Red, green, blue, and alpha channels. 16-bit signed integer per channel.
-     * [-32767, 32767] converted to/from float [-1, 1] in shader.
-     * Requires @ref WGPUNativeFeature_TextureFormat16bitNorm.
-     */
-    WGPUNativeTextureFormat_Rgba16Snorm = 0x00030006,
     /**
      * YUV 4:2:0 chroma subsampled format (NV12).
      * Plane 0 contains R8Unorm luminance (Y), Plane 1 contains Rg8Unorm

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -984,13 +984,14 @@ pub fn map_texture_format(value: native::WGPUTextureFormat) -> Option<wgt::Textu
         native::WGPUTextureFormat_ASTC12x12Unorm => Some(wgt::TextureFormat::Astc { block: AstcBlock::B12x12, channel: AstcChannel::Unorm }),
         native::WGPUTextureFormat_ASTC12x12UnormSrgb => Some(wgt::TextureFormat::Astc { block: AstcBlock::B12x12, channel: AstcChannel::UnormSrgb }),
 
+        // now in webgpu.h
+        native::WGPUTextureFormat_R16Unorm => Some(wgt::TextureFormat::R16Unorm),
+        native::WGPUTextureFormat_R16Snorm => Some(wgt::TextureFormat::R16Snorm),
+        native::WGPUTextureFormat_RG16Unorm => Some(wgt::TextureFormat::Rg16Unorm),
+        native::WGPUTextureFormat_RG16Snorm => Some(wgt::TextureFormat::Rg16Snorm),
+        native::WGPUTextureFormat_RGBA16Unorm => Some(wgt::TextureFormat::Rgba16Unorm),
+        native::WGPUTextureFormat_RGBA16Snorm => Some(wgt::TextureFormat::Rgba16Snorm),
         // wgpu.h extended
-        native::WGPUNativeTextureFormat_R16Unorm => Some(wgt::TextureFormat::R16Unorm),
-        native::WGPUNativeTextureFormat_R16Snorm => Some(wgt::TextureFormat::R16Snorm),
-        native::WGPUNativeTextureFormat_Rg16Unorm => Some(wgt::TextureFormat::Rg16Unorm),
-        native::WGPUNativeTextureFormat_Rg16Snorm => Some(wgt::TextureFormat::Rg16Snorm),
-        native::WGPUNativeTextureFormat_Rgba16Unorm => Some(wgt::TextureFormat::Rgba16Unorm),
-        native::WGPUNativeTextureFormat_Rgba16Snorm => Some(wgt::TextureFormat::Rgba16Snorm),
         native::WGPUNativeTextureFormat_NV12  => Some(wgt::TextureFormat::NV12),
         _ => panic!("Unknown texture format"),
     }
@@ -1102,13 +1103,13 @@ pub fn to_native_texture_format(rs_type: wgt::TextureFormat) -> Option<native::W
         wgt::TextureFormat::Astc { block: AstcBlock::B12x12, channel: AstcChannel::Unorm } => Some(native::WGPUTextureFormat_ASTC12x12Unorm),
         wgt::TextureFormat::Astc { block: AstcBlock::B12x12, channel: AstcChannel::UnormSrgb } => Some(native::WGPUTextureFormat_ASTC12x12UnormSrgb),
 
+        wgt::TextureFormat::R16Unorm => Some(native::WGPUTextureFormat_R16Unorm),
+        wgt::TextureFormat::R16Snorm => Some(native::WGPUTextureFormat_R16Snorm),
+        wgt::TextureFormat::Rg16Unorm => Some(native::WGPUTextureFormat_RG16Unorm),
+        wgt::TextureFormat::Rg16Snorm => Some(native::WGPUTextureFormat_RG16Snorm),
+        wgt::TextureFormat::Rgba16Unorm => Some(native::WGPUTextureFormat_RGBA16Unorm),
+        wgt::TextureFormat::Rgba16Snorm => Some(native::WGPUTextureFormat_RGBA16Snorm),
         // wgpu.h extended
-        wgt::TextureFormat::R16Unorm => Some(native::WGPUNativeTextureFormat_R16Unorm),
-        wgt::TextureFormat::R16Snorm => Some(native::WGPUNativeTextureFormat_R16Snorm),
-        wgt::TextureFormat::Rg16Unorm => Some(native::WGPUNativeTextureFormat_Rg16Unorm),
-        wgt::TextureFormat::Rg16Snorm => Some(native::WGPUNativeTextureFormat_Rg16Snorm),
-        wgt::TextureFormat::Rgba16Unorm => Some(native::WGPUNativeTextureFormat_Rgba16Unorm),
-        wgt::TextureFormat::Rgba16Snorm => Some(native::WGPUNativeTextureFormat_Rgba16Snorm),
         wgt::TextureFormat::NV12 => Some(native::WGPUNativeTextureFormat_NV12),
         wgt::TextureFormat::P010 => Some(native::WGPUNativeTextureFormat_P010)
     }


### PR DESCRIPTION
closes #596 

since this is kinda the headers being ahead of v29 (I think tiers are added in v30) this still needs the native only feature (https://github.com/gfx-rs/wgpu/issues/8122)
I changed the example just to test it for myself.. would need a bit of fancying keep it this way

## Checklist

- [x] `cargo clippy` reports no issues
- [ ] `cargo doc` reports no issues
- [ ] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality. @githubname`

## Description

a question: can we also render to a 16unorm texture?

## Related Issues
