### PR TITLE
CD: Drop qemu in favor of arm linux runner

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -212,15 +212,17 @@ jobs:
   linux:
     # Config
     name: release - ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         include:
           - name: linux-x86_64
+            os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             image: manylinux_2_28_x86_64
           - name: linux-aarch64
+            os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             image: manylinux_2_28_aarch64
     env:
@@ -235,12 +237,6 @@ jobs:
       - name: Set WGPU_NATIVE_VERSION
         run: echo "WGPU_NATIVE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
         shell: bash
-      # prepare qemu for cross-compilation
-      - name: Set up QEMU
-        if: matrix.image == 'manylinux_2_28_aarch64'
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: arm64
       # Build
       - name: Build
         run: |


### PR DESCRIPTION
Linux arm arm runners are available in public repos see [gh blog](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) since about a year and a half. Also see [GH's list of runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners).

This means we can drop QEMU. The build time for linux-aarch64 goes down from 45 min to 4 min like the rest. 🥳 