### PR TITLE
fix `WGPU_WHOLE_MAP_SIZE` case in `bufferMapAsync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ## Unreleased
 
+### Fixed
+- `wgpuBufferMayAsync` now correctly handles the case where size is `WGPU_WHOLE_MAP_SIZE`. By @Vipitis in [#602](https://github.com/gfx-rs/wgpu-native/pull/602).
 
 ### Changed
 - Immediates no longer uses `WGPUPipelineLayoutExtras` chain, the `WGPUPipelineLayoutDescriptor` takes `uint32_t immediateSize` directily. By @Vipitis in [#583](https://github.com/gfx-rs/wgpu-native/pull/583).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1064,7 +1064,10 @@ pub unsafe extern "C" fn wgpuBufferMapAsync(
     if let Err(cause) = context.buffer_map_async(
         buffer_id,
         offset as wgt::BufferAddress,
-        Some(size as wgt::BufferAddress),
+        match size {
+            conv::WGPU_WHOLE_MAP_SIZE => None,
+            _ => Some(size as wgt::BufferAddress),
+        },
         operation,
     ) {
         handle_error(error_sink, cause, None, "wgpuBufferMapAsync");


### PR DESCRIPTION
fixes #601 

## Checklist

- [x] `cargo clippy` reports no issues
- [ ] `cargo doc` reports no issues
- [ ] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality. @githubname`

## Description

## Related Issues
