### PR TITLE
Expose DeviceDescriptor::memory_hints via WGPUDeviceExtras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ## Unreleased
 
+### Added
+- `WGPUDeviceExtras` now exposes `DeviceDescriptor::memory_hints` via `memoryHints` (`WGPUMemoryHints`: `Performance`/`MemoryUsage`/`Manual` with a block-size range); zero-initialized keeps the previous behavior. By @RubyBit in [#619](https://github.com/gfx-rs/wgpu-native/pull/619).
+
 ### Fixed
 - `wgpuBufferMayAsync` now correctly handles the case where size is `WGPU_WHOLE_MAP_SIZE`. By @Vipitis in [#602](https://github.com/gfx-rs/wgpu-native/pull/602).
 

--- a/ffi/wgpu.h
+++ b/ffi/wgpu.h
@@ -1177,6 +1177,23 @@ typedef struct WGPUInstanceExtras
     WGPUNativeDisplayHandle displayHandle;
 } WGPUInstanceExtras;
 
+typedef enum WGPUMemoryHints
+{
+    /** Same as Performance (the wgpu default). */
+    WGPUMemoryHints_Undefined = 0x00000000,
+    /** Favor performance over memory usage. */
+    WGPUMemoryHints_Performance = 0x00000001,
+    /** Favor memory usage over performance. */
+    WGPUMemoryHints_MemoryUsage = 0x00000002,
+    /**
+     * Choose the suballocated memory block size range explicitly via
+     * @ref WGPUDeviceExtras::suballocatedDeviceMemoryBlockSizeStart and
+     * @ref WGPUDeviceExtras::suballocatedDeviceMemoryBlockSizeEnd.
+     */
+    WGPUMemoryHints_Manual = 0x00000003,
+    WGPUMemoryHints_Force32 = 0x7FFFFFFF
+} WGPUMemoryHints;
+
 typedef struct WGPUDeviceExtras
 {
     WGPUChainedStruct chain;
@@ -1188,6 +1205,24 @@ typedef struct WGPUDeviceExtras
      * An empty/undefined string view disables tracing.
      */
     WGPUStringView tracePath;
+    /**
+     * Hints to the backend memory allocator.
+     * Zero-initialized yields @ref WGPUMemoryHints_Undefined (Performance).
+     */
+    WGPUMemoryHints memoryHints;
+    /**
+     * Initial suballocated device-memory block size, in bytes. Only used
+     * with @ref WGPUMemoryHints_Manual.
+     *
+     * After running out of space in existing blocks, the backend may grow
+     * subsequent block sizes up to
+     * @ref WGPUDeviceExtras::suballocatedDeviceMemoryBlockSizeEnd. This does
+     * not limit resource sizes: a resource that does not fit is typically
+     * placed in a dedicated memory block.
+     */
+    uint64_t suballocatedDeviceMemoryBlockSizeStart;
+    /** See @ref WGPUDeviceExtras::suballocatedDeviceMemoryBlockSizeStart. */
+    uint64_t suballocatedDeviceMemoryBlockSizeEnd;
 } WGPUDeviceExtras;
 
 typedef struct WGPUNativeLimits

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -470,7 +470,7 @@ unsafe fn map_native_display_handle(
 pub(crate) unsafe fn map_device_descriptor<'a>(
     des: &native::WGPUDeviceDescriptor,
     base_limits: wgt::Limits,
-    _extras: Option<&native::WGPUDeviceExtras>,
+    extras: Option<&native::WGPUDeviceExtras>,
 ) -> (
     wgt::DeviceDescriptor<wgc::Label<'a>>,
     Option<UncapturedErrorCallback>,
@@ -491,8 +491,18 @@ pub(crate) unsafe fn map_device_descriptor<'a>(
                 },
                 None => base_limits,
             },
-            // TODO(wgpu.h)
-            memory_hints: Default::default(),
+            memory_hints: match extras {
+                Some(extras) => match extras.memoryHints {
+                    native::WGPUMemoryHints_MemoryUsage => wgt::MemoryHints::MemoryUsage,
+                    native::WGPUMemoryHints_Manual => wgt::MemoryHints::Manual {
+                        suballocated_device_memory_block_size: extras
+                            .suballocatedDeviceMemoryBlockSizeStart
+                            ..extras.suballocatedDeviceMemoryBlockSizeEnd,
+                    },
+                    _ => wgt::MemoryHints::Performance,
+                },
+                None => Default::default(),
+            },
             trace: Default::default(),
             experimental_features: wgt::ExperimentalFeatures::disabled(),
         },


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues (unrelated to my changes)
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] Human-readable change descriptions added to CHANGELOG.md under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality. @githubname`

## Description

wgpu's DeviceDescriptor has had memory_hints since MemoryHints was introduced, but map_device_descriptor hardcoded Default::default() (Performance) to be changed in the future (so I changed it): Performance hints make gpu-allocator commit 128 MiB device + 64 MiB host memory blocks for the few tiny internal allocations wgpu makes at device open, so creating a bare device commits ~200 MiB of VRAM (measured on NVIDIA RTX 4080 Laptop/Vulkan; D3D12 is similar), and all committed memory rounds up in 256 MiB steps. Applications with small or mostly-static workloads have had no way to opt out through the C API (such as my tensor library which can load pretty small models on the gpu through wgpu and there is an unnecessary, around 200 MiB overhead). 

Add a WGPUMemoryHints enum (Undefined/Performance/MemoryUsage/Manual) and memoryHints + suballocatedDeviceMemoryBlockSize{Start,End} fields to WGPUDeviceExtras, mapped onto wgt::MemoryHints. Zero-initialized extras keep the previous behavior (Undefined -> Performance).

Measured bare-device committed VRAM (RTX 4080 Laptop, Vulkan):
  Performance (old default): 201 MiB
  MemoryUsage:                21 MiB
  Manual { 4 MiB..256 MiB }:  17 MiB

## Related Issues
