### PR TITLE
Improve panic message for invalid buffer size

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1574,7 +1574,7 @@ pub fn map_bind_group_entry<'a>(
                     buffer: buffer.id,
                     offset: entry.offset,
                     size: match entry.size {
-                        0 => panic!("invalid size"),
+                        0 => panic!("buffer supplied to bind group must have size greater than 0"),
                         WGPU_WHOLE_SIZE => None,
                         _ => Some(entry.size),
                     },


### PR DESCRIPTION
## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [ ] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [ ] Add credit to yourself for each change: `Added new functionality. @githubname`

## Description

I didn't add it to changelog since it's a very minor change in an error message. I can add it if it should still be there.
This error is currently very vague, this PR should make it more obvious what's happening. 

## Related Issues
